### PR TITLE
LIBTD-2137: Display sub-collection list  with paginations

### DIFF
--- a/src/lib/MetadataRenderer.js
+++ b/src/lib/MetadataRenderer.js
@@ -37,9 +37,7 @@ export function dateFormatted(item) {
 
 export function collectionSize(collection) {
   let subCollections =
-    collection.subCollections.items != null
-      ? collection.subCollections.items.length
-      : 0;
+    collection.subCollections != null ? collection.subCollections.length : 0;
   let archives =
     collection.archives.items != null ? collection.archives.items.length : 0;
   return subCollections + archives;

--- a/src/pages/collections/CollectionsShowLoader.js
+++ b/src/pages/collections/CollectionsShowLoader.js
@@ -4,7 +4,7 @@ import { Connect } from "aws-amplify-react";
 import SiteTitle from "../../components/SiteTitle";
 import { getCollectionByCustomKey } from "../../graphql/queries";
 
-import SubCollectionsLoader from "./SubCollectionsLoader";
+import CollectionsShowPage from "./CollectionsShowPage.js";
 
 class CollectionsShowLoader extends Component {
   render() {
@@ -31,7 +31,7 @@ class CollectionsShowLoader extends Component {
                 siteTitle={this.props.siteDetails.siteTitle}
                 pageTitle={collection.title}
               />
-              <SubCollectionsLoader collection={collection} />
+              <CollectionsShowPage collection={collection} />
             </>
           );
         }}

--- a/src/pages/collections/CollectionsShowPage.js
+++ b/src/pages/collections/CollectionsShowPage.js
@@ -1,6 +1,6 @@
 import React, { Component } from "react";
 import "../../css/CollectionsShowPage.css";
-import SubCollectionsList from "./SubCollectionsList.js";
+import SubCollectionsLoader from "./SubCollectionsLoader.js";
 import CollectionItemsLoader from "./CollectionItemsLoader.js";
 import Breadcrumbs from "../../components/Breadcrumbs.js";
 import {
@@ -36,6 +36,10 @@ class CollectionsShowPage extends Component {
 
   componentDidMount() {
     fetchLanguages(this, "abbr");
+  }
+
+  updateSubCollections(collection, subCollections) {
+    collection.subCollections = subCollections;
   }
 
   render() {
@@ -74,10 +78,12 @@ class CollectionsShowPage extends Component {
             </span>
           </div>
           <div className="description">{this.props.collection.description}</div>
-          <SubCollectionsList
-            subCollections={this.props.collection.subCollections}
-          />
 
+          <SubCollectionsLoader
+            collection={this.props.collection}
+            updateSubCollections={this.updateSubCollections}
+          />
+          <br />
           <div className="details-section">
             <div className="details-section-header">
               <h2>Collection Details</h2>

--- a/src/pages/collections/SubCollectionsList.js
+++ b/src/pages/collections/SubCollectionsList.js
@@ -10,7 +10,6 @@ class SubCollectionsList extends Component {
     if (items.length) {
       content = (
         <div>
-          <h3>Subcollections ({items.length})</h3>
           <ul className="subCollectionList">
             {items.map(item => (
               <li key={item.custom_key}>
@@ -29,9 +28,7 @@ class SubCollectionsList extends Component {
   }
 
   render() {
-    return (
-      <div>{this.subCollectionsContent(this.props.subCollections.items)}</div>
-    );
+    return <div>{this.subCollectionsContent(this.props.subCollections)}</div>;
   }
 }
 

--- a/src/pages/collections/SubCollectionsLoader.js
+++ b/src/pages/collections/SubCollectionsLoader.js
@@ -1,39 +1,145 @@
 import React, { Component } from "react";
-import { graphqlOperation } from "aws-amplify";
-import { Connect } from "aws-amplify-react";
+import { API, graphqlOperation } from "aws-amplify";
+import ResultsNumberDropdown from "../../components/ResultsNumberDropdown";
+import Pagination from "../../components/Pagination";
+import SubCollectionsList from "./SubCollectionsList.js";
 
-import CollectionsShowPage from "./CollectionsShowPage";
-
-const GetSubCollections = `query SearchSubCollections($parent_id: String!) {
-  searchCollections(filter: { parent_collection: { eq: $parent_id }},
-      sort: {
+const GetSubCollections = `query SearchSubCollections(
+  $parent_id: String!
+  $limit: Int
+  $nextToken: String
+  ) {
+  searchCollections(
+    filter: {
+      visibility: { eq: true },
+      parent_collection: { eq: $parent_id }
+    },
+    sort: {
         field: identifier,
         direction: asc
-      }) {
+    },
+    limit: $limit
+    nextToken: $nextToken
+  ) {
     items {
       custom_key
       title
-    }
+    },
+    total,
+    nextToken
   }
 }`;
 
+let nextTokens = [];
+
 class SubCollectionsLoader extends Component {
-  render() {
-    return (
-      <Connect
-        query={graphqlOperation(GetSubCollections, {
-          parent_id: this.props.collection.id
-        })}
-      >
-        {({ data: { searchCollections }, loading, errors }) => {
-          if (!(errors === undefined || errors.length === 0))
-            return <h3>Error</h3>;
-          if (loading) return <h3>Loading...</h3>;
-          this.props.collection.subCollections = searchCollections;
-          return <CollectionsShowPage collection={this.props.collection} />;
-        }}
-      </Connect>
+  constructor(props) {
+    super(props);
+    this.state = {
+      items: null,
+      nextTokens: [],
+      limit: 10,
+      page: 0,
+      totalPages: 1
+    };
+  }
+
+  previousPage() {
+    this.setState(
+      {
+        page: this.state.page - 1
+      },
+      function() {
+        this.loadItems(this.props.collection.id);
+      }
     );
+  }
+
+  nextPage() {
+    this.setState(
+      {
+        page: this.state.page + 1
+      },
+      function() {
+        this.loadItems(this.props.collection.id);
+      }
+    );
+  }
+
+  setLimit(event, result) {
+    this.setState(
+      {
+        limit: parseInt(result.value)
+      },
+      function() {
+        this.loadItems(this.props.collection.id);
+      }
+    );
+  }
+
+  updateParentSubcollections(collection, subCollections) {
+    this.props.updateSubCollections(collection, subCollections);
+  }
+
+  async loadItems(collectionID) {
+    const items = await API.graphql(
+      graphqlOperation(GetSubCollections, {
+        parent_id: collectionID,
+        limit: this.state.limit,
+        nextToken: this.state.nextTokens[this.state.page]
+      })
+    );
+    nextTokens[this.state.page + 1] = items.data.searchCollections.nextToken;
+    this.setState({
+      items: items.data.searchCollections.items,
+      total: items.data.searchCollections.total,
+      nextTokens: nextTokens,
+      totalPages: Math.ceil(
+        items.data.searchCollections.total / this.state.limit
+      )
+    });
+    this.updateParentSubcollections(
+      this.props.collection,
+      items.data.searchCollections.items
+    );
+  }
+
+  componentDidMount() {
+    this.loadItems(this.props.collection.id);
+  }
+
+  render() {
+    if (this.state.items !== null && this.state.total > 0) {
+      return (
+        <div className="collection-items-list-wrapper">
+          <div className="mb-3">
+            <h3>Subcollections ({this.state.total})</h3>
+          </div>
+          <form className="form-group">
+            <label className="mr-1">
+              <span>Results per page:</span>
+            </label>
+            <ResultsNumberDropdown setLimit={this.setLimit.bind(this)} />
+          </form>
+          <SubCollectionsList subCollections={this.state.items} />
+          <Pagination
+            numResults={this.state.items.length}
+            total={this.state.total}
+            page={this.state.page}
+            limit={this.state.limit}
+            previousPage={this.previousPage.bind(this)}
+            nextPage={this.nextPage.bind(this)}
+            totalPages={this.state.totalPages}
+            isSearch={false}
+            atBottom={true}
+          />
+        </div>
+      );
+    } else if (this.state.total === 0) {
+      return <div></div>;
+    } else {
+      return <div>Loading...</div>;
+    }
   }
 }
 


### PR DESCRIPTION

**JIRA Ticket**: (https://webapps.es.vt.edu/jira/browse/LIBTD-2137) (:star:)

# What does this Pull Request do? (:star:)
This PR adds pagination to sub-collection listings in a parent collection show page.

# What's the changes? (:star:)

* Re-organize the sub-collection loader and collection show page so that collection loader has collection show page and sub-collection loader has sub-collection show page
* Add call back function to parent collection so that the parent collection size can reflect the number of sub-collections and archives
* Add pagination to sub-collection loader

# How should this be tested?

* For IAWA project, go to "Ms1990_057_Chadeayne" collection, to check out the sub-collection list, and it should have pagination showed up
* For SWVA project, go to "LJC" collection to check out the sub-collection list with pagination

# Interested parties
Tag (@yinlinchen ) interested parties

(:star:) Required fields
