### PR TITLE
Adds static img support for Archive pages

### DIFF
--- a/cypress/integration/archive_media_views.js
+++ b/cypress/integration/archive_media_views.js
@@ -1,0 +1,22 @@
+describe('Archive static img view', () => {
+  it('shows correct img tag', () => {
+    cy.visit('http://localhost:3000/archive/m58xyh90');
+    cy.get('#content-wrapper > div > div.item-image-section > div.row > div > img')
+      .eq(0)
+      .should('have.class', 'item-img')
+      .should('be.visible');
+  });
+});
+
+describe('Archive Mirador viewer', () => {
+  it('renders viewer if manifest.json', () => {
+    cy.visit('http://localhost:3000/archive/5v709r98');
+    cy.get('div#mirador_viewer')
+      .eq(0)
+      .should('have.class', 'mirador-container')
+      .should('be.visible');
+    cy.get('div.workspace-container > div > div > div.window > div.content-container > div.view-container > div.image-view')
+      .eq(0)
+      .should('be.visible');
+  });
+});

--- a/src/components/MiradorViewer.js
+++ b/src/components/MiradorViewer.js
@@ -1,7 +1,7 @@
 import React, { Component } from "react";
 import "../css/Viewer.css";
 
-class Viewer extends Component {
+class MiradorViewer extends Component {
   get miradorConfig() {
     return this.props.config;
   }
@@ -15,4 +15,4 @@ class Viewer extends Component {
   }
 }
 
-export default Viewer;
+export default MiradorViewer;

--- a/src/css/ArchivePage.css
+++ b/src/css/ArchivePage.css
@@ -19,6 +19,10 @@ div.item-image-section div.breadcrumbs-wrapper ul {
   margin: 0;
 }
 
+div.item-image-section img.item-img {
+  width: 100%;
+}
+
 .item-details-section {
   padding: 40px 0 40px 0;
 }

--- a/src/pages/archives/ArchivePage.js
+++ b/src/pages/archives/ArchivePage.js
@@ -1,7 +1,7 @@
 import React, { Component } from "react";
 import { graphqlOperation } from "aws-amplify";
 import { Connect } from "aws-amplify-react";
-import Viewer from "../../components/Viewer";
+import MiradorViewer from "../../components/MiradorViewer";
 import SearchBar from "../../components/SearchBar";
 import Breadcrumbs from "../../components/Breadcrumbs.js";
 import SiteTitle from "../../components/SiteTitle";
@@ -69,6 +69,45 @@ class ArchivePage extends Component {
     return content;
   }
 
+  isImgURL(url) {
+    return url.match(/\.(jpeg|jpg|gif|png)$/) != null;
+  }
+
+  isJsonURL(url) {
+    return url.match(/\.(json)$/) != null;
+  }
+
+  imageViewer(item) {
+    let viewer = null;
+    if (this.isImgURL(item.manifest_url)) {
+      viewer = (
+        <img className="item-img" src={item.manifest_url} alt={item.title} />
+      );
+    } else if (this.isJsonURL(item.manifest_url)) {
+      const miradorConfig = {
+        id: "mirador_viewer",
+        data: [
+          {
+            manifestUri: item.manifest_url,
+            location: this.props.siteDetails.siteId.toUpperCase()
+          }
+        ],
+        windowObjects: [
+          {
+            loadedManifest: item.manifest_url,
+            viewType: "ImageView"
+          }
+        ],
+        showAddFromURLBox: false
+      };
+
+      viewer = <MiradorViewer config={miradorConfig} />;
+    } else {
+      viewer = <></>;
+    }
+    return viewer;
+  }
+
   componentDidMount() {
     fetchLanguages(this, "abbr");
   }
@@ -85,27 +124,12 @@ class ArchivePage extends Component {
             return <h3>Error</h3>;
           if (loading || !searchArchives) return <h3>Loading...</h3>;
           const item = searchArchives.items[0];
-          var miradorConfig = {
-            id: "mirador_viewer",
-            data: [
-              {
-                manifestUri: item.manifest_url,
-                location: this.props.siteDetails.siteId.toUpperCase()
-              }
-            ],
-            windowObjects: [
-              {
-                loadedManifest: item.manifest_url,
-                viewType: "ImageView"
-              }
-            ],
-            showAddFromURLBox: false
-          };
 
           // log archive identifier in ga
           window.ga("send", "pageview", {
             dimension1: item.identifier
           });
+
           if (this.state.languages) {
             return (
               <div className="item-page-wrapper">
@@ -126,9 +150,7 @@ class ArchivePage extends Component {
                     <Breadcrumbs category={"Archives"} record={item} />
                   </div>
                   <div className="row">
-                    <div className="col-sm-12">
-                      <Viewer config={miradorConfig} />
-                    </div>
+                    <div className="col-sm-12">{this.imageViewer(item)}</div>
                   </div>
                 </div>
                 <div className="row item-details-section">


### PR DESCRIPTION
**Adds static img support for Archive pages.**
* * *

**JIRA Ticket**: (https://webapps.es.vt.edu/jira/browse/LIBTD-2203) (:star:)

* Other Relevant Links (Meeting note, project page, related pull requests, etc.)

# What does this Pull Request do? (:star:)
Renders static image if image file is specified in manifest_url instead of a json file

# What's the changes? (:star:)
A in-depth description of the changes made by this PR. Technical details and possible side effects.

Example:
* Renders static image if image file is specified
 * Renders Mirador viewer if manifest.json is specified

# How should this be tested?
* Start localhost server with `REACT_APP_REP_TYPE=default` set
* Visit http://localhost:3000/archive/m58xyh90
* Check that static image renders correctly with item.title as alt value
* Visit http://localhost:3000/archive/5v709r98
* Check that Mirador Viewer still loads correctly

# Additional Notes:
* branch: `LIBTD-2203`

# Interested parties
@yinlinchen 

(:star:) Required fields
