### PR TITLE
Styles search items page

### DIFF
--- a/src/components/Pagination.js
+++ b/src/components/Pagination.js
@@ -24,7 +24,7 @@ class Pagination extends Component {
           ? "Search Results:"
           : "Displaying:";
         displayingCopy = (
-          <div>
+          <div className="pagination-text">
             {textBefore} {this.lowerBound()} {this.upperBound()} of{" "}
             {this.props.total}
           </div>
@@ -34,14 +34,16 @@ class Pagination extends Component {
     };
     const Previous = () => {
       if (this.props.page > 0) {
-        return <Button onClick={this.props.previousPage}>Previous page</Button>;
+        return (
+          <Button onClick={this.props.previousPage}>&laquo; Previous</Button>
+        );
       } else {
         return <div></div>;
       }
     };
     const Next = () => {
       if (this.props.page < this.props.totalPages - 1) {
-        return <Button onClick={this.props.nextPage}>Next page</Button>;
+        return <Button onClick={this.props.nextPage}>Next &raquo;</Button>;
       } else {
         return <div></div>;
       }
@@ -49,7 +51,7 @@ class Pagination extends Component {
 
     if (this.props.atBottom) {
       return (
-        <div>
+        <div className="pagination-section">
           <Displaying />
           <Previous />
           <Next />
@@ -57,7 +59,7 @@ class Pagination extends Component {
       );
     } else {
       return (
-        <div>
+        <div className="pagination-section">
           <Displaying />
         </div>
       );

--- a/src/components/Thumbnail.js
+++ b/src/components/Thumbnail.js
@@ -1,15 +1,23 @@
-import React from "react";
+import React, { Component } from "react";
 import { NavLink } from "react-router-dom";
 import { arkLinkFormatted } from "../lib/MetadataRenderer";
 
-export const Thumbnail = ({ item, dataType }) => {
-  return (
-    <NavLink to={`/${dataType}/${arkLinkFormatted(item.custom_key)}`}>
-      <img
-        className="img-fluid mx-auto d-block"
-        src={item.thumbnail_path}
-        alt={item.title}
-      />
-    </NavLink>
-  );
-};
+class Thumbnail extends Component {
+  render() {
+    return (
+      <NavLink
+        to={`/${this.props.dataType}/${arkLinkFormatted(
+          this.props.item.custom_key
+        )}`}
+      >
+        <img
+          className={this.props.className}
+          src={this.props.item.thumbnail_path}
+          alt={this.props.item.title}
+        />
+      </NavLink>
+    );
+  }
+}
+
+export default Thumbnail;

--- a/src/components/ViewBar.js
+++ b/src/components/ViewBar.js
@@ -22,7 +22,11 @@ class ViewBar extends Component {
           onClick={() => this.updateView("List")}
           active={(this.state.view === "List").toString()}
         >
-          <FontAwesomeIcon icon={faThList} size="lg" style={{ color: "red" }} />
+          <FontAwesomeIcon
+            icon={faThList}
+            size="lg"
+            style={{ color: "var(--themeHighlightColor" }}
+          />
         </button>
         <button
           className="btn btn-outline-light"
@@ -31,7 +35,11 @@ class ViewBar extends Component {
           onClick={() => this.updateView("Gallery")}
           active={(this.state.view === "Gallery").toString()}
         >
-          <FontAwesomeIcon icon={faTh} size="lg" style={{ color: "red" }} />
+          <FontAwesomeIcon
+            icon={faTh}
+            size="lg"
+            style={{ color: "var(--themeHighlightColor" }}
+          />
         </button>
         <button
           className="btn btn-outline-light"
@@ -40,7 +48,11 @@ class ViewBar extends Component {
           onClick={() => this.updateView("Masonry")}
           active={(this.state.view === "Masonry").toString()}
         >
-          <FontAwesomeIcon icon={faImages} size="lg" style={{ color: "red" }} />
+          <FontAwesomeIcon
+            icon={faImages}
+            size="lg"
+            style={{ color: "var(--themeHighlightColor" }}
+          />
         </button>
       </div>
     );

--- a/src/css/ListPages.css
+++ b/src/css/ListPages.css
@@ -1,9 +1,9 @@
 li.collection-entry {
   position: relative;
   display: block;
-  margin-bottom: 30px;
-  border-bottom: 1px dotted #ddd;
+  margin-top: 20px;
 }
+
 h4.collection-title {
   font-size: 24px;
   margin-bottom: 20px;
@@ -54,4 +54,24 @@ a.more-link {
 
 a.more-link:visited {
   color: var(--link-blue);
+}
+
+.pagination-section {
+  font-family: "gineso-condensed", sans-serif;
+  text-align: right;
+  font-size: 1.1em;
+}
+
+.pagination-text {
+  padding: 5px 3.5px 5px 0px;
+  font-weight: 500;
+}
+
+.pagination-section .ui.button {
+  font-family: "gineso-condensed", sans-serif;
+  font-weight: 400;
+  padding: 10px;
+  border: solid 1px #707070;
+  background-color: #f8f8f8;
+  color: #000000;
 }

--- a/src/css/SearchResult.css
+++ b/src/css/SearchResult.css
@@ -4,46 +4,71 @@
   box-sizing: border-box;
 }
 
+.search-result-wrapper {
+  padding-top: 40px;
+}
+
+.search-results {
+  padding: 40px 0px 0px !important;
+}
+
 .navbar {
-  position: relative;
-  display: flex;
-  flex-wrap: wrap;
-  align-items: center;
-  justify-content: space-between;
-  padding: 0.5rem 1rem;
-  padding-top: 0.5rem;
-  padding-right: 1rem;
-  padding-bottom: 0.5rem;
-  padding-left: 1rem;
   z-index: 900;
   background-color: #f8f8f8;
-  border-color: #e7e7e7;
 }
 
-.search-result-wrapper {
-  border-bottom: 1px dashed #ccc;
-  margin-bottom: 30px;
-  padding-bottom: 30px;
-}
-.title-wrapper {
-  margin-bottom: 20px;
+.navbar .ui.compact.selection.dropdown {
+  background-color: #ffffff;
+  border-color: #707070;
+  color: #000000;
 }
 
-.gallery {
-  display: flex;
-  flex-flow: row wrap;
-  flex-wrap: wrap;
+.navbar .ui.compact.selection.dropdown .default.text {
+  color: #000000;
 }
 
-.document {
-  margin-top: 6px;
-  padding-top: 6px;
-  border-bottom: 1px dotted #ddd;
-  border-bottom: none;
-  flex: 1;
-  min-width: 250px;
-  min-height: 250px;
-  -webkit-flex: 1 0 250px;
+.gallery-item {
+  max-width: 262.48px;
+}
+
+.gallery-item .card {
+  margin-top: 10px;
+  margin-bottom: 10px;
+  border: 1px solid #e2e0e0;
+  border-radius: 0px;
+}
+
+.gallery-item .card-img-top {
+  width: 100%;
+  height: 170px;
+  object-fit: cover;
+}
+
+.gallery-item .card-body {
+  height: 168px;
+}
+
+.crop-text-3 {
+  -webkit-line-clamp: 3;
+  overflow: hidden;
+  text-overflow: ellipsis;
+  display: -webkit-box;
+  -webkit-box-orient: vertical;
+}
+
+.gallery-item .card-body .card-title {
+  font-family: "gineso-condensed", sans-serif;
+}
+
+.gallery-item .card-body .card-text {
+  font-family: "Acherus", sans-serif;
+}
+
+.gallery-item a,
+.gallery-item a:hover,
+.gallery-item a:visited {
+  color: black;
+  text-decoration: none;
 }
 
 .glyphicon-list:before {
@@ -65,4 +90,15 @@
 .card-columns {
   display: inline-block;
   column-width: 250px;
+}
+
+.document {
+  margin-top: 6px;
+  padding-top: 6px;
+  border-bottom: 1px dotted #ddd;
+  border-bottom: none;
+  flex: 1;
+  min-width: 250px;
+  min-height: 250px;
+  -webkit-flex: 1 0 250px;
 }

--- a/src/pages/collections/CollectionItemsList.js
+++ b/src/pages/collections/CollectionItemsList.js
@@ -1,6 +1,6 @@
 import React, { Component } from "react";
 import { NavLink } from "react-router-dom";
-import { Thumbnail } from "../../components/Thumbnail";
+import Thumbnail from "../../components/Thumbnail";
 import { arkLinkFormatted } from "../../lib/MetadataRenderer";
 
 import "../../css/CollectionsShowPage.css";

--- a/src/pages/search/GalleryView.js
+++ b/src/pages/search/GalleryView.js
@@ -1,22 +1,44 @@
-import React from "react";
+import React, { Component } from "react";
 import { NavLink } from "react-router-dom";
 import { arkLinkFormatted } from "../../lib/MetadataRenderer";
-import { Thumbnail } from "../../components/Thumbnail";
+import Thumbnail from "../../components/Thumbnail";
 import "../../css/SearchResult.css";
 
-export const GalleryView = ({ item, dataType }) => {
-  return (
-    <div className="document col-12 col-sm-6 col-md-4 col-lg-3">
-      <div className="card text-center">
-        <Thumbnail item={item} dataType={dataType} />
-        <div className="card-body">
-          <h5 className="card-title">
-            <NavLink to={`/${dataType}/${arkLinkFormatted(item.custom_key)}`}>
-              {item.title}
-            </NavLink>
-          </h5>
-        </div>
+class GalleryView extends Component {
+  constructor() {
+    super();
+    this.state = {
+      className: "card-img-top"
+    };
+  }
+
+  render() {
+    return (
+      <div className="col-md-6 col-lg-4 gallery-item">
+        <NavLink
+          to={`/${this.props.dataType}/${arkLinkFormatted(
+            this.props.item.custom_key
+          )}`}
+        >
+          <div className="card">
+            <Thumbnail
+              item={this.props.item}
+              dataType={this.props.dataType}
+              className={this.state.className}
+            />
+            <div className="card-body">
+              <h5 className="card-title crop-text-3">
+                {this.props.item.title}
+              </h5>
+              <p className="card-text crop-text-3">
+                {this.props.item.description}
+              </p>
+            </div>
+          </div>
+        </NavLink>
       </div>
-    </div>
-  );
-};
+    );
+  }
+}
+
+export default GalleryView;

--- a/src/pages/search/ItemListView.js
+++ b/src/pages/search/ItemListView.js
@@ -1,6 +1,6 @@
 import React, { Component } from "react";
 import { RenderItems, titleFormatted } from "../../lib/MetadataRenderer";
-import { Thumbnail } from "../../components/Thumbnail";
+import Thumbnail from "../../components/Thumbnail";
 import "../../css/SearchResult.css";
 import { fetchLanguages } from "../../lib/fetchTools";
 
@@ -33,11 +33,11 @@ class ItemListView extends Component {
     if (this.state.languages !== null) {
       return (
         <li key={this.props.item.id} className="collection-entry">
-          {titleFormatted(this.props.item, this.props.dataType)}
           <span className="collection-img">
             <Thumbnail item={this.props.item} dataType={this.props.dataType} />
           </span>
           <div className="collection-details">
+            {titleFormatted(this.props.item, this.props.dataType)}
             <RenderItems
               keyArray={keyArray}
               item={this.props.item}

--- a/src/pages/search/ItemsList.js
+++ b/src/pages/search/ItemsList.js
@@ -1,6 +1,6 @@
 import React, { Component } from "react";
 import ItemListView from "./ItemListView";
-import { GalleryView } from "./GalleryView";
+import GalleryView from "./GalleryView";
 import { MasonryView } from "./MasonryView";
 
 class ItemsList extends Component {
@@ -14,7 +14,7 @@ class ItemsList extends Component {
 
   render() {
     return (
-      <div className="search-results">
+      <div className="search-results-section">
         <div className={this.getClassName()}>
           {this.props.items.map(item => {
             if (this.props.view === "Gallery") {

--- a/src/pages/search/MasonryView.js
+++ b/src/pages/search/MasonryView.js
@@ -1,5 +1,5 @@
 import React from "react";
-import { Thumbnail } from "../../components/Thumbnail";
+import Thumbnail from "../../components/Thumbnail";
 import "../../css/SearchResult.css";
 
 export const MasonryView = ({ item, dataType }) => {

--- a/src/pages/search/SearchLoader.js
+++ b/src/pages/search/SearchLoader.js
@@ -20,7 +20,7 @@ class SearchLoader extends Component {
       totalPages: 1,
       dataType: "archive",
       searchField: "title",
-      view: "List",
+      view: "Gallery",
       q: "",
       languages: null
     };

--- a/src/pages/search/SearchResults.js
+++ b/src/pages/search/SearchResults.js
@@ -10,6 +10,7 @@ import { labelAttr } from "../../lib/MetadataRenderer";
 import { fetchLanguages } from "../../lib/fetchTools";
 
 import "../../css/ListPages.css";
+import "../../css/SearchResult.css";
 
 class SearchResults extends Component {
   constructor(props) {
@@ -71,7 +72,7 @@ class SearchResults extends Component {
       }
     };
     return (
-      <div>
+      <div className="search-result-wrapper">
         <SearchBar
           dataType={this.props.dataType}
           view={this.props.view}
@@ -79,7 +80,7 @@ class SearchResults extends Component {
           q={this.props.q}
           setPage={this.props.setPage}
         />
-        <div className="container">
+        <div className="container search-results">
           <div className="row">
             <div id="sidebar" className="col-md-3 col-sm-4">
               {/* <h2>Limit your search</h2> */}
@@ -93,11 +94,11 @@ class SearchResults extends Component {
                   <ItemsPaginationDisplay atBottom={false} />
                 </div>
                 <div className="form-inline">
-                  <ResultsNumberDropdown setLimit={this.props.setLimit} />
                   <ViewBar
                     view={this.props.view}
                     updateFormState={this.props.updateFormState}
                   />
+                  <ResultsNumberDropdown setLimit={this.props.setLimit} />
                 </div>
               </div>
               <ItemsList


### PR DESCRIPTION
**JIRA Ticket**: (link) (:star:)
https://webapps.es.vt.edu/jira/browse/LIBTD-2150

* Other Relevant Links (Meeting note, project page, related pull requests, etc.)
wireframe design: https://xd.adobe.com/view/02fc158b-3aaa-4619-671b-65852af58b64-74cd/screen/c8401ee4-3b41-4610-be55-a07c8329ffe3/Search-Grid

# What does this Pull Request do? (:star:)
This PR styles gallery view for the search results page, changes the default view of search results to the gallery view, and restyles other components like the search bar and pagination.  Note: the filters and list view will be styled under separate tickets.

# What's the changes? (:star:)

- Pagination.js - adds classes and other style changes
- Thumbnail.js - refactored into class component and accepts a new props
- ViewBar.js - changes color of icons
- ListPages.css - add/changes styles
- SearchResult.css - add/changes styles
- CollectionItemsList.js - updates Thumbnail import
- GalleryView.js - add/changes html created correct layout; also refactors component into class component
- ItemListView.js - updates import for thumbnail and moves the title of the item.
- ItemsList.js - updates import for gallery view
- MasonryView.js - updated import for thumbnail
- SearchLoader.js - changes default view to gallery
- SearchResults.js - imports css files and moves some things around.

# How should this be tested?
When you click on Search items from the menu, it should load the gallery view page. These changes shouldn't affect the list view or masonry view, or the browse collections section. The page should respond appropriately to small screen sizes. The pagination at the bottom should work as before, but just look restyled.
 
# Additional Notes:
branch: LIBTD-2150

# Interested parties
@yinlinchen 

(:star:) Required fields
