### PR TITLE
Makes works list full-width and fixes responsive issue with table under Collection Details heading.

### DIFF
--- a/src/css/CollectionsShowPage.css
+++ b/src/css/CollectionsShowPage.css
@@ -45,6 +45,10 @@ div.details-section-content table tr .collection-detail-value {
   text-align: left;
   vertical-align: middle;
 }
+div.details-section-content table tr td.collection-detail-value.identifier {
+  -ms-word-break: break-all;
+  word-break: break-all;
+}
 div.details-section-content table tr {
   border-bottom: 1px solid var(--light-gray);
 }
@@ -52,22 +56,29 @@ div.details-section-content table tr {
 div.collection-items-list-wrapper {
   margin-top: 50px;
 }
-
-div.collection-items-list table tbody tr:nth-child(odd) {
-  background-color: var(--light-gray);
-}
-
 div.collection-items-list table tbody tr td.item-image img {
   width: 100px;
 }
-div.collection-items-list table thead tr th,
-div.collection-items-list table tbody tr td.item-info {
-  padding: 0 15px;
+div.collection-items-list table tbody tr td.item-image {
+  padding-right: 0;
+  padding-left: 0.25rem;
 }
 div.collection-items-list table tbody tr td.item-info div.item-link-wrapper {
   font-weight: 700;
 }
+
 div.collection-items-list table tbody tr td.item-info a,
 div.collection-items-list table tbody tr td.item-info a:visited {
   color: var(--link-blue);
+}
+
+div.collection-items-list
+  table
+  tbody
+  tr
+  td.item-info
+  div.collection-link-wrapper
+  a {
+  -ms-word-break: break-all;
+  word-break: break-all;
 }

--- a/src/pages/collections/CollectionItemsList.js
+++ b/src/pages/collections/CollectionItemsList.js
@@ -11,7 +11,7 @@ class CollectionItemsList extends Component {
     if (this.props.items.length) {
       retVal = (
         <div className="collection-items-list">
-          <table>
+          <table className="table table-striped">
             <thead>
               <tr>
                 <th>&nbsp;</th>

--- a/src/pages/collections/CollectionsShowPage.js
+++ b/src/pages/collections/CollectionsShowPage.js
@@ -152,7 +152,7 @@ class CollectionsShowPage extends Component {
                 {this.props.collection.identifier != null ? (
                   <tr>
                     <td className="collection-detail-key">Identifier</td>
-                    <td className="collection-detail-value">
+                    <td className="collection-detail-value identifier">
                       {this.props.collection.identifier}
                     </td>
                   </tr>


### PR DESCRIPTION
**JIRA Ticket**: (link) (:star:)
https://webapps.es.vt.edu/jira/browse/LIBTD-2055

# What does this Pull Request do? (:star:)
This makes the list of works for collections full-width in the page, and it resolves problems with responsive sizing of the Collection Details table. Additional styling to the table will be applied later as part of the interface redesign.

# What's the changes? (:star:)
-CollectionsItemList.js - CSS class for the table changed to bootstrap "table" class.
-CollectionShowPage.css - Classes added to allow long identifiers to break onto a new line at mobile size screens. Also CSS update to remove classes that are no longer needed due to the bootstrap styling. And, added a class to adjust table padding for images.
-CollectionShowPage.js - class added to identifier field.

# How should this be tested?
-Items in which appear in the Browse Collections area should show up in a full width table at the bottom on the page. The table should respond appropriately to mobile size screens and allow long identifiers to break onto new lines so that the thumbnail image retains an appropriate size. The collection detail table should also respond to mobile size screens and long identifiers should break onto a new line. This can be tested with chrome dev tools.

# Additional Notes:
-LIBTD-2055
-The deleted classes were not used for other components on the site and their removal should not affect anything else.

# Interested parties
@yinlinchen 

(:star:) Required fields
