### PR TITLE
Fixed collection image size

### DIFF
--- a/src/css/CollectionsShowPage.css
+++ b/src/css/CollectionsShowPage.css
@@ -17,7 +17,7 @@ div.nav-row a:visited {
 @media only screen and (min-width: 576px) {
   .top-content-row .collection-img-col {
     display: block;
-    max-height: 300px;
+    height: 300px;
     max-width: 390px;
     text-align: center;
   }
@@ -25,8 +25,6 @@ div.nav-row a:visited {
 .top-content-row .collection-img-col img {
   max-height: 100%;
   max-width: 100%;
-  margin-left: auto;
-  margin-right: auto;
 }
 
 h1.collection-title {


### PR DESCRIPTION
**JIRA Ticket**: (link) (:star:)
https://webapps.es.vt.edu/jira/browse/LIBTD-2122

# What does this Pull Request do? (:star:)
A quick fix for the size of the header images for the collection pages.

# What's the changes? (:star:)
CollectionsShowPage.css - just one style rule and a little clean up.

# How should this be tested?
this image (https://swva-dev.cloud.lib.vt.edu/collection/8j19xh9q) was overflwing its container. It shouldn't do that anymore and it should still scale appropriately to different screen sizes.

# Additional Notes:
branch is imageProb

# Interested parties
@yinlinchen 

(:star:) Required fields
