### PR TITLE
LIBTD-2129: Consolidate date_range entry in search query string so to display

### DIFF
--- a/src/components/SearchBar.js
+++ b/src/components/SearchBar.js
@@ -10,8 +10,7 @@ class SearchBar extends Component {
     view: this.props.view,
     dataType: this.props.dataType,
     searchField: this.props.searchField,
-    q: this.props.q,
-    dateRange: this.props.dateRange
+    q: this.props.q
   };
 
   searchFields = [
@@ -60,19 +59,15 @@ class SearchBar extends Component {
 
   updateSearchField = e => {
     if (e.target.value === "date") {
-      this.setState({ searchByDate: true });
+      this.setState({ q: this.date(this.dateRanges[0]) });
     } else {
-      this.setState({ searchByDate: false });
+      this.setState({ q: "" });
     }
     this.setState({ searchField: e.target.value });
   };
 
   updateSearchType = e => {
     this.setState({ dataType: e.target.value });
-  };
-
-  updateDateRange = e => {
-    this.setState({ dateRange: e.target.value });
   };
 
   onKeyPress = e => {
@@ -86,7 +81,6 @@ class SearchBar extends Component {
       data_type: this.state.dataType,
       search_field: this.state.searchField,
       q: this.state.q,
-      date_range: this.state.dateRange,
       view: this.props.view
     };
     try {
@@ -128,10 +122,10 @@ class SearchBar extends Component {
     return (
       <select
         className="form-control"
-        value={this.state.dateRange}
+        value={this.state.q}
         name="dateRangeOptions"
         id="date-range-options"
-        onChange={this.updateDateRange}
+        onChange={this.updateQuery}
       >
         {this.dateRangeOptions()}
       </select>

--- a/src/pages/HomePage.js
+++ b/src/pages/HomePage.js
@@ -39,7 +39,6 @@ class HomePage extends Component {
               searchField="title"
               q=""
               setPage={this.props.setPage}
-              dateRange="1920-1939"
             />
           </div>
           <div className="home-welcome-wrapper">

--- a/src/pages/search/SearchLoader.js
+++ b/src/pages/search/SearchLoader.js
@@ -22,7 +22,6 @@ class SearchLoader extends Component {
       searchField: "title",
       view: "List",
       q: "",
-      dateRange: "1920 - 1939",
       languages: null
     };
     fetchLanguages(this, "name");
@@ -92,14 +91,14 @@ class SearchLoader extends Component {
     };
     let searchPhrase = {};
     if (searchQuery.get("search_field") && searchQuery.get("data_type")) {
-      if (searchQuery.get("search_field") === "date") {
-        let dates = searchQuery.get("date_range").split(" - ");
+      if (
+        searchQuery.get("search_field") === "date" &&
+        searchQuery.get("q") !== ""
+      ) {
+        let dates = searchQuery.get("q").split(" - ");
         searchPhrase = {
           start_date: { gte: `${dates[0]}/01/01`, lte: `${dates[1]}/12/31` }
         };
-        this.setState({
-          dateRange: searchQuery.get("date_range")
-        });
       } else if (
         searchQuery.get("search_field") === "language" &&
         searchQuery.get("q") !== "" &&
@@ -133,13 +132,9 @@ class SearchLoader extends Component {
             matchPhrase: searchQuery.get("q")
           }
         };
-        this.setState({
-          q: searchQuery.get("q")
-        });
       }
       if (searchQuery.get("data_type") === "archive") {
         archiveFilter = { ...archiveFilter, ...searchPhrase };
-        console.log("search query", archiveFilter);
       } else if (searchQuery.get("data_type") === "collection") {
         collectionFilter = { ...collectionFilter, ...searchPhrase };
       }
@@ -236,7 +231,6 @@ class SearchLoader extends Component {
             dataType={this.state.dataType}
             searchField={this.state.searchField}
             q={this.state.q}
-            dateRange={this.state.dateRange}
             view={this.state.view}
             updateFormState={this.updateFormState}
           />

--- a/src/pages/search/SearchResults.js
+++ b/src/pages/search/SearchResults.js
@@ -43,11 +43,10 @@ class SearchResults extends Component {
       data_type: this.props.dataType,
       search_field: "title",
       q: "",
-      date_range: "1920 - 1939",
       view: "List"
     };
     const SearchFieldDisplay = () => {
-      if (this.props.q || this.props.searchField === "date") {
+      if (this.props.q) {
         return (
           <table>
             <tbody>
@@ -58,8 +57,7 @@ class SearchResults extends Component {
               </tr>
               <tr>
                 <td className="collection-detail-value">
-                  {this.props.q ? this.props.q : this.props.dateRange} (
-                  {this.props.total})
+                  {this.props.q} ({this.props.total})
                   <NavLink to={`/search/?${qs.stringify(defaultSearch)}`}>
                     <i className="fas fa-times"></i>
                   </NavLink>
@@ -80,7 +78,6 @@ class SearchResults extends Component {
           searchField={this.props.searchField}
           q={this.props.q}
           setPage={this.props.setPage}
-          dateRange={this.props.dateRange}
         />
         <div className="container">
           <div className="row">


### PR DESCRIPTION
… search query correctly in search by date range results

**JIRA Ticket**: (link) (:star:)

# What does this Pull Request do? (:star:)
This PR removes date_range in the search query string. Instead, it combines q and date_range into one parameter in the search query. It solves the problem that when searching by date range, the resulting search query label incorrectly displayed the previous q.

# What's the changes? (:star:)

* Replace/consolidate the date_range parameter with/into one q parameter

# How should this be tested?

* Go to "Search Items" and search by some field other than "date" 
* Then search by "date", to check if the search query (number of results) part of the search results page displayed correctly

# Interested parties
Tag (@yinlinchen ) interested parties

(:star:) Required fields
