### PR TITLE
pull html from file for About and Terms pages

### DIFF
--- a/src/lib/fetch_tools.js
+++ b/src/lib/fetch_tools.js
@@ -1,4 +1,21 @@
-export const fetchCopyHTML = async (htmlLink, component) => {
+export function getHTML(copyObj, component) {
+  let copy = null;
+  try {
+    if (copyObj.type === "string") {
+      copy = copyObj.value;
+    } else if (copyObj.type === "file") {
+      const copyLink = `${process.env.REACT_APP_CONFIG_PATH}/${copyObj.value}`;
+      fetchCopyHTML(copyLink, component);
+    }
+  } catch (error) {
+    console.error("Error setting copy for component");
+  }
+  if (copy !== null) {
+    component.setState({ copy: copy });
+  }
+}
+
+const fetchCopyHTML = async (htmlLink, component) => {
   let response = null;
   let data = null;
 

--- a/src/pages/AboutPage.js
+++ b/src/pages/AboutPage.js
@@ -1,6 +1,6 @@
 import React, { Component } from "react";
 import SiteTitle from "../components/SiteTitle";
-import { fetchCopyHTML } from "../lib/fetch_tools";
+import { getHTML } from "../lib/fetch_tools";
 
 class AboutPage extends Component {
   constructor(props) {
@@ -11,20 +11,7 @@ class AboutPage extends Component {
   }
 
   componentDidMount() {
-    let aboutCopy = null;
-    try {
-      if (this.props.siteDetails.aboutCopy.type === "string") {
-        aboutCopy = this.props.siteDetails.aboutCopy.value;
-      } else if (this.props.siteDetails.aboutCopy.type === "file") {
-        const copyLink = `${process.env.REACT_APP_CONFIG_PATH}/${this.props.siteDetails.aboutCopy.value}`;
-        fetchCopyHTML(copyLink, this);
-      }
-    } catch (error) {
-      console.error("Error fetching copy for AboutPage component");
-    }
-    if (aboutCopy !== null) {
-      this.setState({ copy: aboutCopy });
-    }
+    getHTML(this.props.siteDetails.aboutCopy, this);
   }
 
   render() {

--- a/src/pages/TermsPage.js
+++ b/src/pages/TermsPage.js
@@ -1,6 +1,6 @@
 import React, { Component } from "react";
 import SiteTitle from "../components/SiteTitle";
-import { fetchCopyHTML } from "../lib/fetch_tools";
+import { getHTML } from "../lib/fetch_tools";
 
 class TermsPage extends Component {
   constructor(props) {
@@ -11,20 +11,7 @@ class TermsPage extends Component {
   }
 
   componentDidMount() {
-    let termsCopy = null;
-    try {
-      if (this.props.siteDetails.termsCopy.type === "string") {
-        termsCopy = this.props.siteDetails.termsCopy.value;
-      } else if (this.props.siteDetails.termsCopy.type === "file") {
-        const copyLink = `${process.env.REACT_APP_CONFIG_PATH}/${this.props.siteDetails.termsCopy.value}`;
-        fetchCopyHTML(copyLink, this);
-      }
-    } catch (error) {
-      console.error("Error fetching copy for TermsPage component");
-    }
-    if (termsCopy !== null) {
-      this.setState({ copy: termsCopy });
-    }
+    getHTML(this.props.siteDetails.termsCopy, this);
   }
 
   render() {


### PR DESCRIPTION
**Pull html from file for About and Terms pages.**
* * *

**JIRA Ticket**: (https://webapps.es.vt.edu/jira/browse/LIBTD-2080) (:star:)

* Other Relevant Links (Meeting note, project page, related pull requests, etc.)

# What does this Pull Request do? (:star:)
Allows react app to pull html from file for About and Terms pages. Still supports putting the html content directly in config file as a string.

# What's the changes? (:star:)
* About and Terms pages can now read html content from file specified in config json
* Adds shared function to fetch html and set Component state

# How should this be tested?
* html directory with files must be present in same directory as `LIBTD-2080` config files in s3
* Load site and visit About and Terms pages.
* Both pages are defined for IAWA
* Only About page is defined for SWVA and default fallback

# Additional Notes:
* branch: `LIBTD-2080`

# Interested parties
@yinlinchen 

(:star:) Required fields
