### PR TITLE
add title(s) to metadata section

### DIFF
--- a/src/components/Breadcrumbs.js
+++ b/src/components/Breadcrumbs.js
@@ -52,7 +52,11 @@ class Breadcrumbs extends Component {
         });
       } while (parent_id !== null);
     }
-    this.setState({ links: parent_list });
+    this.setState({ links: parent_list }, function() {
+      if (typeof this.props.setTitleList == "function") {
+        this.props.setTitleList(parent_list);
+      }
+    });
   }
 
   componentDidMount() {

--- a/src/css/CollectionsShowPage.css
+++ b/src/css/CollectionsShowPage.css
@@ -84,9 +84,9 @@ span.creator:after {
   width: 100%;
   border-bottom: 1px solid var(--light-gray);
 }
-.container-fluid .details-section-header h2 {
+.container-fluid h2.details-section-header {
   font-family: "gineso-condensed", sans-serif;
-  font-size: 22px;
+  font-size: 20px;
   font-weight: 400;
 }
 
@@ -106,7 +106,8 @@ span.creator:after {
 }
 .container-fluid .details-section-content-grid .collection-detail-key {
   font-family: "gineso-condensed", sans-serif;
-  font-size: 20px;
+  font-size: 18px;
+  font-weight: 500;
 }
 .container-fluid .details-section-content-grid .collection-detail-value {
   font-family: "Acherus", sans-serif;

--- a/src/pages/collections/CollectionsShowPage.js
+++ b/src/pages/collections/CollectionsShowPage.js
@@ -24,7 +24,8 @@ class CollectionsShowPage extends Component {
       subDescriptionTruncated: true,
       description: "",
       title: "",
-      thumbnail_path: ""
+      thumbnail_path: "",
+      titleList: []
     };
     this.onMoreLessClick = this.onMoreLessClick.bind(this);
   }
@@ -178,6 +179,21 @@ class CollectionsShowPage extends Component {
     return addNewlineInDesc(description);
   }
 
+  setTitleList(titleList) {
+    const titleListCopy = titleList.slice();
+    this.setState({ titleList: titleListCopy.reverse() });
+  }
+
+  metadataTitle() {
+    let title = "";
+    if (this.state.titleList.length) {
+      title +=
+        "Collection Details for " +
+        this.state.titleList.map(elem => elem.title).join(", ");
+    }
+    return title;
+  }
+
   componentDidMount() {
     fetchLanguages(this, "abbr");
     const topLevelAttributes = ["title", "description", "thumbnail_path"];
@@ -209,6 +225,7 @@ class CollectionsShowPage extends Component {
             <Breadcrumbs
               dataType={"Collections"}
               record={this.props.collection}
+              setTitleList={this.setTitleList.bind(this)}
             />
           </div>
           <div className="top-content-row row">
@@ -224,9 +241,7 @@ class CollectionsShowPage extends Component {
                 <span className="item-count">
                   {this.handleZeroItems(collectionSize(this.props.collection))}
                 </span>
-
                 <this.creatorDates collection={this.props.collection} />
-
                 <span className="last-updated">
                   Last updated: {this.props.collection.modified_date}
                 </span>
@@ -248,10 +263,11 @@ class CollectionsShowPage extends Component {
           <div className="container-fluid">
             <div className="mid-content-row row">
               <div className="col-12 col-lg-8 details-section">
-                <div className="details-section-header"></div>
+                <h2 className="details-section-header">
+                  {this.metadataTitle()}
+                </h2>
                 <div className="details-section-content-grid">
                   {this.subCollectionDescription()}
-
                   <RenderItemsDetailed
                     keyArray={KeyArray}
                     item={this.props.collection}


### PR DESCRIPTION
**Adds Collection title and any sub-collection titles to the top of the metadata section.**
* * *

**JIRA Ticket**: (https://webapps.es.vt.edu/jira/browse/LIBTD-2228) (:star:)

* Other Relevant Links (Meeting note, project page, related pull requests, etc.)
https://xd.adobe.com/view/8bdda111-43ab-4c8d-77c8-e7606a2c6eb4-fdec/screen/61b221d3-4f82-4991-b442-688defc41923/Collection-page-child-collection/

# What does this Pull Request do? (:star:)
Adds Collection title and any sub-collection titles to the top of the metadata section.

# What's the changes? (:star:)
* Adds Collection title and any sub-collection titles to the top of the metadata section.

# How should this be tested?
* View collection show page and check that collection title (and any sub-collection titles) render above metadata section as in mockup linked above.

# Additional Notes:
* branch: `LIBTD-2228`

# Interested parties
@yinlinchen 

(:star:) Required fields
