### PR TITLE
Fixed responsive issues on collection pages

### DIFF
--- a/src/css/CollectionsShowPage.css
+++ b/src/css/CollectionsShowPage.css
@@ -9,9 +9,26 @@ div.nav-row a:visited {
 .top-content-row {
   margin-top: 40px;
 }
-.top-content-row .collection-img-col img {
-  width: 100%;
+
+.top-content-row .collection-img-col {
+  display: none;
 }
+
+@media only screen and (min-width: 576px) {
+  .top-content-row .collection-img-col {
+    display: block;
+    max-height: 300px;
+    max-width: 390px;
+    text-align: center;
+  }
+}
+.top-content-row .collection-img-col img {
+  max-height: 100%;
+  max-width: 100%;
+  margin-left: auto;
+  margin-right: auto;
+}
+
 h1.collection-title {
   font-family: "gineso-condensed", sans-serif;
   font-size: 25px;
@@ -91,19 +108,27 @@ span.creator:after {
 }
 
 .container-fluid .details-section-content-grid {
-  display: grid;
-  grid-template-columns: 1fr 1fr;
-  grid-gap: 10px;
   margin-top: 20px;
-}
-.container-fluid .details-section-content-grid .collection-detail-description {
-  grid-column: 1 / 3;
-  grid-row: 1 / 3;
 }
 
 .container-fluid .details-section-content-grid .collection-detail-entry {
-  margin-bottom: 20px;
+  margin-bottom: 15px;
 }
+
+.container-fluid
+  .details-section-content-grid
+  div.collection-detail-entry:last-child {
+  margin-bottom: 30px;
+}
+
+@media only screen and (min-width: 992px) {
+  .container-fluid
+    .details-section-content-grid
+    div.collection-detail-entry:last-child {
+    margin-bottom: 15px;
+  }
+}
+
 .container-fluid .details-section-content-grid .collection-detail-key {
   font-family: "gineso-condensed", sans-serif;
   font-size: 18px;
@@ -114,31 +139,16 @@ span.creator:after {
   font-size: 14px;
 }
 
-div.details-section-content table tr .collection-detail-key {
-  width: 150px;
-  padding: 8px;
-  font-size: 14px;
-  font-weight: 700;
-}
-div.details-section-content table tr .collection-detail-value {
-  font-size: 14px;
-  font-weight: 400;
-  padding: 8px;
-  text-align: left;
-  vertical-align: middle;
-}
-div.details-section-content table tr td.collection-detail-value.identifier {
+.collection-detail-value.identifier {
   -ms-word-break: break-all;
   word-break: break-all;
-}
-div.details-section-content table tr {
-  border-bottom: 1px solid var(--light-gray);
 }
 
 .container-fluid div.subcollections-section {
   padding-left: 20px;
   line-height: 1.2em;
 }
+
 .container-fluid
   div.subcollections-section
   .ui.compact.selection.dropdown
@@ -158,6 +168,11 @@ div.collection-item {
   min-height: 300px;
   margin: 0 auto;
 }
+
+.collection-items-grid .collection-item-wrapper {
+  border: 1px solid var(--light-gray);
+}
+
 div.collection-item .item-image {
   display: inline-block;
   height: 200px;
@@ -175,8 +190,8 @@ div.collection-item .item-image img {
 }
 .collection-items-grid .item-info {
   padding: 10px;
-  border: 1px solid var(--light-gray);
 }
+
 .collection-items-grid .item-info a,
 .collection-items-grid .item-info a:visited {
   font-family: "gineso-condensed", sans-serif;
@@ -184,7 +199,7 @@ div.collection-item .item-image img {
 }
 
 div.collection-items-list-wrapper {
-  margin-top: 50px;
+  margin-top: 30px;
 }
 .collection-items-list-wrapper h4.collection-items-header {
   font-family: "gineso-condensed", sans-serif;

--- a/src/css/breadcrumbs.css
+++ b/src/css/breadcrumbs.css
@@ -7,6 +7,8 @@
   font-family: "gineso-condensed", sans-serif;
 }
 .breadcrumbs-wrapper ol {
+  margin: 0;
+  padding: 0;
   margin-left: 15px;
   list-style-type: none;
 }
@@ -28,10 +30,6 @@
 .breadcrumbs-wrapper ol li:last-child a.vt-breadcrumbs-link,
 .breadcrumbs-wrapper ol li:last-child a.vt-breadcrumbs-link:visited {
   color: var(--themeHighlightColor);
-}
-
-.breadcrumbs-wrapper ol li:first-child {
-  margin-left: -40px;
 }
 
 .breadcrumbs-wrapper ol li:last-child .breadcrumb-slash {

--- a/src/pages/collections/CollectionItemsList.js
+++ b/src/pages/collections/CollectionItemsList.js
@@ -12,14 +12,16 @@ class CollectionItemsList extends Component {
         <div className="collection-items-grid">
           {this.props.items.map(item => (
             <div className="collection-item" key={item.custom_key}>
-              <div className="item-image">
-                <Thumbnail item={item} category="archive" />
-              </div>
-              <div className="item-info">
-                <div className="item-link-wrapper">
-                  <a href={`/archive/${arkLinkFormatted(item.custom_key)}`}>
-                    {item.title}
-                  </a>
+              <div className="collection-item-wrapper">
+                <div className="item-image">
+                  <Thumbnail item={item} category="archive" />
+                </div>
+                <div className="item-info">
+                  <div className="item-link-wrapper">
+                    <a href={`/archive/${arkLinkFormatted(item.custom_key)}`}>
+                      {item.title}
+                    </a>
+                  </div>
                 </div>
               </div>
             </div>

--- a/src/pages/collections/CollectionItemsLoader.js
+++ b/src/pages/collections/CollectionItemsLoader.js
@@ -115,7 +115,7 @@ class CollectionItemsLoader extends Component {
         <div className="collection-items-list-wrapper">
           <div className="mb-3">
             <h4 className="collection-items-header">
-              Items in collection ({this.state.total})
+              Items in Collection ({this.state.total})
             </h4>
           </div>
           <form className="form-group">

--- a/src/pages/collections/CollectionsShowPage.js
+++ b/src/pages/collections/CollectionsShowPage.js
@@ -250,13 +250,13 @@ class CollectionsShowPage extends Component {
             />
           </div>
           <div className="top-content-row row">
-            <div className="collection-img-col col-4">
+            <div className="collection-img-col col-sm-4">
               <img
                 src={this.collectionImg()}
                 alt={`${this.state.collection} header`}
               />
             </div>
-            <div className="collection-details-col col-8">
+            <div className="collection-details-col col-sm-8">
               <h1 className="collection-title">{this.collectionTitle()}</h1>
               <div className="post-heading">
                 <this.creatorDates collection={this.state.collection} />


### PR DESCRIPTION
**JIRA Ticket**: (link) (:star:)
https://webapps.es.vt.edu/jira/browse/LIBTD-2122

# What does this Pull Request do? (:star:)
Fixes some issues for the display of the collection pages at small screen sizes.

# What's the changes? (:star:)
CollectionsShowPage.css - adds/edits styles to display metadata in a list format, hide collection header image for mobile screen sizes, constrain size of collection header image.
breadcrumbs.css - adjusts left alignment of links at mobile screen sizes
CollectionItemsList.js - adds a containing div for collection items
CollectionItemsLoader.js - capitalization fix
CollectionsShowPage.js - makes columns full width for mobile screen sizes

# How should this be tested?
Changes listed above should show up at mobile screen sizes. The exception is the metadata section which will always show as a list now, rather than a grid.

# Additional Notes:
Branch is LIBTD-2122

# Interested parties
@yinlinchen 

(:star:) Required fields
