### PR TITLE
Renders language codes as their corresponding full language name

### DIFF
--- a/src/lib/MetadataRenderer.js
+++ b/src/lib/MetadataRenderer.js
@@ -46,7 +46,7 @@ export function collectionSize(collection) {
   return subCollections + archives;
 }
 
-function listValue(dataType, attr, value) {
+function listValue(dataType, attr, value, languages) {
   const LinkedFields = [
     "creator",
     "belongs_to",
@@ -55,6 +55,9 @@ function listValue(dataType, attr, value) {
     "resource_type",
     "tags"
   ];
+  if (attr === "language" && languages !== undefined) {
+    value = languages[value];
+  }
   if (LinkedFields.indexOf(attr) > -1) {
     const parsedObject = {
       data_type: dataType,
@@ -72,7 +75,7 @@ function listValue(dataType, attr, value) {
   }
 }
 
-function textFormat(item, attr) {
+function textFormat(item, attr, languages) {
   if (item[attr] === null) return null;
   let dataType = "archive";
   if (item.collection_category) dataType = "collection";
@@ -81,7 +84,7 @@ function textFormat(item, attr) {
       <div>
         {item[attr].map((value, i) => (
           <li className="list-unstyled" key={i}>
-            {listValue(dataType, attr, value)}
+            {listValue(dataType, attr, value, languages)}
           </li>
         ))}
       </div>
@@ -124,8 +127,8 @@ const MoreLink = ({ dataType, item }) => {
   );
 };
 
-const RenderAttribute = ({ item, attribute }) => {
-  if (textFormat(item, attribute)) {
+const RenderAttribute = ({ item, attribute, languages }) => {
+  if (textFormat(item, attribute, languages)) {
     let value_style = attribute === "identifier" ? "identifier" : "";
     return (
       <div className="collection-detail">
@@ -134,7 +137,7 @@ const RenderAttribute = ({ item, attribute }) => {
             <tr>
               <td className="collection-detail-key">{labelAttr(attribute)}:</td>
               <td className={`collection-detail-value ${value_style}`}>
-                {textFormat(item, attribute)}
+                {textFormat(item, attribute, languages)}
               </td>
             </tr>
           </tbody>
@@ -146,14 +149,14 @@ const RenderAttribute = ({ item, attribute }) => {
   }
 };
 
-const RenderAttrDetailed = ({ item, attribute }) => {
-  if (textFormat(item, attribute)) {
+const RenderAttrDetailed = ({ item, attribute, languages }) => {
+  if (textFormat(item, attribute, languages)) {
     let value_style = attribute === "identifier" ? "identifier" : "";
     return (
       <tr>
         <td className="collection-detail-key">{labelAttr(attribute)}</td>
         <td className={`collection-detail-value ${value_style}`}>
-          {textFormat(item, attribute)}
+          {textFormat(item, attribute, languages)}
         </td>
       </tr>
     );
@@ -161,21 +164,31 @@ const RenderAttrDetailed = ({ item, attribute }) => {
     return <></>;
   }
 };
-export const RenderItems = ({ keyArray, item }) => {
+export const RenderItems = ({ keyArray, item, languages }) => {
   let render_items = [];
   for (const [index, value] of keyArray.entries()) {
     render_items.push(
-      <RenderAttribute item={item} attribute={value} key={index} />
+      <RenderAttribute
+        item={item}
+        attribute={value}
+        key={index}
+        languages={languages}
+      />
     );
   }
   return render_items;
 };
 
-export const RenderItemsDetailed = ({ keyArray, item }) => {
+export const RenderItemsDetailed = ({ keyArray, item, languages }) => {
   let render_items_detailed = [];
   for (const [index, value] of keyArray.entries()) {
     render_items_detailed.push(
-      <RenderAttrDetailed item={item} attribute={value} key={index} />
+      <RenderAttrDetailed
+        item={item}
+        attribute={value}
+        key={index}
+        languages={languages}
+      />
     );
   }
   return render_items_detailed;

--- a/src/lib/fetch_tools.js
+++ b/src/lib/fetch_tools.js
@@ -32,3 +32,26 @@ const fetchCopyHTML = async (htmlLink, component) => {
     component.setState({ copy: data });
   }
 };
+
+export const fetchLanguages = async (component, key, callback) => {
+  if (component.state.languages === null) {
+    let response = null;
+    let data = null;
+
+    try {
+      const htmlLink = `${process.env.REACT_APP_CONFIG_PATH}/language_codes_by_${key}.json`;
+      response = await fetch(htmlLink);
+      data = await response.json();
+    } catch (error) {
+      console.error(`Error fetching languages`);
+      console.error(error);
+    }
+    if (data !== null) {
+      component.setState({ languages: data }, function() {
+        if (typeof component.loadItems === "function") {
+          component.loadItems();
+        }
+      });
+    }
+  }
+};

--- a/src/pages/archives/ArchivePage.js
+++ b/src/pages/archives/ArchivePage.js
@@ -6,6 +6,7 @@ import SearchBar from "../../components/SearchBar";
 import Breadcrumbs from "../../components/Breadcrumbs.js";
 import SiteTitle from "../../components/SiteTitle";
 import { RenderItemsDetailed } from "../../lib/MetadataRenderer";
+import { fetchLanguages } from "../../lib/fetch_tools";
 
 const GetArchive = `query searchArchive($customKey: String) {
   searchArchives(filter: {
@@ -65,12 +66,16 @@ const KeyArray = [
 ];
 
 class ArchivePage extends Component {
-  state = {
-    page: 0,
-    dataType: "archive",
-    searchField: "title",
-    view: "List"
-  };
+  constructor(props) {
+    super(props);
+    this.state = {
+      page: 0,
+      dataType: "archive",
+      searchField: "title",
+      view: "List",
+      languages: null
+    };
+  }
 
   updateFormState = (name, val) => {
     this.setState({
@@ -81,6 +86,10 @@ class ArchivePage extends Component {
   setPage = page => {
     this.setState({ page: page });
   };
+
+  componentDidMount() {
+    fetchLanguages(this, "abbr");
+  }
 
   render() {
     return (
@@ -115,44 +124,51 @@ class ArchivePage extends Component {
           window.ga("send", "pageview", {
             dimension1: item.identifier
           });
-
-          return (
-            <div>
-              <SiteTitle
-                siteTitle={this.props.siteDetails.siteTitle}
-                pageTitle={item.title}
-              />
-              <SearchBar
-                dataType={this.state.dataType}
-                view={this.state.view}
-                searchField={this.state.searchField}
-                setPage={this.setPage}
-                updateFormState={this.updateFormState}
-              />
-              <div className="breadcrumbs-wrapper">
-                <Breadcrumbs dataType={"Archives"} record={item} />
-              </div>
-              <h3>{item.title}</h3>
-              <div className="row">
-                <div className="col-sm-12">
-                  <Viewer config={miradorConfig} />
+          if (this.state.languages) {
+            return (
+              <div>
+                <SiteTitle
+                  siteTitle={this.props.siteDetails.siteTitle}
+                  pageTitle={item.title}
+                />
+                <SearchBar
+                  dataType={this.state.dataType}
+                  view={this.state.view}
+                  searchField={this.state.searchField}
+                  setPage={this.setPage}
+                  updateFormState={this.updateFormState}
+                />
+                <div className="breadcrumbs-wrapper">
+                  <Breadcrumbs dataType={"Archives"} record={item} />
+                </div>
+                <h3>{item.title}</h3>
+                <div className="row">
+                  <div className="col-sm-12">
+                    <Viewer config={miradorConfig} />
+                  </div>
+                </div>
+                <p>{item.description}</p>
+                <div className="details-section">
+                  <div className="details-section-header">
+                    <h2>Archive Details</h2>
+                  </div>
+                  <div className="details-section-content">
+                    <table>
+                      <tbody>
+                        <RenderItemsDetailed
+                          keyArray={KeyArray}
+                          item={item}
+                          languages={this.state.languages}
+                        />
+                      </tbody>
+                    </table>
+                  </div>
                 </div>
               </div>
-              <p>{item.description}</p>
-              <div className="details-section">
-                <div className="details-section-header">
-                  <h2>Archive Details</h2>
-                </div>
-                <div className="details-section-content">
-                  <table>
-                    <tbody>
-                      <RenderItemsDetailed keyArray={KeyArray} item={item} />
-                    </tbody>
-                  </table>
-                </div>
-              </div>
-            </div>
-          );
+            );
+          } else {
+            return <></>;
+          }
         }}
       </Connect>
     );

--- a/src/pages/collections/CollectionsListPage.js
+++ b/src/pages/collections/CollectionsListPage.js
@@ -1,5 +1,5 @@
 import React, { Component } from "react";
-import { ItemListView } from "../search/ItemListView";
+import ItemListView from "../search/ItemListView";
 import ResultsNumberDropdown from "../../components/ResultsNumberDropdown";
 import Pagination from "../../components/Pagination";
 import "../../css/ListPages.css";

--- a/src/pages/collections/CollectionsShowPage.js
+++ b/src/pages/collections/CollectionsShowPage.js
@@ -7,8 +7,16 @@ import {
   RenderItemsDetailed,
   collectionSize
 } from "../../lib/MetadataRenderer";
+import { fetchLanguages } from "../../lib/fetch_tools";
 
 class CollectionsShowPage extends Component {
+  constructor(props) {
+    super(props);
+    this.state = {
+      languages: null
+    };
+  }
+
   creatorDates(props) {
     let collection = props.collection;
     if (collection.creator) {
@@ -26,6 +34,10 @@ class CollectionsShowPage extends Component {
     return "";
   }
 
+  componentDidMount() {
+    fetchLanguages(this, "abbr");
+  }
+
   render() {
     const KeyArray = [
       "size",
@@ -39,51 +51,56 @@ class CollectionsShowPage extends Component {
       "rights_holder",
       "related_url"
     ];
-    return (
-      <div>
-        <div className="breadcrumbs-wrapper">
-          <Breadcrumbs
-            dataType={"Collections"}
-            record={this.props.collection}
+    if (this.state.languages) {
+      return (
+        <div>
+          <div className="breadcrumbs-wrapper">
+            <Breadcrumbs
+              dataType={"Collections"}
+              record={this.props.collection}
+            />
+          </div>
+
+          <h1 className="collection-title">{this.props.collection.title}</h1>
+          <div className="post-heading">
+            <span className="item-count">
+              {this.handleZeroItems(collectionSize(this.props.collection))}
+            </span>
+
+            <this.creatorDates collection={this.props.collection} />
+
+            <span className="last-updated">
+              Last updated: {this.props.collection.modified_date}
+            </span>
+          </div>
+          <div className="description">{this.props.collection.description}</div>
+          <SubCollectionsList
+            subCollections={this.props.collection.subCollections}
           />
-        </div>
 
-        <h1 className="collection-title">{this.props.collection.title}</h1>
-        <div className="post-heading">
-          <span className="item-count">
-            {this.handleZeroItems(collectionSize(this.props.collection))}
-          </span>
-
-          <this.creatorDates collection={this.props.collection} />
-
-          <span className="last-updated">
-            Last updated: {this.props.collection.modified_date}
-          </span>
-        </div>
-        <div className="description">{this.props.collection.description}</div>
-        <SubCollectionsList
-          subCollections={this.props.collection.subCollections}
-        />
-
-        <div className="details-section">
-          <div className="details-section-header">
-            <h2>Collection Details</h2>
+          <div className="details-section">
+            <div className="details-section-header">
+              <h2>Collection Details</h2>
+            </div>
+            <div className="details-section-content">
+              <table>
+                <tbody>
+                  <RenderItemsDetailed
+                    keyArray={KeyArray}
+                    item={this.props.collection}
+                    languages={this.state.languages}
+                  />
+                </tbody>
+              </table>
+            </div>
           </div>
-          <div className="details-section-content">
-            <table>
-              <tbody>
-                <RenderItemsDetailed
-                  keyArray={KeyArray}
-                  item={this.props.collection}
-                />
-              </tbody>
-            </table>
-          </div>
-        </div>
 
-        <CollectionItemsLoader collection={this.props.collection} />
-      </div>
-    );
+          <CollectionItemsLoader collection={this.props.collection} />
+        </div>
+      );
+    } else {
+      return <></>;
+    }
   }
 }
 

--- a/src/pages/search/ItemListView.js
+++ b/src/pages/search/ItemListView.js
@@ -1,31 +1,54 @@
-import React from "react";
+import React, { Component } from "react";
 import { RenderItems, titleFormatted } from "../../lib/MetadataRenderer";
 import { Thumbnail } from "../../components/Thumbnail";
 import "../../css/SearchResult.css";
+import { fetchLanguages } from "../../lib/fetch_tools";
 
-export const ItemListView = ({ item, dataType }) => {
-  const keyArray = [
-    "identifier",
-    "description",
-    "date",
-    "source",
-    "language",
-    "creator",
-    "resource_type",
-    "medium",
-    "belongs_to",
-    "tags",
-    "related_url"
-  ];
-  return (
-    <li key={item.id} className="collection-entry">
-      {titleFormatted(item, dataType)}
-      <span className="collection-img">
-        <Thumbnail item={item} dataType={dataType} />
-      </span>
-      <div className="collection-details">
-        <RenderItems keyArray={keyArray} item={item} />
-      </div>
-    </li>
-  );
-};
+class ItemListView extends Component {
+  constructor(props) {
+    super(props);
+    this.state = {
+      languages: null
+    };
+  }
+
+  componentDidMount() {
+    fetchLanguages(this, "abbr");
+  }
+
+  render() {
+    const keyArray = [
+      "identifier",
+      "description",
+      "date",
+      "source",
+      "language",
+      "creator",
+      "resource_type",
+      "medium",
+      "belongs_to",
+      "tags",
+      "related_url"
+    ];
+    if (this.state.languages !== null) {
+      return (
+        <li key={this.props.item.id} className="collection-entry">
+          {titleFormatted(this.props.item, this.props.dataType)}
+          <span className="collection-img">
+            <Thumbnail item={this.props.item} dataType={this.props.dataType} />
+          </span>
+          <div className="collection-details">
+            <RenderItems
+              keyArray={keyArray}
+              item={this.props.item}
+              languages={this.state.languages}
+            />
+          </div>
+        </li>
+      );
+    } else {
+      return <></>;
+    }
+  }
+}
+export default ItemListView;

--- a/src/pages/search/ItemsList.js
+++ b/src/pages/search/ItemsList.js
@@ -1,5 +1,5 @@
 import React, { Component } from "react";
-import { ItemListView } from "./ItemListView";
+import ItemListView from "./ItemListView";
 import { GalleryView } from "./GalleryView";
 import { MasonryView } from "./MasonryView";
 

--- a/src/pages/search/SearchLoader.js
+++ b/src/pages/search/SearchLoader.js
@@ -3,6 +3,7 @@ import { withRouter } from "react-router-dom";
 import { API, graphqlOperation } from "aws-amplify";
 import * as queries from "../../graphql/queries";
 import SiteTitle from "../../components/SiteTitle";
+import { fetchLanguages } from "../../lib/fetch_tools";
 
 import SearchResults from "./SearchResults";
 
@@ -21,8 +22,10 @@ class SearchLoader extends Component {
       searchField: "title",
       view: "List",
       q: "",
-      dateRange: "1920 - 1939"
+      dateRange: "1920 - 1939",
+      languages: null
     };
+    fetchLanguages(this, "name");
   }
 
   updateFormState = (name, val) => {
@@ -97,7 +100,34 @@ class SearchLoader extends Component {
         this.setState({
           dateRange: searchQuery.get("date_range")
         });
-      } else if (searchQuery.get("q") !== "") {
+      } else if (
+        searchQuery.get("search_field") === "language" &&
+        searchQuery.get("q") !== "" &&
+        this.state.languages
+      ) {
+        let languagePhrase = searchQuery.get("q");
+        if (
+          this.state.languages.hasOwnProperty(
+            searchQuery.get("q").toLowerCase()
+          )
+        ) {
+          languagePhrase = this.state.languages[
+            searchQuery.get("q").toLowerCase()
+          ];
+        }
+
+        searchPhrase = {
+          [searchQuery.get("search_field")]: {
+            matchPhrase: languagePhrase
+          }
+        };
+        this.setState({
+          q: languagePhrase
+        });
+      } else if (
+        searchQuery.get("search_field") !== "language" &&
+        searchQuery.get("q") !== ""
+      ) {
         searchPhrase = {
           [searchQuery.get("search_field")]: {
             matchPhrase: searchQuery.get("q")
@@ -181,6 +211,7 @@ class SearchLoader extends Component {
   }
 
   componentDidMount() {
+    fetchLanguages(this, "name", this.loadItems);
     this.loadItems();
   }
 

--- a/src/pages/search/SearchResults.js
+++ b/src/pages/search/SearchResults.js
@@ -7,10 +7,22 @@ import SearchBar from "../../components/SearchBar";
 import ViewBar from "../../components/ViewBar";
 import ItemsList from "./ItemsList";
 import { labelAttr } from "../../lib/MetadataRenderer";
+import { fetchLanguages } from "../../lib/fetch_tools";
 
 import "../../css/ListPages.css";
 
 class SearchResults extends Component {
+  constructor(props) {
+    super(props);
+    this.state = {
+      languages: null
+    };
+  }
+
+  componentDidMount() {
+    fetchLanguages(this, "abbr");
+  }
+
   render() {
     const ItemsPaginationDisplay = ({ atBottom }) => {
       return (


### PR DESCRIPTION
**Renders language codes as their corresponding full language name.**
* * *

**JIRA Ticket**: (https://webapps.es.vt.edu/jira/browse/LIBTD-2081) (:star:)

* Other Relevant Links (Meeting note, project page, related pull requests, etc.)

# What does this Pull Request do? (:star:)
Renders language codes as their corresponding full language name. Such as en -> English, fr -> French.

# What's the changes? (:star:)
* Loads mapping of language codes to language names if not already loaded
* Replaces codes with names on list pages
* Replaces codes with names on detail pages

# How should this be tested?
* copy language_codes.json into `public/site_data` directory of local react app. File here: https://github.com/VTUL/VTDLP-siteconfig/blob/master/configs/language_codes.json
* Start server like this:
`REACT_APP_REP_TYPE=IAWA REACT_APP_CONFIG_PATH="http://localhost:3000/site_data" npm start`
* Visit list pages (collection and archive lists) and make sure that Language attribute is filled with a full language name (probably English)
* Click on an individual Collection and an individual Archive and make sure Language attribute is filled with a full language name (probably English)


# Additional Notes:
* branch: `LIBTD-2081`

# Interested parties
@yinlinchen 

(:star:) Required fields
