### PR TITLE
LIBTD-2044: Refactor metadata field display (display field only when …

### DIFF
--- a/src/pages/collections/CollectionsList.js
+++ b/src/pages/collections/CollectionsList.js
@@ -1,118 +1,26 @@
 import React, { Component } from "react";
-import { NavLink } from "react-router-dom";
 import { Thumbnail } from "../../components/Thumbnail";
-import { arkLinkFormatted } from "../../shared/TextFormatTools";
+import { titleFormatted } from "../../shared/TextFormatTools";
+import { FormattedAttr } from "../../shared/TextFormatTools";
 import "../../css/ListPages.css";
 
 class CollectionsList extends Component {
-  descFormatted(collection) {
-    return collection.description.substring(0, 100) + "...";
-  }
-
-  dateFormatted(collection) {
-    return (
-      parseInt(collection.start_date) + "-" + parseInt(collection.end_date)
-    );
-  }
-
-  sourceLink(collection) {
-    return { __html: collection.source };
-  }
-
   render() {
     return (
       <div>
         {this.props.collections.map(collection => (
           <li key={collection.id} className="collection-entry">
-            <h4 className="collection-title">
-              <NavLink
-                to={`/collection/${arkLinkFormatted(collection.custom_key)}`}
-              >
-                {collection.title}
-              </NavLink>
-            </h4>
+            {titleFormatted(collection, "collection")}
             <span className="collection-img">
               <Thumbnail item={collection} dataType="collection" />
             </span>
             <div className="collection-details">
-              <div className="collection-detail">
-                <table>
-                  <tbody>
-                    <tr>
-                      <td className="collection-detail-key">Identifier:</td>
-                      <td className="collection-detail-value">
-                        {collection.identifier}
-                      </td>
-                    </tr>
-                  </tbody>
-                </table>
-              </div>
-
-              <div className="collection-detail">
-                <table>
-                  <tbody>
-                    <tr>
-                      <td className="collection-detail-key">Description:</td>
-                      <td className="collection-detail-value">
-                        {this.descFormatted(collection)}
-                      </td>
-                    </tr>
-                  </tbody>
-                </table>
-              </div>
-
-              <div className="collection-detail">
-                <table>
-                  <tbody>
-                    <tr>
-                      <td className="collection-detail-key">Date:</td>
-                      <td className="collection-detail-value">
-                        {this.dateFormatted(collection)}
-                      </td>
-                    </tr>
-                  </tbody>
-                </table>
-              </div>
-
-              <div className="collection-detail">
-                <table>
-                  <tbody>
-                    <tr>
-                      <td className="collection-detail-key">Source:</td>
-                      <td
-                        className="collection-detail-value"
-                        dangerouslySetInnerHTML={this.sourceLink(collection)}
-                      ></td>
-                    </tr>
-                  </tbody>
-                </table>
-              </div>
-
-              <div className="collection-detail">
-                <table>
-                  <tbody>
-                    <tr>
-                      <td className="collection-detail-key">Language:</td>
-                      <td className="collection-detail-value">
-                        {collection.language}
-                      </td>
-                    </tr>
-                  </tbody>
-                </table>
-              </div>
-
-              <div className="collection-detail">
-                <table>
-                  <tbody>
-                    <tr>
-                      <td className="collection-detail-key">Creator:</td>
-                      <td className="collection-detail-value">
-                        {collection.creator}
-                      </td>
-                    </tr>
-                  </tbody>
-                </table>
-              </div>
+              <FormattedAttr item={collection} attribute="identifier" />
+              <FormattedAttr item={collection} attribute="description" />
+              <FormattedAttr item={collection} attribute="date" />
+              <FormattedAttr item={collection} attribute="source" />
+              <FormattedAttr item={collection} attribute="language" />
+              <FormattedAttr item={collection} attribute="creator" />
             </div>
           </li>
         ))}

--- a/src/pages/search/ArchiveListView.js
+++ b/src/pages/search/ArchiveListView.js
@@ -1,76 +1,27 @@
 import React from "react";
-import { NavLink } from "react-router-dom";
-import { arkLinkFormatted } from "../../shared/TextFormatTools";
+import { titleFormatted } from "../../shared/TextFormatTools";
+import { FormattedAttr } from "../../shared/TextFormatTools";
 import { Thumbnail } from "../../components/Thumbnail";
 import "../../css/SearchResult.css";
-import ReactHtmlParser from "react-html-parser";
-
-const DateValue = archive => {
-  let circa_date = archive.circa ? archive.circa : "";
-  let end_date = archive["end_date"] ? " - " + archive["end_date"] : "";
-  return circa_date + archive["start_date"] + end_date;
-};
-
-const MultiValueAttr = (label, value) => {
-  if (Array.isArray(value)) {
-    return (
-      <tr>
-        <th>{label}:</th>
-        <td>{value.join(" and ")}</td>
-      </tr>
-    );
-  } else {
-    return "";
-  }
-};
 
 export const ArchiveListView = ({ archive }) => {
   return (
     <div className="row search-result-wrapper">
       <div className="col-sm-12 title-wrapper">
-        <h4>
-          <NavLink to={`/archive/${arkLinkFormatted(archive.custom_key)}`}>
-            {archive.title}
-          </NavLink>
-        </h4>
+        {titleFormatted(archive, "archive")}
       </div>
       <div className="col-md-4 col-sm-4 my-auto">
         <Thumbnail item={archive} dataType="archive" />
       </div>
       <div className="col-md-8 col-sm-8">
-        <table className="table">
-          <tbody>
-            <tr>
-              <th>Identifier:</th>
-              <td>
-                <NavLink
-                  to={`/archive/${arkLinkFormatted(archive.custom_key)}`}
-                >
-                  {archive.identifier}
-                </NavLink>
-              </td>
-            </tr>
-            <tr>
-              <th>Date:</th>
-              <td>{DateValue(archive)}</td>
-            </tr>
-            {MultiValueAttr("Type", archive.resource_type)}
-            {MultiValueAttr("Medium", archive.medium)}
-            <tr>
-              <th>Source:</th>
-              <td>
-                {archive.source.map((value, i) => (
-                  <li className="list-unstyled" key={i}>
-                    {ReactHtmlParser(value)}
-                  </li>
-                ))}
-              </td>
-            </tr>
-            {MultiValueAttr("Belongs to", archive.belongs_to)}
-            {MultiValueAttr("Tags", archive.tags)}
-            {MultiValueAttr("Creator", archive.creator)}
-          </tbody>
-        </table>
+        <FormattedAttr item={archive} attribute="identifier" />
+        <FormattedAttr item={archive} attribute="date" />
+        <FormattedAttr item={archive} attribute="resource_type" />
+        <FormattedAttr item={archive} attribute="medium" />
+        <FormattedAttr item={archive} attribute="source" />
+        <FormattedAttr item={archive} attribute="belongs_to" />
+        <FormattedAttr item={archive} attribute="tags" />
+        <FormattedAttr item={archive} attribute="creator" />
       </div>
     </div>
   );

--- a/src/pages/search/CollectionListView.js
+++ b/src/pages/search/CollectionListView.js
@@ -1,83 +1,25 @@
 import React from "react";
-import { NavLink } from "react-router-dom";
-import { arkLinkFormatted } from "../../shared/TextFormatTools";
+import { titleFormatted } from "../../shared/TextFormatTools";
+import { FormattedAttr } from "../../shared/TextFormatTools";
 import { Thumbnail } from "../../components/Thumbnail";
 import "../../css/SearchResult.css";
-import ReactHtmlParser from "react-html-parser";
-
-const DateValue = collection => {
-  let circa_date = collection.circa ? collection.circa : "";
-  let end_date = collection["end_date"] ? " - " + collection["end_date"] : "";
-  return circa_date + collection["start_date"] + end_date;
-};
-
-const DescFormatted = collection => {
-  return collection.description.substring(0, 100) + "...";
-};
-
-const MultiValueAttr = (label, value) => {
-  if (Array.isArray(value)) {
-    return (
-      <tr>
-        <th>{label}:</th>
-        <td>{value.join(" and ")}</td>
-      </tr>
-    );
-  } else {
-    return "";
-  }
-};
 
 export const CollectionListView = ({ collection }) => {
   return (
     <div className="row search-result-wrapper">
       <div className="col-sm-12 title-wrapper">
-        <h4>
-          <NavLink
-            to={`/collection/${arkLinkFormatted(collection.custom_key)}`}
-          >
-            {collection.title}
-          </NavLink>
-        </h4>
+        {titleFormatted(collection, "collection")}
       </div>
       <div className="col-md-4 col-sm-4 my-auto">
         <Thumbnail item={collection} dataType="collection" />
       </div>
       <div className="col-md-8 col-sm-8">
-        <table className="table">
-          <tbody>
-            <tr>
-              <th>Identifier:</th>
-              <td>
-                <NavLink
-                  to={`/collection/${arkLinkFormatted(collection.custom_key)}`}
-                >
-                  {collection.identifier}
-                </NavLink>
-              </td>
-            </tr>
-            <tr>
-              <th>Description:</th>
-              <td>{DescFormatted(collection)}</td>
-            </tr>
-            <tr>
-              <th>Date:</th>
-              <td>{DateValue(collection)}</td>
-            </tr>
-            <tr>
-              <th>Source:</th>
-              <td>
-                {collection.source.map((value, i) => (
-                  <li className="list-unstyled" key={i}>
-                    {ReactHtmlParser(value)}
-                  </li>
-                ))}
-              </td>
-            </tr>
-            {MultiValueAttr("language", collection.language)}
-            {MultiValueAttr("Creator", collection.creator)}
-          </tbody>
-        </table>
+        <FormattedAttr item={collection} attribute="identifier" />
+        <FormattedAttr item={collection} attribute="description" />
+        <FormattedAttr item={collection} attribute="date" />
+        <FormattedAttr item={collection} attribute="source" />
+        <FormattedAttr item={collection} attribute="language" />
+        <FormattedAttr item={collection} attribute="creator" />
       </div>
     </div>
   );

--- a/src/shared/TextFormatTools.js
+++ b/src/shared/TextFormatTools.js
@@ -1,3 +1,87 @@
+import React from "react";
+import { NavLink } from "react-router-dom";
+import "../css/ListPages.css";
+
+function labelAttr(attr) {
+  if (attr === "resource_type") return "Type";
+  else if (attr === "belongs_to") return "Belongs to";
+  else return attr.charAt(0).toUpperCase() + attr.slice(1);
+}
+
 export function arkLinkFormatted(customKey) {
   return customKey.replace("ark:/53696/", "");
 }
+
+export function titleFormatted(item, dataType) {
+  return (
+    <h4>
+      <NavLink to={`/${dataType}/${arkLinkFormatted(item.custom_key)}`}>
+        {item.title}
+      </NavLink>
+    </h4>
+  );
+}
+export function dateFormatted(item) {
+  let circa_date = item.circa ? item.circa : "";
+  let end_date = item.end_date ? " - " + parseInt(item.end_date) : "";
+  let start_date = item.start_date ? parseInt(item.start_date) : "";
+  return circa_date + start_date + end_date;
+}
+
+export const FormattedAttr = ({ item, attribute }) => {
+  function textFormat(item, attr) {
+    if (Array.isArray(item[attr])) {
+      return item[attr].join(" and ");
+    } else if (attr === "description") {
+      return item[attr].substring(0, 100) + "...";
+    } else if (attr === "date") {
+      return dateFormatted(item);
+    } else {
+      return item[attr];
+    }
+  }
+
+  function tdFormat(item, attr) {
+    if (attr === "source") {
+      return (
+        <td
+          className="collection-detail-value"
+          dangerouslySetInnerHTML={{ __html: item[attr] }}
+        ></td>
+      );
+    } else if (attr === "identifier") {
+      let dataType = "collection";
+      if (item.item_category) dataType = "archive";
+      return (
+        <td className="collection-detail-value">
+          <NavLink to={`/${dataType}/${arkLinkFormatted(item.custom_key)}`}>
+            {textFormat(item, attribute)}
+          </NavLink>
+        </td>
+      );
+    } else {
+      return (
+        <td className="collection-detail-value">
+          {textFormat(item, attribute)}
+        </td>
+      );
+    }
+  }
+
+  if (textFormat(item, attribute)) {
+    return (
+      <div className="collection-detail">
+        <table>
+          <tbody>
+            <tr>
+              <td className="collection-detail-key">{labelAttr(attribute)}:</td>
+              {tdFormat(item, attribute)}
+            </tr>
+          </tbody>
+        </table>
+      </div>
+    );
+  } else {
+    return "";
+  }
+};


### PR DESCRIPTION
…the value is not empty, share and reuse text formatting functions)

**JIRA Ticket**: (https://webapps.es.vt.edu/jira/browse/LIBTD-2044) (:star:)

# What does this Pull Request do? (:star:)
This PR addresses the issue that we should display metadata fields for either Archive or Collection only when the corresponding value is not empty. Also this PR consolidates metadata displaying functions into one shared TextFormat file so that the functions can be reused application wide, consequently, repeated/inconsistent code can be avoid.

# What's the changes? (:star:)

* Move metadata display functions into one text formatting shared file.
* Check if the value is empty before displaying the metadata field.

# How should this be tested?

* Check if the metadata fields are displayed properly in "Browse Collections" page;
* Check if the metadata fields are displayed properly in "Search Items" page.

# Interested parties
Tag (@yinlinchen ) interested parties

(:star:) Required fields
