### PR TITLE
Change item link to archive

### DIFF
--- a/src/components/Breadcrumbs.js
+++ b/src/components/Breadcrumbs.js
@@ -61,6 +61,7 @@ class Breadcrumbs extends Component {
   }
 
   render() {
+    const linksCopy = this.state.links.slice();
     return (
       <ul>
         <li>
@@ -68,7 +69,7 @@ class Breadcrumbs extends Component {
             Home
           </NavLink>
         </li>
-        {this.state.links.reverse().map(link => (
+        {linksCopy.reverse().map(link => (
           <li key={arkLinkFormatted(link.custom_key)}>
             <NavLink className="breadcrumb-link" to={link.url}>
               {link.title}

--- a/src/components/SiteNavigationLinks.js
+++ b/src/components/SiteNavigationLinks.js
@@ -6,35 +6,35 @@ class SiteNavigationLinks extends Component {
       <ul id="vt_main_nav" role="presentation" aria-label="Pages in Site">
         <li className="nav-item">
           <div className="link-wrapper">
-            <a href="/" tabindex="-1">
+            <a href="/" tabIndex="-1">
               Home
             </a>
           </div>
         </li>
         <li className="nav-item">
           <div className="link-wrapper">
-            <a href="/about" tabindex="-1">
+            <a href="/about" tabIndex="-1">
               About
             </a>
           </div>
         </li>
         <li className="nav-item">
           <div className="link-wrapper">
-            <a href="/terms" tabindex="-1">
+            <a href="/terms" tabIndex="-1">
               PERMISSION PAGE
             </a>
           </div>
         </li>
         <li className="nav-item">
           <div className="link-wrapper">
-            <a href="/collections" tabindex="-1">
+            <a href="/collections" tabIndex="-1">
               BROWSE COLLECTIONS
             </a>
           </div>
         </li>
         <li className="nav-item">
           <div className="link-wrapper">
-            <a href="/search" tabindex="-1">
+            <a href="/search" tabIndex="-1">
               SEARCH ITEMS
             </a>
           </div>

--- a/src/pages/archives/ArchivePage.js
+++ b/src/pages/archives/ArchivePage.js
@@ -121,7 +121,7 @@ class ArchivePage extends Component {
                 updateFormState={this.updateFormState}
               />
               <div className="breadcrumbs-wrapper">
-                <Breadcrumbs dataType={"Items"} record={item} />
+                <Breadcrumbs dataType={"Archives"} record={item} />
               </div>
               <h3>{item.title}</h3>
               <div className="row">


### PR DESCRIPTION
**Change item link in breadcrumbs to archive. Also changes tabindex to tabIndex and fixes bug in breadcrumbs.**
* * *

**JIRA Ticket**: (https://webapps.es.vt.edu/jira/browse/LIBTD-2022) (:star:)

* Other Relevant Links (Meeting note, project page, related pull requests, etc.)

# What does this Pull Request do? (:star:)
Change item link in breadcrumbs to archive. Also changes tabindex to tabIndex and fixes bug in breadcrumbs.

# What's the changes? (:star:)
* Change item links in breadcrumbs to archive to match new routes
* Change tabindex to tabIndex in SiteNavigationLinks because React attributes are supposed to be camel-case
* Fixes bug in breadcrumbs where the list would reverse every time you clicked on a link that referred to the same page. I forgot that array.reverse() in js is destructive. oops.

# How should this be tested?
* Visit an archive page and check that the link in the breadcrumbs correctly refers to /archive/:id instead of /item/:id
* Check in dev console that React isn't complaining about tabindex anymore
* Click on archive link in breadcrumb and make sure that it doesn't reverse the list (placing the archive first, then last, then first again) every time you click it

# Additional Notes:
* branch: `LIBTD-2022`

# Interested parties
@yinlinchen 

(:star:) Required fields
