### PR TITLE
Remove 'item' page and add Menu Bar without styles

### DIFF
--- a/public/index.html
+++ b/public/index.html
@@ -182,16 +182,7 @@
 
 
     <div id="root">
-      <div class="row">
-        <div id="mirador_frame" class="col-sm-12"></div>
-      </div>
-      <div class="row">
-        <div class="col-sm-8">
-          <h2>Metadata</h2>
-          <div id="metadata_table"></div>
-        </div>
-        <div class="col-sm-4"></div>
-      </div>
+    
     </div>
 
 

--- a/src/App.js
+++ b/src/App.js
@@ -1,26 +1,34 @@
-import React from 'react';
-import logo from './logo.svg';
+import React, { Component } from 'react';
+import {
+  BrowserRouter as Router,
+  Route,
+  Switch,
+} from 'react-router-dom';
+import HomePage from './pages/HomePage';
+import AboutPage from './pages/AboutPage';
+import CollectionsPage from './pages/CollectionsPage';
+import ItemsPage from './pages/ItemsPage';
+import NavBar from './NavBar';
 import './App.css';
 
-function App() {
-  return (
-    <div className="App">
-      <header className="App-header">
-        <img src={logo} className="App-logo" alt="logo" />
-        <p>
-          Edit <code>src/App.js</code> and save to reload.
-        </p>
-        <a
-          className="App-link"
-          href="https://reactjs.org"
-          target="_blank"
-          rel="noopener noreferrer"
-        >
-          Learn React
-        </a>
-      </header>
-    </div>
-  );
+class App extends Component {
+  render() {
+    return (
+      <Router>
+        <div>
+          <NavBar />
+          <div id="content-wrapper" class="container" role="main">
+            <Switch>
+              <Route path="/" component={HomePage} exact/>
+              <Route path="/about" component={AboutPage} />
+              <Route path="/collections" component={CollectionsPage} />
+              <Route path="/items" component={ItemsPage} />
+            </Switch>
+        </div>
+        </div>
+      </Router>
+    )
+  }
 }
 
 export default App;

--- a/src/NavBar.js
+++ b/src/NavBar.js
@@ -1,0 +1,22 @@
+import React from 'react';
+import {
+    BrowserRouter as Router,
+    Route,
+  } from 'react-router-dom';
+import { Link } from 'react-router-dom';
+
+const NavBar = () => (
+    <nav>
+        <ul>
+            <li>
+                <Link to="/">Home</Link>
+                <Link to="/about">About</Link>
+                <Link to="/terms">Permission Page</Link>
+                <Link to="/collections">EXPLORE COLLECTIONS</Link>
+                <Link to="/items">BROWSE ITEMS</Link>
+            </li>
+        </ul>
+    </nav>
+);
+
+export default NavBar;

--- a/src/index.js
+++ b/src/index.js
@@ -1,44 +1,13 @@
 import React from 'react';
 import ReactDOM from 'react-dom';
 import './index.css';
-import Viewer from './Viewer'
-import Table from './Table'
+import NavBar from './NavBar';
+import App from './App';
 import * as serviceWorker from './serviceWorker';
-
-let attributeList = [
-  {"name": "Tags", "values": ["Awards"]},
-  {"name": "Source", "values": ["Please consult the Guide to the Lorraine Rudoff Architectural Collection for more information."]},
-  {"name": "Date", "values": ["1980-03-27"]},
-  {"name": "Rights", "values": ["Permission to publish material from the Certificate and program for YWCA Leader Luncheon VI, March 27, 1980 (Ms1990-025) must be obtained from University Libraries Special Collections, Virginia Tech."]},
-  {"name": "Language", "values": ["en"]},
-  {"name": "Type", "values": ["Documents"]},
-  {"name": "Identifier", "values": ["Ms1990_025_Per_Awd_B001_F001_006"]},
-  {"name": "Location", "values": ["Los Angeles, California"]},
-  {"name": "Belongs to", "values": ["Ms1990-025, Box 1, Folder 1", "Ms1990-025"]},
-  {"name": "Bibliographic citation", "values": ["Researchers wishing to cite this collection should include the following information: - Special Collections, Virginia Polytechnic Institute and State University, Blacksburg, Va."]},
-  {"name": "Rights holder", "values":["Special Collections, University Libraries, Virginia Tech"]}
-]
-
-
-let mirador_config = {
-	"id":"mirador_viewer",
-	"buildPath":"/assets/",
-	"i18nPath":"",
-	"imagesPath":"",
-	"data":[{"manifestUri":"https://img.cloud.lib.vt.edu/iawa/Ms1990_025_Rudoff/Ms1990_025_Box1/Ms1990_025_Box1_Folder1/Ms1990_025_Per_Awd_B001_F001_006/manifest.json"}],
-	"windowObjects":[{"loadedManifest":"https://img.cloud.lib.vt.edu/iawa/Ms1990_025_Rudoff/Ms1990_025_Box1/Ms1990_025_Box1_Folder1/Ms1990_025_Per_Awd_B001_F001_006/manifest.json","viewType":"ImageView"}],
-	"showAddFromURLBox": false
-}
-
-ReactDOM.render(
-	<Viewer config={mirador_config} />, 
-	document.getElementById('mirador_frame'));
-ReactDOM.render(
-	<Table rows={attributeList} />,
-	document.getElementById('metadata_table')
-);
+ReactDOM.render(<App />, document.getElementById('root'));
 
 // If you want your app to work offline and load faster, you can change
 // unregister() to register() below. Note this comes with some pitfalls.
 // Learn more about service workers: https://bit.ly/CRA-PWA
 serviceWorker.unregister();
+

--- a/src/pages/AboutPage.js
+++ b/src/pages/AboutPage.js
@@ -1,0 +1,17 @@
+import React from 'react';
+import {Link} from 'react-router-dom';
+
+const AboutPage = () => (
+    <>
+        <h1>About IAWA</h1>
+        <h2>Our History</h2>
+        <p>The International Archive of Women in Architecture (IAWA) was established in 1985 as a joint program of the College of Architecture and Urban Studies and the University Libraries at Virginia Tech. The purpose of the Archive is to document the history of women's contributions to the built environment by collecting, preserving, and providing access to the records of women's architectural organizations and the professional papers of women architects, landscape architects, designers, architectural historians and critics, and urban planners.</p>
+        <p>The IAWA collections have always been open to scholars, students, and public researchers around the world. Historically, this meant traveling to Virginia Tech and visiting the University Libraries’ Special Collections Department to see materials in person. Through this website, today’s researchers also have access to a growing library of digitized documents and visual materials from the IAWA collections.</p>
+        <h2>What We Collect</h2>
+        <p>Today, the IAWA documents the legacies of more than 435 individuals, firms, organizations, and exhibits from the 1890s through the present day. The permanent collections include approximately 2000 cubic feet of documents, photographs and negatives, architectural drawings, sketches, scrapbooks, building models, presentation boards, and other materials that capture the creative process. The IAWA also collects books, biographical information, and other published materials as part of its mission to act as a clearinghouse of information about the global history of women in architecture.</p>
+        <p>Women who are interested in enhancing the historic record of architecture and related design professions should visit the Special Collections donations page or contact the IAWA Archivist for more information about donating materials to the IAWA.</p>
+        <h2>Are you starting a new research project? Check out our guide to conducting research in the IAWA collections: </h2>
+   </>
+);
+
+export default AboutPage;

--- a/src/pages/CollectionsPage.js
+++ b/src/pages/CollectionsPage.js
@@ -1,0 +1,9 @@
+import React from 'react';
+
+const CollectionsPage = () => (
+    <>
+        <h1>Collections List</h1>
+   </>
+);
+
+export default CollectionsPage;

--- a/src/pages/HomePage.js
+++ b/src/pages/HomePage.js
@@ -1,0 +1,16 @@
+import React from 'react';
+
+const HomePage = () => (
+    <>
+        <div id="content-wrapper" class="container" role="main">
+            <div class="row home-content">
+                <h3>A visual exhibit of selected items from the International 
+                    Archive of Women in Architecture, a joint partnership between 
+                    the College of Architecture and Urban Studies and the University 
+                    Libraries at Virginia Tech</h3>
+            </div>
+        </div>
+   </>
+);
+
+export default HomePage;

--- a/src/pages/ItemsPage.js
+++ b/src/pages/ItemsPage.js
@@ -1,0 +1,10 @@
+import React from 'react';
+import { Link } from 'react-router-dom';
+
+const ItemsPage = () => (
+    <>
+        <h1>Items List</h1>
+   </>
+);
+
+export default ItemsPage;


### PR DESCRIPTION
**JIRA Ticket**: (https://webapps.es.vt.edu/jira/browse/LIBTD-1912) (:star:)

* Other Relevant Links (Meeting note, project page, related pull requests, etc.)

# What does this Pull Request do? (:star:)
This PR removes the mirador view and metadata table from the page and add React NavBar to the landing page without css styles.

# What's the changes? (:star:)

Example:
* Removes Mirador viewer
* Removes Item metadata table
* Adds NavBar with links to "about", "collections", and "items" pages

# How should this be tested?

* npm start 
* Should see NavBar at the top of the main page. Click on each of the links to "about", "collections" and "items" page.

# Interested parties
Tag (@whunter ) interested parties

(:star:) Required fields
