### PR TITLE
just use searchCollections and searchArchives

### DIFF
--- a/src/components/HeaderBreadcrumbs.js
+++ b/src/components/HeaderBreadcrumbs.js
@@ -16,23 +16,31 @@ class HeaderBreadcrumbs extends Breadcrumbs {
   async getTitle(pathname, path_array) {
     const type = path_array[1];
     const customKey = path_array[2];
-    const filter = { customKey: `ark:/53696/${customKey}` };
+    const options = {
+      order: "ASC",
+      limit: 1,
+      filter: {
+        custom_key: {
+          eq: `ark:/53696/${customKey}`
+        }
+      }
+    };
     let title = null;
     let query = null;
     let dataRecord = null;
     if (type === "collection") {
-      query = queries.getCollectionByCustomKey;
+      query = queries.searchCollections;
       dataRecord = "searchCollections";
     } else if (type === "archive") {
-      query = queries.getArchiveByCustomKey;
+      query = queries.searchArchives;
       dataRecord = "searchArchives";
     }
     if (query) {
-      const item = await API.graphql(graphqlOperation(query, filter));
+      const item = await API.graphql(graphqlOperation(query, options));
       try {
         title = item.data[dataRecord].items[0].title;
       } catch (error) {
-        console.error(`error getting title for archive: ${customKey}`);
+        console.error(`error getting title for ${type}: ${customKey}`);
       }
     }
     if (title) {

--- a/src/graphql/queries.js
+++ b/src/graphql/queries.js
@@ -159,81 +159,6 @@ export const getCollection = /* GraphQL */ `
     }
   }
 `;
-
-export const getCollectionByCustomKey = `query searchCollection($customKey: String) {
-  searchCollections(
-    filter: {
-      custom_key: {
-          eq: $customKey
-      }
-    },
-    sort: {
-      field: identifier, 
-      direction: asc
-    }
-  ){
-    items {
-      id
-      title
-      identifier
-      description
-      creator
-      source
-      circa
-      start_date
-      end_date
-      subject
-      location
-      rights_statement
-      language
-      bibliographic_citation
-      rights_holder
-      custom_key
-      collection_category
-      visibility
-      thumbnail_path
-      parent_collection
-      create_date
-      modified_date
-      archives {
-        items {
-          id
-          title
-          identifier
-          description
-          tags
-          creator
-          source
-          circa
-          start_date
-          end_date
-          rights_statement
-          language
-          resource_type
-          belongs_to
-          location
-          medium
-          bibliographic_citation
-          rights_holder
-          format
-          related_url
-          contributor
-          custom_key
-          parent_collection
-          item_category
-          visibility
-          thumbnail_path
-          manifest_url
-          create_date
-          modified_date
-        }
-      }
-    }
-    nextToken
-  }
-}
-`;
-
 export const listCollections = /* GraphQL */ `
   query ListCollections(
     $filter: ModelCollectionFilterInput
@@ -343,44 +268,6 @@ export const getArchive = /* GraphQL */ `
     }
   }
 `;
-
-export const getArchiveByCustomKey = `query searchArchive($customKey: String) {
-  searchArchives(filter: {
-      custom_key: {
-          eq: $customKey
-      }
-  })
-  {
-    items {
-      id
-      title
-      description
-      identifier
-      belongs_to
-      bibliographic_citation
-      contributor
-      creator
-      custom_key
-      format
-      language
-      location
-      medium
-      resource_type
-      related_url
-      rights_holder
-      rights_statement
-      source
-      circa
-      start_date
-      end_date
-      tags
-      parent_collection
-      manifest_url
-    }
-  }
-}
-`;
-
 export const listArchives = /* GraphQL */ `
   query ListArchives(
     $filter: ModelArchiveFilterInput

--- a/src/pages/archives/ArchivePage.js
+++ b/src/pages/archives/ArchivePage.js
@@ -13,7 +13,7 @@ import {
   addNewlineInDesc
 } from "../../lib/MetadataRenderer";
 import { fetchLanguages } from "../../lib/fetchTools";
-import { getArchiveByCustomKey } from "../../graphql/queries";
+import { searchArchives } from "../../graphql/queries";
 
 import "../../css/ArchivePage.css";
 
@@ -191,8 +191,14 @@ class ArchivePage extends Component {
   render() {
     return (
       <Connect
-        query={graphqlOperation(getArchiveByCustomKey, {
-          customKey: `ark:/53696/${this.props.customKey}`
+        query={graphqlOperation(searchArchives, {
+          order: "ASC",
+          limit: 1,
+          filter: {
+            custom_key: {
+              eq: `ark:/53696/${this.props.customKey}`
+            }
+          }
         })}
       >
         {({ data: { searchArchives }, loading, errors }) => {

--- a/src/pages/collections/CollectionsShowLoader.js
+++ b/src/pages/collections/CollectionsShowLoader.js
@@ -2,7 +2,7 @@ import React, { Component } from "react";
 import { graphqlOperation } from "aws-amplify";
 import { Connect } from "aws-amplify-react";
 import SiteTitle from "../../components/SiteTitle";
-import { getCollectionByCustomKey } from "../../graphql/queries";
+import { searchCollections } from "../../graphql/queries";
 
 import CollectionsShowPage from "./CollectionsShowPage.js";
 
@@ -10,8 +10,14 @@ class CollectionsShowLoader extends Component {
   render() {
     return (
       <Connect
-        query={graphqlOperation(getCollectionByCustomKey, {
-          customKey: `ark:/53696/${this.props.customKey}`
+        query={graphqlOperation(searchCollections, {
+          order: "ASC",
+          limit: 1,
+          filter: {
+            custom_key: {
+              eq: `ark:/53696/${this.props.customKey}`
+            }
+          }
         })}
       >
         {({ data: { searchCollections }, loading, errors }) => {


### PR DESCRIPTION
**just use searchCollections and searchArchives queries instead of the wrappers that I wrote for them to query based on custom_key.**
* * *

**JIRA Ticket**: (https://webapps.es.vt.edu/jira/browse/LIBTD-2144) (:star:)

* Other Relevant Links (Meeting note, project page, related pull requests, etc.)

# What does this Pull Request do? (:star:)
just use searchCollections and searchArchives queries instead of the wrappers that I wrote for them to query based on custom_key.

# What's the changes? (:star:)
* removes `getCollectionByCustomKey` query
* removes `getArchiveByCustomKey` query
* refactors to just use the "search" queries with the appropriate filters instead

# How should this be tested?
* Visit collection show page and make sure that content still loads correctly
* Visit archive show page and make sure that content still loads correctly

# Additional Notes:
* branch: `LIBTD-2144`

# Interested parties
@yinlinchen 

(:star:) Required fields
