### PR TITLE
LIBTD-2012: Fix wrong title link in collection search results

### DIFF
--- a/src/pages/collections/CollectionItemsList.js
+++ b/src/pages/collections/CollectionItemsList.js
@@ -1,5 +1,6 @@
 import React, { Component } from "react";
 import { NavLink } from "react-router-dom";
+import { Thumbnail } from "../../components/Thumbnail";
 import { arkLinkFormatted } from "../../shared/TextFormatTools";
 
 import "../../css/CollectionsShowPage.css";
@@ -21,12 +22,12 @@ class CollectionItemsList extends Component {
               {this.props.items.map(item => (
                 <tr key={item.custom_key}>
                   <td className="item-image">
-                    <img src={item.thumbnail_path} alt={item.title} />
+                    <Thumbnail item={item} dataType="archive" />
                   </td>
                   <td className="item-info">
                     <div className="item-link-wrapper">
                       <NavLink
-                        to={`/item/${arkLinkFormatted(item.custom_key)}`}
+                        to={`/archive/${arkLinkFormatted(item.custom_key)}`}
                       >
                         {item.title}
                       </NavLink>
@@ -34,7 +35,7 @@ class CollectionItemsList extends Component {
                     <div className="collection-link-wrapper">
                       Identifier:{" "}
                       <NavLink
-                        to={`/item/${arkLinkFormatted(item.custom_key)}`}
+                        to={`/archive/${arkLinkFormatted(item.custom_key)}`}
                       >
                         {item.identifier}
                       </NavLink>

--- a/src/pages/collections/CollectionsList.js
+++ b/src/pages/collections/CollectionsList.js
@@ -1,5 +1,6 @@
 import React, { Component } from "react";
 import { NavLink } from "react-router-dom";
+import { Thumbnail } from "../../components/Thumbnail";
 import { arkLinkFormatted } from "../../shared/TextFormatTools";
 import "../../css/ListPages.css";
 
@@ -31,7 +32,7 @@ class CollectionsList extends Component {
               </NavLink>
             </h4>
             <span className="collection-img">
-              <img src={collection.thumbnail_path} alt={collection.title} />
+              <Thumbnail item={collection} dataType="collection" />
             </span>
             <div className="collection-details">
               <div className="collection-detail">

--- a/src/pages/search/CollectionListView.js
+++ b/src/pages/search/CollectionListView.js
@@ -33,7 +33,9 @@ export const CollectionListView = ({ collection }) => {
     <div className="row search-result-wrapper">
       <div className="col-sm-12 title-wrapper">
         <h4>
-          <NavLink to={`/item/${arkLinkFormatted(collection.custom_key)}`}>
+          <NavLink
+            to={`/collection/${arkLinkFormatted(collection.custom_key)}`}
+          >
             {collection.title}
           </NavLink>
         </h4>

--- a/src/pages/search/GalleryView.js
+++ b/src/pages/search/GalleryView.js
@@ -8,7 +8,7 @@ export const GalleryView = ({ item, dataType }) => {
   return (
     <div className="document col-12 col-sm-6 col-md-4 col-lg-3">
       <div className="card text-center">
-        <Thumbnail item={item} dataType />
+        <Thumbnail item={item} dataType={dataType} />
         <div className="card-body">
           <h5 className="card-title">
             <NavLink to={`/${dataType}/${arkLinkFormatted(item.custom_key)}`}>


### PR DESCRIPTION
**JIRA Ticket**: (https://webapps.es.vt.edu/jira/browse/LIBTD-2012) (:star:)

# What does this Pull Request do? (:star:)
This PR fixes the wrong title link to the collection in collection search results.

# What's the changes? (:star:)

* Changes the word "item" to "collection"

# How should this be tested?

* Search collection and click on the title link of a search result entry
* Switch to gallery view and click on the search result thumbnail image

# Interested parties
Tag (@yinlinchen ) interested parties

(:star:) Required fields
