### PR TITLE
LIBTD-2070: Provide links to metadata fields with every one of which …

### DIFF
--- a/src/components/SearchBar.js
+++ b/src/components/SearchBar.js
@@ -1,6 +1,7 @@
 import React, { Component } from "react";
 import { withRouter } from "react-router-dom";
 import qs from "query-string";
+import { labelAttr } from "../shared/MetadataRenderer";
 
 class SearchBar extends Component {
   state = {
@@ -10,12 +11,21 @@ class SearchBar extends Component {
     q: this.props.q
   };
 
-  searchFields = ["title", "creator", "description"];
+  searchFields = [
+    "title",
+    "creator",
+    "description",
+    "belongs_to",
+    "language",
+    "medium",
+    "resource_type",
+    "tags"
+  ];
 
   fieldOptions = () => {
     return this.searchFields.map(field => (
       <option value={field} key={field}>
-        {field}
+        {labelAttr(field)}
       </option>
     ));
   };

--- a/src/pages/archives/ArchivePage.js
+++ b/src/pages/archives/ArchivePage.js
@@ -44,7 +44,7 @@ const GetArchive = `query searchArchive($customKey: String) {
 }
 `;
 
-const keyArray = [
+const KeyArray = [
   "identifier",
   "belongs_to",
   "bibliographic_citation",
@@ -141,7 +141,7 @@ class ArchivePage extends Component {
                 <div className="details-section-content">
                   <table>
                     <tbody>
-                      <RenderItemsDetailed keyArray={keyArray} item={item} />
+                      <RenderItemsDetailed keyArray={KeyArray} item={item} />
                     </tbody>
                   </table>
                 </div>

--- a/src/pages/collections/CollectionsShowPage.js
+++ b/src/pages/collections/CollectionsShowPage.js
@@ -25,7 +25,7 @@ class CollectionsShowPage extends Component {
   }
 
   render() {
-    const keyArray = [
+    const KeyArray = [
       "size",
       "creator",
       "rights_statement",
@@ -71,7 +71,7 @@ class CollectionsShowPage extends Component {
             <table>
               <tbody>
                 <RenderItemsDetailed
-                  keyArray={keyArray}
+                  keyArray={KeyArray}
                   item={this.props.collection}
                 />
               </tbody>

--- a/src/shared/MetadataRenderer.js
+++ b/src/shared/MetadataRenderer.js
@@ -47,7 +47,15 @@ export function collectionSize(collection) {
 }
 
 function listValue(dataType, attr, value) {
-  if (attr === "creator") {
+  const LinkedFields = [
+    "creator",
+    "belongs_to",
+    "language",
+    "medium",
+    "resource_type",
+    "tags"
+  ];
+  if (LinkedFields.indexOf(attr) > -1) {
     const parsedObject = {
       data_type: dataType,
       search_field: attr,


### PR DESCRIPTION
…lands on search by the corresponding field page

**JIRA Ticket**: (https://webapps.es.vt.edu/jira/browse/LIBTD-2070) (:star:)

* Other Relevant Links (https://webapps.es.vt.edu/jira/browse/LIBTD-2059)

# What does this Pull Request do? (:star:)
This PR generates links to several metadata fields. Each of these links provides searching by the corresponding field functionality and goes to the search results page.

# What's the changes? (:star:)

* Changes constant variable with first letter capitalized.
* Feeds an array of metadata fields required to be linked. 
* Generate the search query with corresponding search field among other props, and then send the query  through <NavLink>.

# How should this be tested?

* Go to Search Items page, click on one of the following metadata fields with links: "Creator", "Belongs to", "Language", "Medium", "Type", and "Tags." It should bring you to the search results page searched by these fields. 
* You can go to any other pages with metadata fields, such as individual Archive page, individual Collection page, and test out the functionality as in the previous step.

# Interested parties
Tag (@yinlinchen ) interested parties

(:star:) Required fields
