### PR TITLE
Styled list view

### DIFF
--- a/src/css/ListPages.css
+++ b/src/css/ListPages.css
@@ -1,47 +1,75 @@
-li.collection-entry {
+div.collection-entry {
   position: relative;
   display: block;
-  margin-top: 20px;
+  margin-top: 30px;
+}
+
+.collection-entry a {
+  color: var(--themeHighlightColor);
+}
+
+.collection-entry a:hover,
+.collection-entry a:focus {
+  color: var(--themeHighlightColor);
+}
+
+div.collection-details h4 a {
+  color: black;
 }
 
 h4.collection-title {
   font-size: 24px;
   margin-bottom: 20px;
 }
-span.collection-img {
+div.collection-img {
   display: inline-block;
-  width: 250px;
-  margin-right: 30px;
+  margin-right: 15px;
 }
-span.collection-img img {
-  display: block;
-  max-width: 250px;
-  margin: 0 auto;
+
+div.collection-img img {
+  width: 150px;
+  height: 108px;
+  object-fit: cover;
 }
+
 div.collection-details {
   position: relative;
   display: inline-block;
-  width: calc(100% - 280px);
   vertical-align: top;
+  width: calc(100% - 180px);
 }
+
+div.collection-details h4 {
+  font-size: 1.2em;
+  font-family: "gineso-condensed", sans-serif;
+  margin-bottom: 0.25rem;
+}
+
 div.collection-detail {
-  border-top: 1px solid #ddd;
+  display: none;
 }
-div.collection-detail table {
-  margin-bottom: 0;
-}
+
 div.collection-detail table tr .collection-detail-key {
-  width: 150px;
-  padding: 8px;
-  font-size: 24px;
-  font-weight: 400;
+  font-size: 1.3em;
+  padding-right: 3px;
+  font-family: "gineso-condensed", sans-serif;
+  vertical-align: text-top;
 }
+
 div.collection-detail table tr .collection-detail-value {
-  font-size: 16px;
+  font-size: 1em;
+  font-family: "Acherus", sans-serif;
   font-weight: 400;
-  padding: 8px;
   text-align: left;
-  vertical-align: middle;
+  vertical-align: text-top;
+}
+
+td.collection-detail-value div span.list-unstyled {
+  margin-right: 2px;
+}
+
+span.list-unstyled:nth-of-type(n + 2)::before {
+  content: ", ";
 }
 
 h3.list-type {
@@ -50,10 +78,7 @@ h3.list-type {
 
 a.more-link {
   margin-left: 10px;
-}
-
-a.more-link:visited {
-  color: var(--link-blue);
+  color: var(--themeHighlightColor);
 }
 
 .pagination-section {
@@ -74,4 +99,34 @@ a.more-link:visited {
   border: solid 1px #707070;
   background-color: #f8f8f8;
   color: #000000;
+}
+
+@media (min-width: 768px) {
+  div.collection-detail {
+    display: block;
+  }
+
+  div.collection-img img {
+    width: 250px;
+    height: 180px;
+    object-fit: cover;
+  }
+
+  div.collection-details {
+    position: relative;
+    display: inline-block;
+    vertical-align: top;
+    width: calc(100% - 300px);
+  }
+
+  div.collection-details h4 {
+    font-size: 20px;
+    font-family: "gineso-condensed", sans-serif;
+    margin-bottom: 0.25rem;
+  }
+
+  div.collection-img {
+    display: inline-block;
+    margin-right: 30px;
+  }
 }

--- a/src/css/SearchResult.css
+++ b/src/css/SearchResult.css
@@ -27,6 +27,10 @@
   color: #000000;
 }
 
+.search-results-section {
+  padding-bottom: 20px;
+}
+
 .gallery-item {
   max-width: 262.48px;
 }

--- a/src/lib/MetadataRenderer.js
+++ b/src/lib/MetadataRenderer.js
@@ -78,9 +78,9 @@ function textFormat(item, attr, languages) {
     return (
       <div>
         {item[attr].map((value, i) => (
-          <li className="list-unstyled" key={i}>
+          <span className="list-unstyled" key={i}>
             {listValue(dataType, attr, value, languages)}
-          </li>
+          </span>
         ))}
       </div>
     );

--- a/src/pages/search/GalleryView.js
+++ b/src/pages/search/GalleryView.js
@@ -5,13 +5,6 @@ import Thumbnail from "../../components/Thumbnail";
 import "../../css/SearchResult.css";
 
 class GalleryView extends Component {
-  constructor() {
-    super();
-    this.state = {
-      className: "card-img-top"
-    };
-  }
-
   render() {
     return (
       <div className="col-md-6 col-lg-4 gallery-item">
@@ -24,7 +17,7 @@ class GalleryView extends Component {
             <Thumbnail
               item={this.props.item}
               dataType={this.props.dataType}
-              className={this.state.className}
+              className="card-img-top"
             />
             <div className="card-body">
               <h5 className="card-title crop-text-3">

--- a/src/pages/search/ItemListView.js
+++ b/src/pages/search/ItemListView.js
@@ -17,25 +17,13 @@ class ItemListView extends Component {
   }
 
   render() {
-    const keyArray = [
-      "identifier",
-      "description",
-      "date",
-      "source",
-      "language",
-      "creator",
-      "resource_type",
-      "medium",
-      "belongs_to",
-      "tags",
-      "related_url"
-    ];
+    const keyArray = ["description", "tags", "creator"];
     if (this.state.languages !== null) {
       return (
-        <li key={this.props.item.id} className="collection-entry">
-          <span className="collection-img">
+        <div key={this.props.item.id} className="col-12 collection-entry">
+          <div className="collection-img">
             <Thumbnail item={this.props.item} dataType={this.props.dataType} />
-          </span>
+          </div>
           <div className="collection-details">
             {titleFormatted(this.props.item, this.props.dataType)}
             <RenderItems
@@ -44,7 +32,7 @@ class ItemListView extends Component {
               languages={this.state.languages}
             />
           </div>
-        </li>
+        </div>
       );
     } else {
       return <></>;

--- a/src/pages/search/SearchResults.js
+++ b/src/pages/search/SearchResults.js
@@ -82,13 +82,13 @@ class SearchResults extends Component {
         />
         <div className="container search-results">
           <div className="row">
-            <div id="sidebar" className="col-md-3 col-sm-4">
+            <div id="sidebar" className="col-lg-3 col-sm-12">
               {/* <h2>Limit your search</h2> */}
               <div className="collection-detail">
                 <SearchFieldDisplay />
               </div>
             </div>
-            <div id="content" className="col-md-9 col-sm-8">
+            <div id="content" className="col-lg-9 col-sm-12">
               <div className="navbar navbar-light justify-content-between">
                 <div className="navbar-text text-dark">
                   <ItemsPaginationDisplay atBottom={false} />


### PR DESCRIPTION
**JIRA Ticket**: (link) (:star:)
https://webapps.es.vt.edu/jira/browse/LIBTD-2197

* Other Relevant Links (Meeting note, project page, related pull requests, etc.)
-Wireframes: https://xd.adobe.com/view/02fc158b-3aaa-4619-671b-65852af58b64-74cd/screen/89c5f020-3431-4374-a60b-3224885bf2b0/Search-List

# What does this Pull Request do? (:star:)
This PR styles the list view for search results, and for the collections browse section

# What's the changes? (:star:)
- ListPages.css - adds classes and changes styles
- SearchResult.css - adjusts one class
-MetadataRenderer.js - changes the element generated from <li> to <span> so that multiple results will be on a single line. Note: CSS added in ListPages.css to insert a comma between each span.
-GalleryView.js - Made one unrelated fix in here because I realized I overcomplicated something in my last PR....
-ItemListView.js - Made changes to html for layout and added classes.
-SearchResults.js - Changed layout at smaller screen sizes so the sidebar stacks on top of content section, and content section goes full-width. This is preparation for adding the filters section later.

# How should this be tested?
In the search results, when you click on the list view icon it should look pretty similar to the wireframe. At smaller screen sizes the metadata for each item is hidden so only the image and the title show. Also the side bar will dissappear to allow the content to be full width.  These changes also affect the list view for "Browse collections" but that is ok because they should be styled the same.

# Additional Notes:
Branch: LIBTD-2197

# Interested parties
@yinlinchen 

(:star:) Required fields
