### PR TITLE
pin workerSrc version to pdfjs version

### DIFF
--- a/src/components/PDFViewer.js
+++ b/src/components/PDFViewer.js
@@ -1,7 +1,5 @@
 import React, { Component } from "react";
 const pdfjs = require("pdfjs-dist");
-pdfjs.GlobalWorkerOptions.workerSrc =
-  "https://cdnjs.cloudflare.com/ajax/libs/pdf.js/2.4.456/pdf.worker.js";
 
 class PDFViewer extends Component {
   constructor(props) {
@@ -23,6 +21,7 @@ class PDFViewer extends Component {
   }
 
   componentDidMount() {
+    pdfjs.GlobalWorkerOptions.workerSrc = `https://cdnjs.cloudflare.com/ajax/libs/pdf.js/${pdfjs.version}/pdf.worker.js`;
     this.getPdfHeight();
   }
 


### PR DESCRIPTION
**pin workerSrc version to pdfjs version.**
* * *

**JIRA Ticket**: (https://webapps.es.vt.edu/jira/browse/LIBTD-2259) (:star:)

* Other Relevant Links (Meeting note, project page, related pull requests, etc.)

# What does this Pull Request do? (:star:)
PDFJS throws an error if workerSrc version doesn't match. Use PDFJS version to fetch workerSrc from cdn dynamically so that it doesn't break when the npm repo gets updated.

# What's the changes? (:star:)
* pin workerSrc version to pdfjs version

# How should this be tested?

A description of what steps someone could take to:
* start localhost server w/ default.json site_config file specified
* Visit http://localhost:3000/archive/m92xyh34 and check that pdf still loads correctly

# Additional Notes:
* branch: LIBTD-2259

# Interested parties
@yinlinchen 

(:star:) Required fields
