### PR TITLE
LIBTD-2054: Fix missing 'next/previous page' button at the bottom of …

### DIFF
--- a/src/pages/collections/CollectionItemsLoader.js
+++ b/src/pages/collections/CollectionItemsLoader.js
@@ -125,6 +125,8 @@ class CollectionItemsLoader extends Component {
             previousPage={this.previousPage.bind(this)}
             nextPage={this.nextPage.bind(this)}
             totalPages={this.state.totalPages}
+            isSearch={false}
+            atBottom={true}
           />
         </div>
       );


### PR DESCRIPTION
…collection's list of archives page

**JIRA Ticket**: (https://webapps.es.vt.edu/jira/browse/LIBTD-2054) (:star:)

# What does this Pull Request do? (:star:)
This PR adds the "Previous Page"/"Next Page" to the bottom of a Collection's list of archives display page.

# What's the changes? (:star:)

* Set up the proper isSearch and atBottom props for Pagination component 

# How should this be tested?

* Specifically, through "Browse Collections" in the homepage menu, go to the "Ms1990_025_Folder1" subcollection under "Ms1990_025_Rudoff" collection as it has 33 archives. Check if "Next Page" and "Previous Page" buttons at the bottom of the page work as intended.

# Interested parties
Tag (@yinlinchen ) interested parties

(:star:) Required fields
