### PR TITLE
Made widgets for search results, show results, and viewing options be on one line.

### DIFF
--- a/src/components/ViewBar.js
+++ b/src/components/ViewBar.js
@@ -14,44 +14,34 @@ class ViewBar extends Component {
 
   render() {
     return (
-      <div className="text-right">
-        <div className="btn-group pt-1 mr-2" aria-label="View Options">
-          <button
-            className="btn btn-outline-light"
-            data-toggle="tooltip"
-            title="List"
-            onClick={() => this.updateView("List")}
-            active={(this.state.view === "List").toString()}
-          >
-            <FontAwesomeIcon
-              icon={faThList}
-              size="lg"
-              style={{ color: "red" }}
-            />
-          </button>
-          <button
-            className="btn btn-outline-light"
-            data-toggle="tooltip"
-            title="Gallery"
-            onClick={() => this.updateView("Gallery")}
-            active={(this.state.view === "Gallery").toString()}
-          >
-            <FontAwesomeIcon icon={faTh} size="lg" style={{ color: "red" }} />
-          </button>
-          <button
-            className="btn btn-outline-light"
-            data-toggle="tooltip"
-            title="Masonry"
-            onClick={() => this.updateView("Masonry")}
-            active={(this.state.view === "Masonry").toString()}
-          >
-            <FontAwesomeIcon
-              icon={faImages}
-              size="lg"
-              style={{ color: "red" }}
-            />
-          </button>
-        </div>
+      <div className="btn-group" aria-label="View Options">
+        <button
+          className="btn btn-outline-light"
+          data-toggle="tooltip"
+          title="List"
+          onClick={() => this.updateView("List")}
+          active={(this.state.view === "List").toString()}
+        >
+          <FontAwesomeIcon icon={faThList} size="lg" style={{ color: "red" }} />
+        </button>
+        <button
+          className="btn btn-outline-light"
+          data-toggle="tooltip"
+          title="Gallery"
+          onClick={() => this.updateView("Gallery")}
+          active={(this.state.view === "Gallery").toString()}
+        >
+          <FontAwesomeIcon icon={faTh} size="lg" style={{ color: "red" }} />
+        </button>
+        <button
+          className="btn btn-outline-light"
+          data-toggle="tooltip"
+          title="Masonry"
+          onClick={() => this.updateView("Masonry")}
+          active={(this.state.view === "Masonry").toString()}
+        >
+          <FontAwesomeIcon icon={faImages} size="lg" style={{ color: "red" }} />
+        </button>
       </div>
     );
   }

--- a/src/css/ListPages.css
+++ b/src/css/ListPages.css
@@ -43,16 +43,6 @@ div.collection-detail table tr .collection-detail-value {
   text-align: left;
   vertical-align: middle;
 }
-div#pagination-list-wrapper {
-  width: 50%;
-  margin: 0 auto;
-}
-div#pagination-list-wrapper ul li {
-  display: inline-block;
-}
-div#pagination-list-wrapper ul li a {
-  padding: 5px 10px;
-}
 
 h3.list-type {
   margin-top: 30px;

--- a/src/css/ResultsNumberDropdown.css
+++ b/src/css/ResultsNumberDropdown.css
@@ -1,7 +1,0 @@
-.dropdown-wrapper {
-  width: 100%;
-  height: 40px;
-}
-.ui.compact.dropdown {
-  float: right;
-}

--- a/src/pages/search/SearchResults.js
+++ b/src/pages/search/SearchResults.js
@@ -33,19 +33,23 @@ class SearchResults extends Component {
           setPage={this.props.setPage}
           updateFormState={this.props.updateFormState}
         />
-        <ItemsPaginationDisplay atBottom={false} />
-        <ResultsNumberDropdown setLimit={this.props.setLimit} />
         <div className="container">
           <div className="row">
             <div id="sidebar" className="col-md-3 col-sm-4">
               {/* <h2>Limit your search</h2> */}
             </div>
             <div id="content" className="col-md-9 col-sm-8">
-              <div>
-                <ViewBar
-                  view={this.props.view}
-                  updateFormState={this.props.updateFormState}
-                />
+              <div className="navbar navbar-light justify-content-between">
+                <div className="navbar-text text-dark">
+                  <ItemsPaginationDisplay atBottom={false} />
+                </div>
+                <div className="form-inline">
+                  <ResultsNumberDropdown setLimit={this.props.setLimit} />
+                  <ViewBar
+                    view={this.props.view}
+                    updateFormState={this.props.updateFormState}
+                  />
+                </div>
               </div>
               <ItemsList
                 items={this.props.items}

--- a/src/shared/Pagination.js
+++ b/src/shared/Pagination.js
@@ -41,7 +41,7 @@ class Pagination extends Component {
 
     if (this.props.atBottom) {
       return (
-        <div id="pagination-list-wrapper">
+        <div>
           <Displaying />
           <Previous />
           <Next />
@@ -49,7 +49,7 @@ class Pagination extends Component {
       );
     } else {
       return (
-        <div id="pagination-list-wrapper">
+        <div>
           <Displaying />
         </div>
       );

--- a/src/shared/ResultsNumberDropdown.js
+++ b/src/shared/ResultsNumberDropdown.js
@@ -2,7 +2,6 @@ import React, { Component } from "react";
 import { Dropdown } from "semantic-ui-react";
 
 import "semantic-ui-css/semantic.min.css";
-import "../css/ResultsNumberDropdown.css";
 
 class ResultsNumberDropdown extends Component {
   constructor(props) {
@@ -43,7 +42,7 @@ class ResultsNumberDropdown extends Component {
     ];
     const placeholder = "Show Results: " + this.state.selectedLimit;
     return (
-      <div className="dropdown-wrapper">
+      <div className="btn-group mr-2">
         <Dropdown
           placeholder={placeholder}
           compact


### PR DESCRIPTION
**The title of this pull-request should be a brief description of what the pull-request fixes/improves/changes. Ideally 50 characters or less.**
* * *
Made widgets for search results, show results, and viewing options be on one line.

**JIRA Ticket**: (link) (:star:)
https://webapps.es.vt.edu/jira/browse/LIBTD-2004

* Other Relevant Links (Meeting note, project page, related pull requests, etc.)

# What does this Pull Request do? (:star:)
A brief description of what the intended result of the PR will be and/or what problem it solves.
Places the Pagination, ResultsNumberDropdown, and ViewBar components in a single line above the ItemsList.

# What's the changes? (:star:)
A in-depth description of the changes made by this PR. Technical details and possible side effects.
This removes some prexisting style classes from ViewBar.js, ListPages.css, Pagination.js, and ResultsNumberDropdown.js, and reformats that styling of all these elements with different classes and container divs in the SearchResults.js file. I also deleted ResultsNumberDropdown.css after consulting with Lee because the classes in there were no being used anywhere in the app anymore.

# How should this be tested?
Click on "search items" in the menu, and all three elements should appear at the top in a grey box and should stay relatively organized at different viewport sizes. The buttons should all work when clicked.

A description of what steps someone could take to:
* Outline the steps to test or reproduce the PR here. 
* Please be as detailed as possible.

# Additional Notes:
LIBTD-2004

# Interested parties
Tag (@ mention) interested parties
@whunter 

(:star:) Required fields
