### PR TITLE
LIBTD-1982: Provide Metadata display configurations for Collection an…

### DIFF
--- a/cypress/integration/archive_metadata_display.spec.js
+++ b/cypress/integration/archive_metadata_display.spec.js
@@ -1,0 +1,27 @@
+describe('A single Archive Show page metadata section', () => {
+  beforeEach(() => {
+    cy.visit('/archive/hs59hv2z');
+    cy.get('#content-wrapper > div.item-page-wrapper > div.item-details-section > div.details-section-metadata > table > tbody')
+      .as('metadataSection')
+  })
+
+  it('displays the identifier field and its corresponding value', () => {
+    cy.get('@metadataSection')
+      .find(':nth-child(1) > td.collection-detail-key')
+      .invoke('text')
+      .should('equal', 'Identifier')
+    cy.get('@metadataSection')
+      .find(':nth-child(1) > td.collection-detail-value').click()
+    cy.url().should('include', '/archive/hs59hv2z')
+  })
+
+  it('displays the custom key field and its corresponding value', () => {
+    cy.get('@metadataSection')
+      .find(':nth-child(5) > td.collection-detail-key')
+      .invoke('text')
+      .should('equal', 'Permanent Link')
+    cy.get('@metadataSection')
+      .find(':nth-child(5) > td.collection-detail-value')
+      .contains('idn.lib.vt.edu/ark:/53696/hs59hv2z')
+  })
+})

--- a/cypress/integration/collection_metadata_display.spec.js
+++ b/cypress/integration/collection_metadata_display.spec.js
@@ -1,0 +1,28 @@
+describe('A single Collection Show page metadata section', () => {
+  beforeEach(() => {
+    cy.visit('/collection/vb765t25');
+    cy.get('#content-wrapper')
+      .find('div.details-section-content-grid')
+      .as('metadataSection')
+  })
+
+  it('displays the size field and its corresponding value', () => {
+    cy.get('@metadataSection')
+      .find(':nth-child(1) > div.collection-detail-key')
+      .invoke('text')
+      .should('equal', 'Size')
+    cy.get('@metadataSection')
+      .find(':nth-child(1) > div.collection-detail-value')
+      .contains('Collections:')
+  })
+
+  it('displays the identifier field and its corresponding value', () => {
+    cy.get('@metadataSection')
+      .find(':nth-child(7) > div.collection-detail-key')
+      .invoke('text')
+      .should('equal', 'Identifier')
+    cy.get('@metadataSection')
+      .find(':nth-child(7) > div.collection-detail-value').click()
+    cy.url().should('include', '/collection/vb765t25')
+  })
+})

--- a/cypress/integration/search_bar.spec.js
+++ b/cypress/integration/search_bar.spec.js
@@ -65,7 +65,7 @@ describe('Search by all fields by hitting enter key', () => {
       .clear()
       .type('Diazotypes (copies){enter}')
       .trigger('input');
-    cy.wait(1000);
+    cy.wait(2000);
   });
 
   it('returns resulting objects with full text search', () => {

--- a/cypress/integration/search_facet.spec.js
+++ b/cypress/integration/search_facet.spec.js
@@ -16,7 +16,7 @@ describe('Collapsible search filter field', () => {
 
   it('displays the facet field while hiding the list of facet values', () => {
     cy.get('[data-cy=filter-collapsibles] > :nth-child(1) > div.facet-listing')
-    .should('not.be.visible');
+      .should('not.be.visible');
     cy.get('[data-cy=filter-collapsibles] > :nth-child(1)')
       .invoke('text')
       .should('equal', 'Category');

--- a/src/lib/MetadataRenderer.js
+++ b/src/lib/MetadataRenderer.js
@@ -160,15 +160,15 @@ const MoreLink = ({ category, item }) => {
 
 const RenderAttribute = ({ item, attribute, languages }) => {
   if (textFormat(item, attribute, languages)) {
-    let value_style = attribute === "identifier" ? "identifier" : "";
+    let value_style = attribute.field === "identifier" ? "identifier" : "";
     return (
       <div className="collection-detail">
         <table>
           <tbody>
             <tr>
-              <td className="collection-detail-key">{labelAttr(attribute)}:</td>
+              <td className="collection-detail-key">{attribute.label}:</td>
               <td className={`collection-detail-value ${value_style}`}>
-                {textFormat(item, attribute, languages)}
+                {textFormat(item, attribute.field, languages)}
               </td>
             </tr>
           </tbody>
@@ -181,23 +181,23 @@ const RenderAttribute = ({ item, attribute, languages }) => {
 };
 
 const RenderAttrDetailed = ({ item, attribute, languages, type }) => {
-  if (textFormat(item, attribute, languages)) {
-    let value_style = attribute === "identifier" ? "identifier" : "";
+  if (textFormat(item, attribute.field, languages)) {
+    let value_style = attribute.field === "identifier" ? "identifier" : "";
     if (type === "table") {
       return (
         <tr>
-          <td className="collection-detail-key">{labelAttr(attribute)}</td>
+          <td className="collection-detail-key">{attribute.label}</td>
           <td className={`collection-detail-value ${value_style}`}>
-            {textFormat(item, attribute, languages)}
+            {textFormat(item, attribute.field, languages)}
           </td>
         </tr>
       );
     } else if (type === "grid") {
       return (
         <div className="collection-detail-entry">
-          <div className="collection-detail-key">{labelAttr(attribute)}</div>
+          <div className="collection-detail-key">{attribute.label}</div>
           <div className={`collection-detail-value ${value_style}`}>
-            {textFormat(item, attribute, languages)}
+            {textFormat(item, attribute.field, languages)}
           </div>
         </div>
       );

--- a/src/pages/archives/ArchivePage.js
+++ b/src/pages/archives/ArchivePage.js
@@ -17,29 +17,6 @@ import { searchArchives } from "../../graphql/queries";
 
 import "../../css/ArchivePage.css";
 
-const KeyArray = [
-  "identifier",
-  "belongs_to",
-  "bibliographic_citation",
-  "contributor",
-  "creator",
-  "custom_key",
-  "format",
-  "language",
-  "location",
-  "medium",
-  "resource_type",
-  "related_url",
-  "provenance",
-  "repository",
-  "reference",
-  "rights_holder",
-  "rights_statement",
-  "source",
-  "start_date",
-  "tags"
-];
-
 class ArchivePage extends Component {
   constructor(props) {
     super(props);
@@ -230,7 +207,9 @@ class ArchivePage extends Component {
                     <table>
                       <tbody>
                         <RenderItemsDetailed
-                          keyArray={KeyArray}
+                          keyArray={
+                            this.props.siteDetails.displayedAttributes.archive
+                          }
                           item={item}
                           languages={this.state.languages}
                         />

--- a/src/pages/collections/CollectionsShowLoader.js
+++ b/src/pages/collections/CollectionsShowLoader.js
@@ -37,7 +37,10 @@ class CollectionsShowLoader extends Component {
                 siteTitle={this.props.siteDetails.siteTitle}
                 pageTitle={collection.title}
               />
-              <CollectionsShowPage collection={collection} />
+              <CollectionsShowPage
+                collection={collection}
+                siteDetails={this.props.siteDetails}
+              />
             </>
           );
         }}

--- a/src/pages/collections/CollectionsShowPage.js
+++ b/src/pages/collections/CollectionsShowPage.js
@@ -222,20 +222,6 @@ class CollectionsShowPage extends Component {
   }
 
   render() {
-    const KeyArray = [
-      "size",
-      "creator",
-      "rights_statement",
-      "date",
-      "subject",
-      "language",
-      "identifier",
-      "bibliographic_citation",
-      "rights_holder",
-      "related_url",
-      "provenance",
-      "belongs_to"
-    ];
     const topLevelDesc =
       this.state.description || this.state.collection.description;
 
@@ -287,7 +273,9 @@ class CollectionsShowPage extends Component {
                 <div className="details-section-content-grid">
                   {this.subCollectionDescription()}
                   <RenderItemsDetailed
-                    keyArray={KeyArray}
+                    keyArray={
+                      this.props.siteDetails.displayedAttributes.collection
+                    }
                     item={this.state.collection}
                     languages={this.state.languages}
                     type="grid"


### PR DESCRIPTION
…d Archive for a specific application

**JIRA Ticket**: (https://webapps.es.vt.edu/jira/browse/LIBTD-1982) (:star:)

* Other Relevant Links (Meeting note, project page, related pull requests, etc.)
This PR will work depending on the merge of https://webapps.es.vt.edu/jira/browse/LIBTD-2311, which sets up the site configuration for metadata fields.

Amplify review: https://libtd-1982.djf1n0m63xbku.amplifyapp.com

# What does this Pull Request do? (:star:)
This PR provides customized metadata display for Collection and Archive objects in specific application by reading configurations from the site config file. The customizations include specific set of metadata fields to be displayed as well as the labelings for the metadata fields.

# What's the changes? (:star:)

* Adds tests for Collection and Archive metadata display page: archive_metadata_display.spec.js, collection_metadata_display.spec.js
* Refactors Collection and Archive metadata renderings through the config JSON file instead of static arrays: ArchivePage.js, CollectionsShowPage.js, CollectionsShowLoader.js
* Read field and label for each metadata field instead of defining the labelings:  MetadataRenderer.js

# How should this be tested?

* Wait until PR for https://webapps.es.vt.edu/jira/browse/LIBTD-2311 is merge
* Bring up the IAWA application, go to a Collection show page or an Archive show page, check if the metadata section is displayed as expected 
* Bring up the SWVA application, go to a Collection show page or an Archive show page, note that customizations for some of the metadata fields, e.g., "Belongs to" is replaced by "Is Part Of", "Related URL" is replaced by "Relation."

# Interested parties
Tag (@yinlinchen ) interested parties

(:star:) Required fields
