### PR TITLE
Generate code to support "additional" pages based on config jsons

### DIFF
--- a/cypress/integration/additional_pages.spec.js
+++ b/cypress/integration/additional_pages.spec.js
@@ -1,0 +1,27 @@
+describe('Site nav menu', () => {
+  it('shows generated About link', () => {
+    cy.visit('/');
+    cy.get('#vt_main_nav > li:nth-child(4)')
+      .eq(0)
+      .should('have.class', 'nav-item')
+      .should('not.be.visible');
+      cy.get('#vt_main_nav > li:nth-child(4) .link-wrapper a')
+        .invoke('text')
+        .should('contain', "ABOUT")
+  });
+});
+
+describe('About link', () => {
+  it('links to correct About page', () => {
+    cy.visit('/');
+    cy.get('#vt_nav > div.linkWrapper > button')
+      .click();
+    cy.get('#vt_main_nav > li:nth-child(4) .link-wrapper a')
+      .should('be', 'visible')
+      .click();
+    cy.get('#content-wrapper > div > div.col-12.about-heading > h1')
+      .invoke('text')
+      .should('contain', 'About');
+  });
+});
+

--- a/src/App.js
+++ b/src/App.js
@@ -5,9 +5,9 @@ import { fetchSiteDetails } from "./lib/fetchTools";
 import AnalyticsConfig from "./components/AnalyticsConfig";
 import Header from "./components/Header";
 import Footer from "./components/Footer";
+import { buildRoutes } from "./lib/CustomPageRoutes";
 import HomePage from "./pages/HomePage";
-import AboutPage from "./pages/AboutPage";
-import PermissionsPage from "./pages/PermissionsPage";
+
 import CollectionsListLoader from "./pages/collections/CollectionsListLoader";
 import CollectionsShowLoader from "./pages/collections/CollectionsShowLoader";
 
@@ -15,7 +15,6 @@ import SearchLoader from "./pages/search/SearchLoader";
 import ArchivePage from "./pages/archives/ArchivePage";
 
 import "./App.css";
-import AdditionalPages from "./pages/AdditionalPages";
 
 class App extends Component {
   constructor(props) {
@@ -46,7 +45,7 @@ class App extends Component {
   render() {
     if (this.state.siteDetails !== null) {
       this.setColor(this.state.siteDetails.siteColor);
-
+      const customRoutes = buildRoutes(this.state.siteDetails);
       return (
         <Router>
           <AnalyticsConfig analyticsID={this.state.siteDetails.analyticsID} />
@@ -58,25 +57,12 @@ class App extends Component {
           <main style={{ minHeight: "500px", padding: "1em 1em 0 1em" }}>
             <div id="content-wrapper" className="container p-0" role="main">
               <Switch>
+                {customRoutes}
                 <Route
                   path="/"
                   exact
                   render={props => (
                     <HomePage siteDetails={this.state.siteDetails} />
-                  )}
-                />
-                <Route
-                  path="/about"
-                  exact
-                  render={props => (
-                    <AboutPage siteDetails={this.state.siteDetails} />
-                  )}
-                />
-                <Route
-                  path="/permissions"
-                  exact
-                  render={props => (
-                    <PermissionsPage siteDetails={this.state.siteDetails} />
                   )}
                 />
                 <Route
@@ -118,25 +104,6 @@ class App extends Component {
                     />
                   )}
                 />
-                {this.state.siteDetails.aboutCopy.additionalPages
-                  ? this.state.siteDetails.aboutCopy.additionalPages.map(
-                      (page, index) => {
-                        return (
-                          <Route
-                            key={index}
-                            path={page.link}
-                            exact
-                            render={() => (
-                              <AdditionalPages
-                                siteDetails={this.state.siteDetails}
-                                page={page}
-                              />
-                            )}
-                          />
-                        );
-                      }
-                    )
-                  : null}
               </Switch>
             </div>
           </main>

--- a/src/components/SiteNavigationLinks.js
+++ b/src/components/SiteNavigationLinks.js
@@ -5,48 +5,88 @@ class SiteNavigationLinks extends Component {
     window.foldAction(event.currentTarget);
   }
 
-  render() {
-    const aboutPage = this.props.siteDetails.aboutCopy.additionalPages ? (
-      <li className="nav-item has-submenu">
+  buildListItems() {
+    let listItems = [];
+    for (const [key, page] of Object.entries(
+      this.props.siteDetails.sitePages
+    )) {
+      listItems.push(this.topLevelItem(key, page));
+    }
+    return listItems;
+  }
+
+  topLevelItem(key, page) {
+    const hasChildClass = page.children ? "nav-item has-submenu" : "nav-item";
+
+    const listItem = (
+      <li key={page.text} className={hasChildClass}>
         <div className="link-wrapper">
-          <a href="/about" className="" tabIndex="-1">
-            About
+          <a href={page.local_url} tabIndex="-1">
+            {page.text.toUpperCase()}
           </a>
-          <button
-            tabIndex="-1"
-            className="fold-icon"
-            onClick={this.onFoldAction}
-            aria-expanded="false"
-            aria-label="About Submenu Toggle"
-            aria-controls="about_submenu"
-          >
-            <span className="far fa-times" focusable="false"></span>
-            <span className="sr-only">About Submenu Toggle</span>
-          </button>
+          {this.childButton(page)}
         </div>
-        <ul className="submenu" id="about_submenu" aria-label="About Submenu">
-          {this.props.siteDetails.aboutCopy.additionalPages.map(
-            (item, index) => {
-              return (
-                <li className="nav-item" key={index}>
-                  <a href={item.link} tabIndex="-1">
-                    {item.title}
-                  </a>
-                </li>
-              );
-            }
-          )}
-        </ul>
-      </li>
-    ) : (
-      <li className="nav-item">
-        <div className="link-wrapper">
-          <a href="/about" tabIndex="-1">
-            About
-          </a>
-        </div>
+        {this.childList(page)}
       </li>
     );
+    return listItem;
+  }
+
+  childList(page) {
+    let childList = <></>;
+    if (page.children) {
+      const ulID = `${page.text.toLowerCase()}_submenu`;
+      const ariaLabel = `${page.text} Submenu`;
+      childList = (
+        <ul className="submenu" id={ulID} aria-label={ariaLabel}>
+          {this.childItems(page)}
+        </ul>
+      );
+    }
+    return childList;
+  }
+
+  childItems(parentPage) {
+    const parentKey = parentPage.text;
+    let childItems = [];
+    for (const [childKey, page] of Object.entries(parentPage.children)) {
+      const liKey = `${parentKey}.${childKey}`;
+      const item = (
+        <li className="nav-item" key={liKey}>
+          <a href={page.local_url} tabIndex="-1">
+            {page.text}
+          </a>
+        </li>
+      );
+      childItems.push(item);
+    }
+    return childItems;
+  }
+
+  childButton(page) {
+    let childButton = <></>;
+    if (page.children) {
+      const accessibilityText = `${page.text} Submenu Toggle`;
+      const ariaControls = `${page.text.toLowerCase()}_submenu`;
+      childButton = (
+        <button
+          tabIndex="-1"
+          className="fold-icon"
+          onClick={this.onFoldAction}
+          aria-expanded="false"
+          aria-label={accessibilityText}
+          aria-controls={ariaControls}
+        >
+          <span className="far fa-times" focusable="false"></span>
+          <span className="sr-only">{accessibilityText}</span>
+        </button>
+      );
+    }
+    return childButton;
+  }
+
+  render() {
+    const additionalListItems = this.buildListItems();
 
     return (
       <ul id="vt_main_nav" role="presentation" aria-label="Pages in Site">
@@ -54,14 +94,6 @@ class SiteNavigationLinks extends Component {
           <div className="link-wrapper">
             <a href="/" tabIndex="-1">
               Home
-            </a>
-          </div>
-        </li>
-        {aboutPage}
-        <li className="nav-item">
-          <div className="link-wrapper">
-            <a href="/permissions" tabIndex="-1">
-              PERMISSIONS
             </a>
           </div>
         </li>
@@ -79,6 +111,7 @@ class SiteNavigationLinks extends Component {
             </a>
           </div>
         </li>
+        {additionalListItems}
       </ul>
     );
   }

--- a/src/lib/CustomPageRoutes.js
+++ b/src/lib/CustomPageRoutes.js
@@ -1,0 +1,55 @@
+import React from "react";
+import { Route } from "react-router-dom";
+import AboutPage from "../pages/AboutPage";
+import PermissionsPage from "../pages/PermissionsPage";
+import AdditionalPages from "../pages/AdditionalPages";
+
+const pageComponents = {
+  AboutPage: AboutPage,
+  PermissionsPage: PermissionsPage,
+  AdditionalPages: AdditionalPages
+};
+
+function route(siteDetails, key, path, PageComponent, childKey = null) {
+  let elemKey = key;
+  if (childKey) {
+    elemKey += "." + childKey;
+  }
+  return (
+    <Route
+      key={elemKey}
+      path={path}
+      exact
+      render={props => (
+        <PageComponent
+          siteDetails={siteDetails}
+          parentKey={key}
+          childKey={childKey}
+        />
+      )}
+    />
+  );
+}
+
+export function buildRoutes(siteDetails) {
+  let routes = [];
+  for (const [key, obj] of Object.entries(siteDetails.sitePages)) {
+    const pageComponent = pageComponents[obj.component];
+    routes.push(route(siteDetails, key, obj.local_url, pageComponent));
+    if (obj.children) {
+      for (const [childKey, childObj] of Object.entries(obj.children)) {
+        const childPageComponent = pageComponents[childObj.component];
+        routes.push(
+          route(
+            siteDetails,
+            key,
+            childObj.local_url,
+            childPageComponent,
+            childKey
+          )
+        );
+      }
+    }
+  }
+  return routes;
+}

--- a/src/lib/fetchTools.js
+++ b/src/lib/fetchTools.js
@@ -44,14 +44,10 @@ export const fetchSiteDetails = async (component, siteName) => {
   });
 };
 
-export function getHTML(basePath, copyObj, component) {
+export function getHTML(basePath, copyURL, component) {
   let copy = null;
   try {
-    if (copyObj.type === "string") {
-      copy = copyObj.value;
-    } else if (copyObj.type === "file") {
-      fetchCopyHTML(basePath, copyObj, component);
-    }
+    fetchCopyHTML(basePath, copyURL, component);
   } catch (error) {
     console.error("Error setting copy for component");
   }
@@ -60,16 +56,16 @@ export function getHTML(basePath, copyObj, component) {
   }
 }
 
-const fetchCopyHTML = async (basePath, copyObj, component) => {
+const fetchCopyHTML = async (basePath, copyURL, component) => {
   let data = null;
   try {
-    data = sessionStorage.getItem(copyObj.value);
+    data = sessionStorage.getItem(copyURL);
   } catch (error) {
-    console.log(`${copyObj.value} not in sessionStorage`);
+    console.log(`${copyURL} not in sessionStorage`);
   }
   if (data === null) {
     try {
-      const copyLink = `${basePath}/${copyObj.value}`;
+      const copyLink = `${basePath}/${copyURL}`;
       console.log(copyLink);
       console.log(`fetching copy from: ${copyLink}`);
       const response = await fetch(copyLink);
@@ -82,7 +78,7 @@ const fetchCopyHTML = async (basePath, copyObj, component) => {
     }
   }
   if (data !== null) {
-    sessionStorage.setItem(copyObj.value, data);
+    sessionStorage.setItem(copyURL, data);
     component.setState({ copy: data });
   }
 };

--- a/src/pages/AboutPage.js
+++ b/src/pages/AboutPage.js
@@ -15,7 +15,7 @@ class AboutPage extends Component {
   componentDidMount() {
     getHTML(
       this.props.siteDetails.assetBasePath,
-      this.props.siteDetails.aboutCopy,
+      this.props.siteDetails.sitePages[this.props.parentKey].data_url,
       this
     );
   }
@@ -40,7 +40,7 @@ class AboutPage extends Component {
         </div>
         <div className="col-md-4 contact-section-wrapper">
           <ContactSection siteDetails={this.props.siteDetails} />
-          {this.props.siteDetails.termsCopy.value ? (
+          {this.props.siteDetails.sitePages.terms ? (
             <a href="/permissions" className="about-terms-link">
               Permissions
             </a>

--- a/src/pages/AdditionalPages.js
+++ b/src/pages/AdditionalPages.js
@@ -10,7 +10,12 @@ class AdditionalPages extends Component {
   }
 
   componentDidMount() {
-    getHTML(this.props.siteDetails.assetBasePath, this.props.page, this);
+    let copyObj = this.props.siteDetails.sitePages[this.props.parentKey];
+    if (copyObj.children && this.props.childKey) {
+      copyObj = copyObj.children[this.props.childKey];
+    }
+    const copyUrl = copyObj.data_url;
+    getHTML(this.props.siteDetails.assetBasePath, copyUrl, this);
   }
 
   render() {

--- a/src/pages/PermissionsPage.js
+++ b/src/pages/PermissionsPage.js
@@ -13,11 +13,20 @@ class PermissionsPage extends Component {
   }
 
   componentDidMount() {
-    const assetBasePath = this.props.siteDetails.assetBasePath;
-    getHTML(assetBasePath, this.props.siteDetails.termsCopy, this);
+    getHTML(
+      this.props.siteDetails.assetBasePath,
+      this.props.siteDetails.sitePages[this.props.parentKey].data_url,
+      this
+    );
   }
 
   render() {
+    let download = "";
+    try {
+      download = this.props.siteDetails.sitePages.terms.assets.download;
+    } catch (error) {
+      console.log("no download link specified");
+    }
     return (
       <>
         <div className="row terms-page-wrapper">
@@ -36,12 +45,10 @@ class PermissionsPage extends Component {
           </div>
           <div className="col-md-4 contact-section-wrapper">
             <ContactSection siteDetails={this.props.siteDetails} />
-            {this.props.siteDetails.termsCopy.download ? (
+            {download ? (
               <div>
                 <p className="terms-downloads-heading">Downloadable forms</p>
-                <a href={this.props.siteDetails.termsCopy.download}>
-                  Permission form for image reproductions
-                </a>
+                <a href={download}>Permission form for image reproductions</a>
               </div>
             ) : null}
           </div>


### PR DESCRIPTION
**Generate code to support "additional" pages based on config jsons.**
* * *

**JIRA Ticket**: (https://webapps.es.vt.edu/jira/browse/LIBTD-2282) (:star:)

**This PR depends on the format of the config files in the `LIBTD-2282` branch of VTDLP-siteconfig to work correctly https://github.com/VTUL/VTDLP-siteconfig/tree/LIBTD-2282**

# What does this Pull Request do? (:star:)
Generate code to support "additional" pages based on config jsons

# What's the changes? (:star:)
* Generates Routes (in App.js) based on `sitePages` object in config.jsons. It will also generate routes for sub-pages like those in SWVA About.
* Generates Site nav menu based on `sitePages` object in config.jsons. It will also generate sub-menus (one level max) to support pages like in SWVA About. Home, Browse Collections, and Search links will remain hardcoded since they will always be present
* Passes the url where the data for each page can be found to the Component that is specified to handle the page.
* Also supports passing additional "assets" to the specified component that might be needed.

# How should this be tested?
* Start localhost server using the config files here https://github.com/VTUL/VTDLP-siteconfig/tree/LIBTD-2282/configs
* Load the different sites and check that the site nav menus match what is defined in the config files (most sites only have an About page. SWVA has About with a bunch of sub pages. IAWA has About and Permissions).
* Check that the links work correctly and that the content for these pages loads correctly.

# Additional Notes:
* branch: `LIBTD-2282`
* This PR depends on the format of the config files in the `LIBTD-2282` branch of VTDLP-siteconfig to work correctly https://github.com/VTUL/VTDLP-siteconfig/tree/LIBTD-2282

# Interested parties
@yinlinchen 

(:star:) Required fields
