### PR TITLE
Created conditional rendering for title text overlay

### DIFF
--- a/src/css/FeaturedStaticImage.css
+++ b/src/css/FeaturedStaticImage.css
@@ -5,9 +5,16 @@
   max-height: 450px;
 }
 
-.home-static-image-wrapper img {
+.home-wrapper .home-static-image-wrapper img {
   width: 100%;
   filter: brightness(70%) contrast(70%);
+  margin: 0px;
+  max-height: 450px;
+  object-fit: cover;
+}
+
+.home-wrapper-no-text .home-static-image-wrapper img {
+  width: 100%;
   margin: 0px;
   max-height: 450px;
   object-fit: cover;

--- a/src/css/HomePage.css
+++ b/src/css/HomePage.css
@@ -5,7 +5,7 @@
   position: relative;
 }
 
-#home-site-title-wrapper {
+.home-wrapper #home-site-title-wrapper {
   width: 100%;
   max-height: 500px;
   text-align: center;
@@ -17,22 +17,26 @@
   transform: translate(-50%, -50%);
 }
 
-#home-site-title-wrapper a,
-#home-site-title-wrapper a:visited,
-#home-site-title-wrapper a:hover {
+.home-wrapper #home-site-title-wrapper a,
+.home-wrapper #home-site-title-wrapper a:visited,
+.home-wrapper #home-site-title-wrapper a:hover {
   color: white;
   font-family: "crimson-text", serif;
   font-weight: 600;
-  text-shadow: -2px 3px 5px black;
+  text-shadow: -2px 3px 5px #000000b5;
   text-decoration: none;
 }
 
-.home-welcome-wrapper {
+.home-wrapper-no-text #home-site-title-wrapper {
+  display: none;
+}
+
+.home-statement-wrapper {
   width: 100%;
   padding: 40px 0px 40px 0px;
 }
 
-.home-welcome-wrapper h1 {
+.home-statement-wrapper h1 {
   font-family: "gineso-condensed", sans-serif;
   text-align: center;
 }
@@ -42,29 +46,39 @@
   font-family: "Acherus", sans-serif;
 }
 
-.home-search-wrapper {
+.home-wrapper .home-search-wrapper {
   width: 100%;
-  padding: 0 10px 0px 10px;
+  padding: 0 10px 0 10px;
   transform: translate(0, -23px);
 }
 
+.home-wrapper-no-text .home-search-wrapper {
+  width: 100%;
+  padding-top: 40px;
+}
+
 @media (min-width: 576px) {
-  #home-site-title-wrapper {
+  .home-wrapper #home-site-title-wrapper {
     font-size: 30px;
     width: 60%;
   }
 
-  .home-welcome-wrapper {
+  .home-statement-wrapper {
     padding: 40px;
   }
 
-  .home-search-wrapper {
+  .home-wrapper .home-search-wrapper {
     padding: 0 40px 0 40px;
+  }
+
+  .home-wrapper-no-text .home-search-wrapper {
+    padding: 0 40px 0 40px;
+    transform: translate(0, -23px);
   }
 }
 
 @media (min-width: 768px) {
-  #home-site-title-wrapper {
+  .home-wrapper #home-site-title-wrapper {
     font-size: 40px;
   }
 }

--- a/src/pages/HomePage.js
+++ b/src/pages/HomePage.js
@@ -35,7 +35,13 @@ class HomePage extends Component {
           siteTitle={this.props.siteDetails.siteTitle}
           pageTitle="Home"
         />
-        <div className="home-wrapper">
+        <div
+          className={
+            this.props.siteDetails.homePage.staticImage.showTitle
+              ? "home-wrapper"
+              : "home-wrapper-no-text"
+          }
+        >
           <div className="home-featured-image-wrapper">
             <FeaturedStaticImage staticImage={staticImage} />
             <div id="home-site-title-wrapper">

--- a/src/pages/home/FeaturedStaticImage.js
+++ b/src/pages/home/FeaturedStaticImage.js
@@ -7,10 +7,12 @@ class FeaturedStaticImage extends Component {
     if (this.props.staticImage) {
       return (
         <div className="home-static-image-wrapper">
-          <img
-            src={this.props.staticImage.src}
-            alt={this.props.staticImage.altText}
-          />
+          <a href="/">
+            <img
+              src={this.props.staticImage.src}
+              alt={this.props.staticImage.altText}
+            />
+          </a>
         </div>
       );
     } else {

--- a/src/pages/home/HomeStatement.js
+++ b/src/pages/home/HomeStatement.js
@@ -4,7 +4,7 @@ class HomeStatement extends Component {
   render() {
     if (this.props.homeStatement) {
       return (
-        <div className="home-welcome-wrapper">
+        <div className="home-statement-wrapper">
           <h1
             style={{
               display: this.props.homeStatement.heading ? "block" : "none"


### PR DESCRIPTION
**JIRA Ticket**: (link) (:star:)
https://webapps.es.vt.edu/jira/browse/LIBTD-2278

# What does this Pull Request do? (:star:)
Creates conditional rendering for cover image text overlay

# What's the changes? (:star:)
FeaturedStaticImage.css - adds css for no-text option
HomePage.css - also adds css for no-text option
HomePage.js - adds conditional for which class name will be used (based on showTitle value in config file)
FeaturedStaticImage.js - makes the image itself a link back to the home page
HomeStatement.js - just updates the name of a class to something which makes more sense now.

# How should this be tested?
These changes should allow the cover image and text overlay to appear as normal when the showTitle value is true. When the showTitle value is false (only podcast library so far), then the cover image will show without the text overlay. Also at mobile screen sizes the search bar will move below the image so that it doesn't cover anything important in the image.

# Additional Notes:
branch is LIBTD-2278

# Interested parties
@yinlinchen 
(:star:) Required fields
