### PR TITLE
add analytics id configuration

### DIFF
--- a/public/index.html
+++ b/public/index.html
@@ -12,10 +12,6 @@
       (i[r].q=i[r].q||[]).push(arguments)},i[r].l=1*new Date();a=s.createElement(o),
       m=s.getElementsByTagName(o)[0];a.async=1;a.src=g;m.parentNode.insertBefore(a,m)
       })(window,document,'script','https://www.google-analytics.com/analytics.js','ga');
-
-      ga('create', 'UA-4094890-21', 'auto');
-      ga('set', 'anonymizeIp', true);
-      ga('send', 'pageview');
     </script>
     <!-- End Google Analytics -->
 

--- a/src/App.js
+++ b/src/App.js
@@ -2,6 +2,7 @@ import React, { Component } from "react";
 import { BrowserRouter as Router, Route, Switch } from "react-router-dom";
 import ScrollToTop from "./lib/ScrollToTop";
 import { fetchSiteDetails } from "./lib/fetchTools";
+import AnalyticsConfig from "./components/AnalyticsConfig";
 import Header from "./components/Header";
 import Footer from "./components/Footer";
 import HomePage from "./pages/HomePage";
@@ -47,6 +48,7 @@ class App extends Component {
       this.setColor(this.state.siteDetails.siteColor);
       return (
         <Router>
+          <AnalyticsConfig analyticsID={this.state.siteDetails.analyticsID} />
           <ScrollToTop paginationClick={this.state.paginationClick} />
           <Header
             siteDetails={this.state.siteDetails}

--- a/src/components/AnalyticsConfig.js
+++ b/src/components/AnalyticsConfig.js
@@ -1,0 +1,15 @@
+import React, { Component } from "react";
+
+class AnalyticsConfig extends Component {
+  componentDidMount() {
+    window.ga("create", this.props.analyticsID, "auto");
+    window.ga("set", "anonymizeIp", true);
+    window.ga("send", "pageview");
+  }
+
+  render() {
+    return <></>;
+  }
+}
+
+export default AnalyticsConfig;


### PR DESCRIPTION
**add analytics id configuration.**
* * *

**JIRA Ticket**: (https://webapps.es.vt.edu/jira/browse/LIBTD-2221) (:star:)

* Other Relevant Links (Meeting note, project page, related pull requests, etc.)

# What does this Pull Request do? (:star:)
Reads analytics ID (currently Google Analytics) from siteconfig json files so that separate analytics  accounts can be used for our different supported sites.

# What's the changes? (:star:)
Reads analytics ID (currently Google Analytics) from siteconfig json files so that separate analytics  accounts can be used for our different supported sites.

# How should this be tested?
* Update VTDLP-siteconfig `dev` repo and copy the iawa, swva, and default json files into you local public directory.
* Make sure you clear your browser's sessionStorage to force the updated versions to be cached.
* Check in your dev console that the account is being set with the correct ID and that `ga()` calls are firing. This can easily be checked in Chrome using the [Google Analytics Debugger](https://chrome.google.com/webstore/detail/google-analytics-debugger/jnkmfdileelhofjcijamephohjechhna)

# Additional Notes:
* branch: `LIBTD-2221`
# Interested parties
@yinlinchen 

(:star:) Required fields
