### PR TITLE
Remove hardcoded IAWAs. Change class to className

### DIFF
--- a/public/index.html
+++ b/public/index.html
@@ -43,10 +43,6 @@
       work correctly both with client-side routing and a non-root public URL.
       Learn how to configure a non-root public URL by running `npm run build`.
     -->
-    <title>IAWA</title>
-
-
-
 
 
   </head>

--- a/src/components/SearchBar.js
+++ b/src/components/SearchBar.js
@@ -154,7 +154,7 @@ class SearchBar extends Component {
             {this.fieldOptions()}
           </select>
           <button className="btn" type="submit" onClick={this.submit}>
-            <i class="fas fa-search"></i>
+            <i className="fas fa-search"></i>
           </button>
         </div>
       </div>

--- a/src/pages/archives/ArchivePage.js
+++ b/src/pages/archives/ArchivePage.js
@@ -90,7 +90,7 @@ class ArchivePage extends Component {
             data: [
               {
                 manifestUri: item.manifest_url,
-                location: "IAWA"
+                location: this.props.siteDetails.siteId.toUpperCase()
               }
             ],
             windowObjects: [


### PR DESCRIPTION
**Remove hardcoded IAWAs. Change class to className.**
* * *

**JIRA Ticket**: (link) (:star:)

* Other Relevant Links (Meeting note, project page, related pull requests, etc.)

# What does this Pull Request do? (:star:)
Remove hardcoded IAWAs. The `<title>` tag on line 46 of "public/index.html" was already being replaced dynamically in "src/components/SiteTitle.js" so I just removed it.  This pr also changes class to className in "src/components/SearchBar.js" to resolve a browser dev console warning

# What's the changes? (:star:)
* Remove hardcoded IAWAs. 
* Change class to className

# How should this be tested?

A description of what steps someone could take to:
* Check that site titles are still being generated correctly.
* Visit Archive show pages and make sure that Mirador viewer is still loading and functioning correctly. Check in IAWA site as well as in SWVA site
* Check dev console to see if "class" warning is still showing from SearchBar.js

# Additional Notes:
* branch: `LIBTD-2236`

# Interested parties
@yinlinchen 

(:star:) Required fields
