### PR TITLE
Make mirador viewer options configurable and add default config

### DIFF
--- a/src/components/MiradorViewer.js
+++ b/src/components/MiradorViewer.js
@@ -2,16 +2,98 @@ import React, { Component } from "react";
 import "../css/Viewer.css";
 
 class MiradorViewer extends Component {
-  get miradorConfig() {
-    return this.props.config;
+  constructor(props) {
+    super(props);
+    this.state = {
+      annotationTooltipVisible: false,
+      viewTypeControlVisible: false
+    };
+  }
+
+  miradorConfig() {
+    let config = {
+      id: "mirador_viewer",
+      mainMenuSettings: {
+        show: false
+      },
+      data: [
+        {
+          manifestUri: this.props.item.manifest_url,
+          location: this.props.siteDetails.siteId.toUpperCase()
+        }
+      ],
+      windowObjects: [
+        {
+          loadedManifest: this.props.item.manifest_url,
+          viewType: "ImageView",
+          displayLayout: false,
+          bottomPanel: false,
+          bottomPanelAvailable: false,
+          bottomPanelVisible: false,
+          sidePanel: false,
+          annotationLayer: false
+        }
+      ],
+      showAddFromURLBox: false
+    };
+    if (
+      this.props.siteDetails.miradorOptions &&
+      this.props.siteDetails.miradorOptions.windowObjects
+    ) {
+      config.windowObjects[0] = Object.assign(
+        config.windowObjects[0],
+        this.props.siteDetails.miradorOptions.windowObjects
+      );
+    }
+    return config;
+  }
+
+  hideElement(elementClassName) {
+    window.setTimeout(function() {
+      try {
+        let elem = document.getElementsByClassName(elementClassName)[0];
+        elem.style.display = "none";
+      } catch (error) {
+        console.log(`error hiding ${elementClassName}`);
+      }
+    }, 500);
+  }
+
+  setOptionState(option) {
+    if (
+      this.props.siteDetails.miradorOptions &&
+      option in this.props.siteDetails.miradorOptions
+    ) {
+      let stateObj = {};
+      stateObj[option] = this.props.siteDetails.miradorOptions[option];
+
+      this.setState(stateObj, function() {
+        this.setOptionVisibility();
+      });
+    } else {
+      this.setOptionVisibility();
+    }
+  }
+
+  setOptionVisibility() {
+    if (!this.state.annotationTooltipVisible) {
+      this.hideElement("mirador-osd-annotation-controls");
+    }
+    if (!this.state.viewTypeControlVisible) {
+      this.hideElement("mirador-icon-view-type");
+    }
   }
 
   componentDidMount() {
-    window.Mirador(this.miradorConfig);
+    this.miradorConfig();
+    window.Mirador(this.miradorConfig());
+
+    this.setOptionState("annotationTooltipVisible");
+    this.setOptionState("viewTypeControlVisible");
   }
 
   render() {
-    return <div id={this.miradorConfig.id}></div>;
+    return <div id={this.miradorConfig().id}></div>;
   }
 }
 

--- a/src/pages/archives/ArchivePage.js
+++ b/src/pages/archives/ArchivePage.js
@@ -113,23 +113,9 @@ class ArchivePage extends Component {
     let config = {};
     let tracks = [];
     if (this.isJsonURL(item.manifest_url)) {
-      const miradorConfig = {
-        id: "mirador_viewer",
-        data: [
-          {
-            manifestUri: item.manifest_url,
-            location: this.props.siteDetails.siteId.toUpperCase()
-          }
-        ],
-        windowObjects: [
-          {
-            loadedManifest: item.manifest_url,
-            viewType: "ImageView"
-          }
-        ],
-        showAddFromURLBox: false
-      };
-      display = <MiradorViewer config={miradorConfig} />;
+      display = (
+        <MiradorViewer item={item} siteDetails={this.props.siteDetails} />
+      );
     } else if (this.isImgURL(item.manifest_url)) {
       display = (
         <img className="item-img" src={item.manifest_url} alt={item.title} />


### PR DESCRIPTION
**Make mirador viewer options configurable and add default config.**
* * *

**JIRA Ticket**: (https://webapps.es.vt.edu/jira/browse/LIBTD-2258) (:star:)

* Other Relevant Links (Meeting note, project page, related pull requests, etc.)

# What does this Pull Request do? (:star:)
Make mirador viewer options configurable and add default config.

# What's the changes? (:star:)
* Add default options to disable features in mirador that are broken and/or not being used
* Allow options to be overridden if they are defined in json config file

# How should this be tested?
* start localhost server specifying iawa and using this config file: https://github.com/VTUL/VTDLP-siteconfig/blob/LIBTD-2258/configs/iawa.json
* View any "item" page and check that unneeded and/or broken features are disabled. 
  * Top bar with "change layout" and "fullscreen" should be disabled. 
  * "change layout", "side panel", and "view type" on second bar should be disabled 
  * "annotations" on left column should be disabled
  * "thumbnail selection" at the bottom should be disabled.
* View an item page on iawa.lib.vt.edu for comparison if necessary
* Change values in iawa.json and refresh to make sure that options can be changed (Note: you will need to run `sessionStorage.clear();` after every change for the changes to be seen.

# Additional Notes:
* branch: `LIBTD-2258`

# Interested parties
@yinlinchen 

(:star:) Required fields
