### PR TITLE
LIBTD-1981: Filter search query within IAWA project

### DIFF
--- a/src/pages/collections/CollectionsListLoader.js
+++ b/src/pages/collections/CollectionsListLoader.js
@@ -56,10 +56,9 @@ class CollectionsListLoader extends Component {
     const collections = await API.graphql(
       graphqlOperation(queries.searchCollections, {
         filter: {
+          collection_category: { eq: process.env.REACT_APP_REP_TYPE },
           visibility: { eq: true },
-          parent_collection: {
-            exists: false
-          }
+          parent_collection: { exists: false }
         },
         limit: this.state.limit,
         nextToken: this.state.nextTokens[this.state.page]

--- a/src/pages/search/SearchLoader.js
+++ b/src/pages/search/SearchLoader.js
@@ -74,12 +74,15 @@ class SearchLoader extends Component {
 
   async loadItems() {
     const searchQuery = new URLSearchParams(this.props.location.search);
-    let archiveFilter = { visibility: { eq: true } };
+    const REP_TYPE = process.env.REACT_APP_REP_TYPE;
+    let archiveFilter = {
+      item_category: { eq: REP_TYPE },
+      visibility: { eq: true }
+    };
     let collectionFilter = {
+      collection_category: { eq: REP_TYPE },
       visibility: { eq: true },
-      parent_collection: {
-        exists: false
-      }
+      parent_collection: { exists: false }
     };
     if (
       searchQuery.get("search_field") !== null &&


### PR DESCRIPTION
**JIRA Ticket**: (https://webapps.es.vt.edu/jira/browse/LIBTD-1981) (:star:)

# What does this Pull Request do? (:star:)
This PR restricts archives and collections search within IAWA project, i.e., set item_category and collection_category as "IAWA" in the search filter.

# What's the changes? (:star:)

* Add a filter field to search queries by setting the item or collection category as  "IAWA" in collection and archive search loaders

# How should this be tested?

* Go to Amplify console to set an environment variable: REACT_APP_REP_TYPE as IAWA. Make sure to use the REACT_APP prefix.
* Modify/Add an item in DynamoDB Collection table and Archive table, set the corresponding "collection_category" and "item_category" as something other than "IAWA", respectively.
* Set category in search filter to "IAWA", perform search through frontend or AppSync, then make sure that the search results return the intended items only.

# Interested parties
Tag (@yinlinchen ) interested parties

(:star:) Required fields
