### PR TITLE
use sessionStorage for siteDetails and language data

### DIFF
--- a/src/App.js
+++ b/src/App.js
@@ -26,25 +26,39 @@ class App extends Component {
   async fetchSiteDetails(siteName) {
     let response = null;
     let data = null;
-
     try {
-      response = await fetch(
-        `${process.env.REACT_APP_CONFIG_PATH}/${siteName.toLowerCase()}.json`
+      data = JSON.parse(
+        sessionStorage.getItem(`${siteName.toLowerCase()}_config`)
       );
-      data = await response.json();
     } catch (error) {
-      console.error(`Error fetching config file`);
-      console.error(error);
+      console.log("Site details not in storage");
     }
     if (data === null) {
+      console.log("Fetching site details");
       try {
         response = await fetch(
-          `${process.env.REACT_APP_CONFIG_PATH}/default.json`
+          `${process.env.REACT_APP_CONFIG_PATH}/${siteName.toLowerCase()}.json`
         );
         data = await response.json();
       } catch (error) {
-        console.error("Error fetching default.json");
+        console.error(`Error fetching config file`);
         console.error(error);
+      }
+      if (data === null) {
+        try {
+          response = await fetch(
+            `${process.env.REACT_APP_CONFIG_PATH}/default.json`
+          );
+          data = await response.json();
+        } catch (error) {
+          console.error("Error fetching default.json");
+          console.error(error);
+        }
+      } else {
+        sessionStorage.setItem(
+          `${siteName.toLowerCase()}_config`,
+          JSON.stringify(data)
+        );
       }
     }
     this.setState({

--- a/src/lib/fetch_tools.js
+++ b/src/lib/fetch_tools.js
@@ -34,10 +34,15 @@ const fetchCopyHTML = async (htmlLink, component) => {
 };
 
 export const fetchLanguages = async (component, key, callback) => {
-  if (component.state.languages === null) {
+  let data = null;
+  try {
+    data = JSON.parse(sessionStorage.getItem(`lang_by_${key}`));
+  } catch (error) {
+    console.log(`lang_by_${key} not in sessionStorage`);
+  }
+  if (data === null) {
+    console.log(`fetching by lang_by_${key}`);
     let response = null;
-    let data = null;
-
     try {
       const htmlLink = `${process.env.REACT_APP_CONFIG_PATH}/language_codes_by_${key}.json`;
       response = await fetch(htmlLink);
@@ -46,12 +51,13 @@ export const fetchLanguages = async (component, key, callback) => {
       console.error(`Error fetching languages`);
       console.error(error);
     }
-    if (data !== null) {
-      component.setState({ languages: data }, function() {
-        if (typeof component.loadItems === "function") {
-          component.loadItems();
-        }
-      });
-    }
+  }
+  if (data !== null) {
+    sessionStorage.setItem(`lang_by_${key}`, JSON.stringify(data));
+    component.setState({ languages: data }, function() {
+      if (typeof component.loadItems === "function") {
+        component.loadItems();
+      }
+    });
   }
 };

--- a/src/pages/search/SearchLoader.js
+++ b/src/pages/search/SearchLoader.js
@@ -24,7 +24,6 @@ class SearchLoader extends Component {
       q: "",
       languages: null
     };
-    fetchLanguages(this, "name");
   }
 
   updateFormState = (name, val) => {


### PR DESCRIPTION
**use browser sessionStorage for siteDetails and language data.**
* * *

**JIRA Ticket**: (https://webapps.es.vt.edu/jira/browse/LIBTD-2136) (:star:)

* Other Relevant Links (Meeting note, project page, related pull requests, etc.)

# What does this Pull Request do? (:star:)
use browser sessionStorage to store siteDetails and language data to reduce number of server requests and speed up pages

# What's the changes? (:star:)
* Request siteDetails and language data normally the first time they are needed
* Store in browser sessionStorage
* Use data in sessionStorage for all subsequent requests

# How should this be tested?
* Visit all pages on the site and make sure that they function normally
* Average page load times (vs. dev branch) here: https://docs.google.com/spreadsheets/d/1H-CLLKbAuoe0pLBH-o94ltPODAVezuqLEc1J3kai7Ek/edit?usp=sharing

# Additional Notes:
* branch: `LIBTD-2136`

# Interested parties
@yinlinchen 

(:star:) Required fields
