### PR TITLE
add video support

### DIFF
--- a/cypress/integration/archive_media_views.js
+++ b/cypress/integration/archive_media_views.js
@@ -18,6 +18,26 @@ describe('Archive audio player', () => {
   });
 });
 
+describe('Archive video player', () => {
+  it('renders html5 video player', () => {
+    cy.visit('http://localhost:3000/archive/m70xyh12');
+    cy.get('video')
+      .eq(0)
+      .should('have.class', 'videojs')
+      .should('be.visible');
+  });
+});
+
+describe('Archive kaltura embed', () => {
+  it('renders kaltura video player inside iframe', () => {
+    cy.visit('http://localhost:3000/archive/m81xyh23');
+    cy.get('iframe')
+      .eq(0)
+      .should('have.class', 'kaltura-player')
+      .should('be.visible');
+  });
+});
+
 describe('Archive Mirador viewer', () => {
   it('renders viewer if manifest.json', () => {
     cy.visit('http://localhost:3000/archive/5v709r98');

--- a/src/components/KalturaPlayer.js
+++ b/src/components/KalturaPlayer.js
@@ -1,0 +1,40 @@
+import React, { Component } from "react";
+import "../css/Viewer.css";
+
+class KalturaPlayer extends Component {
+  getURL() {
+    return `${this.props.manifest_url}?iframeembed=true&playerId=kaltura_player&entry_id=1_qvxfd4bn&flashvars[streamerType]=auto&amp;flashvars[localizationCode]=en&amp;flashvars[leadWithHTML5]=true&amp;flashvars[sideBarContainer.plugin]=true&amp;flashvars[sideBarContainer.position]=left&amp;flashvars[sideBarContainer.clickToClose]=true&amp;flashvars[chapters.plugin]=true&amp;flashvars[chapters.layout]=vertical&amp;flashvars[chapters.thumbnailRotator]=false&amp;flashvars[streamSelector.plugin]=true&amp;flashvars[EmbedPlayer.SpinnerTarget]=videoHolder&amp;flashvars[dualScreen.plugin]=true&amp;flashvars[Kaltura.addCrossoriginToIframe]=true&amp;&wid=1_x2fmman0`;
+  }
+  render() {
+    return (
+      <div
+        style={{
+          position: "relative",
+          paddingBottom: "71.25%"
+        }}
+      >
+        <iframe
+          id="kaltura_player"
+          className="kaltura-player"
+          src={this.getURL()}
+          allowFullScreen
+          webkitallowfullscreen="true"
+          mozallowfullscreen="true"
+          allow="autoplay *; fullscreen *; encrypted-media *"
+          sandbox="allow-forms allow-same-origin allow-scripts allow-top-navigation allow-pointer-lock allow-popups allow-modals allow-orientation-lock allow-popups-to-escape-sandbox allow-presentation allow-top-navigation-by-user-activation"
+          frameBorder="0"
+          title="Kaltura Player"
+          style={{
+            position: "absolute",
+            top: 0,
+            left: 0,
+            width: "100%",
+            height: "100%"
+          }}
+        ></iframe>
+      </div>
+    );
+  }
+}
+
+export default KalturaPlayer;

--- a/src/components/VideoPlayer.js
+++ b/src/components/VideoPlayer.js
@@ -1,0 +1,28 @@
+import React, { Component } from "react";
+import "../css/Viewer.css";
+
+class VideoPlayer extends Component {
+  render() {
+    return (
+      <div>
+        <video
+          controls
+          id="video-player"
+          className="videojs"
+          style={{ width: "100%" }}
+          preload="auto"
+        >
+          <source src={this.props.manifest_url} />
+          <p>
+            Your browser does not support the video tag.
+            <br />
+            You can download the video file directly{" "}
+            <a href={this.props.manifest_url}>here</a>
+          </p>
+        </video>
+      </div>
+    );
+  }
+}
+
+export default VideoPlayer;

--- a/src/pages/archives/ArchivePage.js
+++ b/src/pages/archives/ArchivePage.js
@@ -2,6 +2,8 @@ import React, { Component } from "react";
 import { graphqlOperation } from "aws-amplify";
 import { Connect } from "aws-amplify-react";
 import AudioPlayer from "../../components/AudioPlayer";
+import VideoPlayer from "../../components/VideoPlayer";
+import KalturaPlayer from "../../components/KalturaPlayer";
 import MiradorViewer from "../../components/MiradorViewer";
 import SearchBar from "../../components/SearchBar";
 import Breadcrumbs from "../../components/Breadcrumbs.js";
@@ -78,6 +80,14 @@ class ArchivePage extends Component {
     return url.match(/\.(mp3|ogg|wav)$/) != null;
   }
 
+  isVideoURL(url) {
+    return url.match(/\.(mp4)$/) != null;
+  }
+
+  isKalturaURL(url) {
+    return url.match(/\.(kaltura.com)/) != null;
+  }
+
   isJsonURL(url) {
     return url.match(/\.(json)$/) != null;
   }
@@ -109,6 +119,10 @@ class ArchivePage extends Component {
       );
     } else if (this.isAudioURL(item.manifest_url)) {
       display = <AudioPlayer manifest_url={item.manifest_url} />;
+    } else if (this.isVideoURL(item.manifest_url)) {
+      display = <VideoPlayer manifest_url={item.manifest_url} />;
+    } else if (this.isKalturaURL(item.manifest_url)) {
+      display = <KalturaPlayer manifest_url={item.manifest_url} />;
     } else {
       display = <></>;
     }


### PR DESCRIPTION
**Add video support**
* * *

**JIRA Ticket**: (https://webapps.es.vt.edu/jira/browse/LIBTD-2204) (:star:)

* Other Relevant Links (Meeting note, project page, related pull requests, etc.)

# What does this Pull Request do? (:star:)
Adds video support using both kaltura embeds and native html5 video tags

# What's the changes? (:star:)
* Adds support for kaltura videos hosted on vt canvas
* Adds native video support for videos hosted elsewhere (currently just mp4 though)

# How should this be tested?
* Start localhost server with default.json site config specified
* Visit http://localhost:3000/archive/m81xyh23 and check that kaltura video renders and is viewable

# Additional Notes:
* branch: `LIBTD-2204`

# Interested parties
@yinlinchen 

(:star:) Required fields
