### PR TITLE
Refactor image grid to show images for collection and it's children

### DIFF
--- a/amplify/backend/api/collectionarchives/schema.graphql
+++ b/amplify/backend/api/collectionarchives/schema.graphql
@@ -70,6 +70,8 @@ type Collectionmap
     id: ID!
     collection_id: String!
     map_object: String!
+    create_date: String!
+    modified_date: String!
     collection: Collection @connection(name: "CollectionCollectionMap")
   }
 
@@ -111,6 +113,7 @@ type Archive implements Object
   visibility: Boolean!
   thumbnail_path: String
   manifest_url: String!
+  heirarchy_path: [String!]
   create_date: String!
   modified_date: String!
   collection: Collection @connection(name: "CollectionArchives")
@@ -235,6 +238,7 @@ input SearchableCollectionFilterInput {
   visibility: SearchableBooleanFilterInput
   thumbnail_path: SearchableStringFilterInput
   parent_collection: SearchableStringFilterInput
+  heirarchy_path: SearchableStringFilterInput
   create_date: SearchableStringFilterInput
   modified_date: SearchableStringFilterInput
   and: [SearchableCollectionFilterInput]
@@ -314,6 +318,7 @@ input SearchableArchiveFilterInput {
   manifest_url: SearchableStringFilterInput
   create_date: SearchableStringFilterInput
   modified_date: SearchableStringFilterInput
+  heirarchy_path: SearchableStringFilterInput
   and: [SearchableArchiveFilterInput]
   or: [SearchableArchiveFilterInput]
   not: SearchableArchiveFilterInput

--- a/amplify/backend/function/collectionTitleEdit/collectionTitleEdit-cloudformation-template.json
+++ b/amplify/backend/function/collectionTitleEdit/collectionTitleEdit-cloudformation-template.json
@@ -101,8 +101,8 @@
         "Layers": [],
         "Timeout": "25",
         "Code": {
-          "S3Bucket": "amplify-iawav2-dev-154638-deployment",
-          "S3Key": "amplify-builds/collectionTitleEdit-31517564454a5553726d-build.zip"
+          "S3Bucket": "amplify-iawav2-leearchive-132616-deployment",
+          "S3Key": "amplify-builds/collectionTitleEdit-6352715447494d614d2f-build.zip"
         }
       }
     },

--- a/amplify/backend/function/createCollectionHeirarchy/createCollectionHeirarchy-cloudformation-template.json
+++ b/amplify/backend/function/createCollectionHeirarchy/createCollectionHeirarchy-cloudformation-template.json
@@ -101,8 +101,8 @@
         "Layers": [],
         "Timeout": "25",
         "Code": {
-          "S3Bucket": "amplify-iawav2-dev-154638-deployment",
-          "S3Key": "amplify-builds/createCollectionHeirarchy-39645830474776496e54-build.zip"
+          "S3Bucket": "amplify-iawav2-leearchive-132616-deployment",
+          "S3Key": "amplify-builds/createCollectionHeirarchy-3562494e5541336a676f-build.zip"
         }
       }
     },

--- a/amplify/backend/function/createCollectionMap/createCollectionMap-cloudformation-template.json
+++ b/amplify/backend/function/createCollectionMap/createCollectionMap-cloudformation-template.json
@@ -134,8 +134,8 @@
         "Layers": [],
         "Timeout": "25",
         "Code": {
-          "S3Bucket": "amplify-iawav2-dev-154638-deployment",
-          "S3Key": "amplify-builds/createCollectionMap-386a5a457a4d50597a34-build.zip"
+          "S3Bucket": "amplify-iawav2-leearchive-132616-deployment",
+          "S3Key": "amplify-builds/createCollectionMap-61456956587458666648-build.zip"
         }
       }
     },

--- a/amplify/backend/function/iawav2658176f3PostConfirmation/iawav2658176f3PostConfirmation-cloudformation-template.json
+++ b/amplify/backend/function/iawav2658176f3PostConfirmation/iawav2658176f3PostConfirmation-cloudformation-template.json
@@ -101,7 +101,7 @@
         "Runtime": "nodejs10.x",
         "Timeout": "25",
         "Code": {
-          "S3Bucket": "amplify-iawav2-dev-154638-deployment",
+          "S3Bucket": "amplify-iawav2-leearchive-132616-deployment",
           "S3Key": "amplify-builds/iawav2658176f3PostConfirmation-39306338766f6d616c46-build.zip"
         }
       }

--- a/src/graphql/mutations.js
+++ b/src/graphql/mutations.js
@@ -35,6 +35,8 @@ export const createCollection = /* GraphQL */ `
         id
         collection_id
         map_object
+        create_date
+        modified_date
         collection {
           id
           title
@@ -63,7 +65,11 @@ export const createCollection = /* GraphQL */ `
           modified_date
           heirarchy_path
           collectionmap_id
+          createdAt
+          updatedAt
         }
+        createdAt
+        updatedAt
       }
       archives {
         items {
@@ -97,11 +103,16 @@ export const createCollection = /* GraphQL */ `
           visibility
           thumbnail_path
           manifest_url
+          heirarchy_path
           create_date
           modified_date
+          createdAt
+          updatedAt
         }
         nextToken
       }
+      createdAt
+      updatedAt
     }
   }
 `;
@@ -139,6 +150,8 @@ export const updateCollection = /* GraphQL */ `
         id
         collection_id
         map_object
+        create_date
+        modified_date
         collection {
           id
           title
@@ -167,7 +180,11 @@ export const updateCollection = /* GraphQL */ `
           modified_date
           heirarchy_path
           collectionmap_id
+          createdAt
+          updatedAt
         }
+        createdAt
+        updatedAt
       }
       archives {
         items {
@@ -201,11 +218,16 @@ export const updateCollection = /* GraphQL */ `
           visibility
           thumbnail_path
           manifest_url
+          heirarchy_path
           create_date
           modified_date
+          createdAt
+          updatedAt
         }
         nextToken
       }
+      createdAt
+      updatedAt
     }
   }
 `;
@@ -243,6 +265,8 @@ export const deleteCollection = /* GraphQL */ `
         id
         collection_id
         map_object
+        create_date
+        modified_date
         collection {
           id
           title
@@ -271,7 +295,11 @@ export const deleteCollection = /* GraphQL */ `
           modified_date
           heirarchy_path
           collectionmap_id
+          createdAt
+          updatedAt
         }
+        createdAt
+        updatedAt
       }
       archives {
         items {
@@ -305,11 +333,16 @@ export const deleteCollection = /* GraphQL */ `
           visibility
           thumbnail_path
           manifest_url
+          heirarchy_path
           create_date
           modified_date
+          createdAt
+          updatedAt
         }
         nextToken
       }
+      createdAt
+      updatedAt
     }
   }
 `;
@@ -319,6 +352,8 @@ export const createCollectionmap = /* GraphQL */ `
       id
       collection_id
       map_object
+      create_date
+      modified_date
       collection {
         id
         title
@@ -351,11 +386,19 @@ export const createCollectionmap = /* GraphQL */ `
           id
           collection_id
           map_object
+          create_date
+          modified_date
+          createdAt
+          updatedAt
         }
         archives {
           nextToken
         }
+        createdAt
+        updatedAt
       }
+      createdAt
+      updatedAt
     }
   }
 `;
@@ -365,6 +408,8 @@ export const updateCollectionmap = /* GraphQL */ `
       id
       collection_id
       map_object
+      create_date
+      modified_date
       collection {
         id
         title
@@ -397,11 +442,19 @@ export const updateCollectionmap = /* GraphQL */ `
           id
           collection_id
           map_object
+          create_date
+          modified_date
+          createdAt
+          updatedAt
         }
         archives {
           nextToken
         }
+        createdAt
+        updatedAt
       }
+      createdAt
+      updatedAt
     }
   }
 `;
@@ -411,6 +464,8 @@ export const deleteCollectionmap = /* GraphQL */ `
       id
       collection_id
       map_object
+      create_date
+      modified_date
       collection {
         id
         title
@@ -443,11 +498,19 @@ export const deleteCollectionmap = /* GraphQL */ `
           id
           collection_id
           map_object
+          create_date
+          modified_date
+          createdAt
+          updatedAt
         }
         archives {
           nextToken
         }
+        createdAt
+        updatedAt
       }
+      createdAt
+      updatedAt
     }
   }
 `;
@@ -484,6 +547,7 @@ export const createArchive = /* GraphQL */ `
       visibility
       thumbnail_path
       manifest_url
+      heirarchy_path
       create_date
       modified_date
       collection {
@@ -518,11 +582,19 @@ export const createArchive = /* GraphQL */ `
           id
           collection_id
           map_object
+          create_date
+          modified_date
+          createdAt
+          updatedAt
         }
         archives {
           nextToken
         }
+        createdAt
+        updatedAt
       }
+      createdAt
+      updatedAt
     }
   }
 `;
@@ -559,6 +631,7 @@ export const updateArchive = /* GraphQL */ `
       visibility
       thumbnail_path
       manifest_url
+      heirarchy_path
       create_date
       modified_date
       collection {
@@ -593,11 +666,19 @@ export const updateArchive = /* GraphQL */ `
           id
           collection_id
           map_object
+          create_date
+          modified_date
+          createdAt
+          updatedAt
         }
         archives {
           nextToken
         }
+        createdAt
+        updatedAt
       }
+      createdAt
+      updatedAt
     }
   }
 `;
@@ -634,6 +715,7 @@ export const deleteArchive = /* GraphQL */ `
       visibility
       thumbnail_path
       manifest_url
+      heirarchy_path
       create_date
       modified_date
       collection {
@@ -668,11 +750,19 @@ export const deleteArchive = /* GraphQL */ `
           id
           collection_id
           map_object
+          create_date
+          modified_date
+          createdAt
+          updatedAt
         }
         archives {
           nextToken
         }
+        createdAt
+        updatedAt
       }
+      createdAt
+      updatedAt
     }
   }
 `;

--- a/src/graphql/queries.js
+++ b/src/graphql/queries.js
@@ -51,10 +51,16 @@ export const searchObjects = /* GraphQL */ `
             id
             collection_id
             map_object
+            create_date
+            modified_date
+            createdAt
+            updatedAt
           }
           archives {
             nextToken
           }
+          createdAt
+          updatedAt
         }
         ... on Archive {
           tags
@@ -66,6 +72,7 @@ export const searchObjects = /* GraphQL */ `
           contributor
           item_category
           manifest_url
+          heirarchy_path
           collection {
             id
             title
@@ -94,7 +101,11 @@ export const searchObjects = /* GraphQL */ `
             modified_date
             heirarchy_path
             collectionmap_id
+            createdAt
+            updatedAt
           }
+          createdAt
+          updatedAt
         }
       }
       nextToken
@@ -149,10 +160,16 @@ export const fulltextCollections = /* GraphQL */ `
           id
           collection_id
           map_object
+          create_date
+          modified_date
+          createdAt
+          updatedAt
         }
         archives {
           nextToken
         }
+        createdAt
+        updatedAt
       }
       nextToken
       total
@@ -205,6 +222,7 @@ export const fulltextArchives = /* GraphQL */ `
         visibility
         thumbnail_path
         manifest_url
+        heirarchy_path
         create_date
         modified_date
         collection {
@@ -235,7 +253,11 @@ export const fulltextArchives = /* GraphQL */ `
           modified_date
           heirarchy_path
           collectionmap_id
+          createdAt
+          updatedAt
         }
+        createdAt
+        updatedAt
       }
       nextToken
       total
@@ -276,6 +298,8 @@ export const getCollection = /* GraphQL */ `
         id
         collection_id
         map_object
+        create_date
+        modified_date
         collection {
           id
           title
@@ -304,7 +328,11 @@ export const getCollection = /* GraphQL */ `
           modified_date
           heirarchy_path
           collectionmap_id
+          createdAt
+          updatedAt
         }
+        createdAt
+        updatedAt
       }
       archives {
         items {
@@ -338,11 +366,16 @@ export const getCollection = /* GraphQL */ `
           visibility
           thumbnail_path
           manifest_url
+          heirarchy_path
           create_date
           modified_date
+          createdAt
+          updatedAt
         }
         nextToken
       }
+      createdAt
+      updatedAt
     }
   }
 `;
@@ -385,10 +418,16 @@ export const listCollections = /* GraphQL */ `
           id
           collection_id
           map_object
+          create_date
+          modified_date
+          createdAt
+          updatedAt
         }
         archives {
           nextToken
         }
+        createdAt
+        updatedAt
       }
       nextToken
     }
@@ -400,6 +439,8 @@ export const getCollectionmap = /* GraphQL */ `
       id
       collection_id
       map_object
+      create_date
+      modified_date
       collection {
         id
         title
@@ -432,11 +473,19 @@ export const getCollectionmap = /* GraphQL */ `
           id
           collection_id
           map_object
+          create_date
+          modified_date
+          createdAt
+          updatedAt
         }
         archives {
           nextToken
         }
+        createdAt
+        updatedAt
       }
+      createdAt
+      updatedAt
     }
   }
 `;
@@ -451,6 +500,8 @@ export const listCollectionmaps = /* GraphQL */ `
         id
         collection_id
         map_object
+        create_date
+        modified_date
         collection {
           id
           title
@@ -479,7 +530,11 @@ export const listCollectionmaps = /* GraphQL */ `
           modified_date
           heirarchy_path
           collectionmap_id
+          createdAt
+          updatedAt
         }
+        createdAt
+        updatedAt
       }
       nextToken
     }
@@ -518,6 +573,7 @@ export const getArchive = /* GraphQL */ `
       visibility
       thumbnail_path
       manifest_url
+      heirarchy_path
       create_date
       modified_date
       collection {
@@ -552,11 +608,19 @@ export const getArchive = /* GraphQL */ `
           id
           collection_id
           map_object
+          create_date
+          modified_date
+          createdAt
+          updatedAt
         }
         archives {
           nextToken
         }
+        createdAt
+        updatedAt
       }
+      createdAt
+      updatedAt
     }
   }
 `;
@@ -598,6 +662,7 @@ export const listArchives = /* GraphQL */ `
         visibility
         thumbnail_path
         manifest_url
+        heirarchy_path
         create_date
         modified_date
         collection {
@@ -628,7 +693,11 @@ export const listArchives = /* GraphQL */ `
           modified_date
           heirarchy_path
           collectionmap_id
+          createdAt
+          updatedAt
         }
+        createdAt
+        updatedAt
       }
       nextToken
     }
@@ -681,10 +750,16 @@ export const collectionByIdentifier = /* GraphQL */ `
           id
           collection_id
           map_object
+          create_date
+          modified_date
+          createdAt
+          updatedAt
         }
         archives {
           nextToken
         }
+        createdAt
+        updatedAt
       }
       nextToken
     }
@@ -736,6 +811,7 @@ export const archiveByIdentifier = /* GraphQL */ `
         visibility
         thumbnail_path
         manifest_url
+        heirarchy_path
         create_date
         modified_date
         collection {
@@ -766,7 +842,11 @@ export const archiveByIdentifier = /* GraphQL */ `
           modified_date
           heirarchy_path
           collectionmap_id
+          createdAt
+          updatedAt
         }
+        createdAt
+        updatedAt
       }
       nextToken
     }
@@ -817,10 +897,16 @@ export const searchCollections = /* GraphQL */ `
           id
           collection_id
           map_object
+          create_date
+          modified_date
+          createdAt
+          updatedAt
         }
         archives {
           nextToken
         }
+        createdAt
+        updatedAt
       }
       nextToken
       total
@@ -844,6 +930,8 @@ export const searchCollectionmaps = /* GraphQL */ `
         id
         collection_id
         map_object
+        create_date
+        modified_date
         collection {
           id
           title
@@ -872,7 +960,11 @@ export const searchCollectionmaps = /* GraphQL */ `
           modified_date
           heirarchy_path
           collectionmap_id
+          createdAt
+          updatedAt
         }
+        createdAt
+        updatedAt
       }
       nextToken
       total
@@ -923,6 +1015,7 @@ export const searchArchives = /* GraphQL */ `
         visibility
         thumbnail_path
         manifest_url
+        heirarchy_path
         create_date
         modified_date
         collection {
@@ -953,7 +1046,11 @@ export const searchArchives = /* GraphQL */ `
           modified_date
           heirarchy_path
           collectionmap_id
+          createdAt
+          updatedAt
         }
+        createdAt
+        updatedAt
       }
       nextToken
       total

--- a/src/graphql/schema.json
+++ b/src/graphql/schema.json
@@ -2524,6 +2524,38 @@
               },
               "isDeprecated": false,
               "deprecationReason": null
+            },
+            {
+              "name": "createdAt",
+              "description": null,
+              "args": [],
+              "type": {
+                "kind": "NON_NULL",
+                "name": null,
+                "ofType": {
+                  "kind": "SCALAR",
+                  "name": "AWSDateTime",
+                  "ofType": null
+                }
+              },
+              "isDeprecated": false,
+              "deprecationReason": null
+            },
+            {
+              "name": "updatedAt",
+              "description": null,
+              "args": [],
+              "type": {
+                "kind": "NON_NULL",
+                "name": null,
+                "ofType": {
+                  "kind": "SCALAR",
+                  "name": "AWSDateTime",
+                  "ofType": null
+                }
+              },
+              "isDeprecated": false,
+              "deprecationReason": null
             }
           ],
           "inputFields": null,
@@ -2591,6 +2623,38 @@
               "deprecationReason": null
             },
             {
+              "name": "create_date",
+              "description": null,
+              "args": [],
+              "type": {
+                "kind": "NON_NULL",
+                "name": null,
+                "ofType": {
+                  "kind": "SCALAR",
+                  "name": "String",
+                  "ofType": null
+                }
+              },
+              "isDeprecated": false,
+              "deprecationReason": null
+            },
+            {
+              "name": "modified_date",
+              "description": null,
+              "args": [],
+              "type": {
+                "kind": "NON_NULL",
+                "name": null,
+                "ofType": {
+                  "kind": "SCALAR",
+                  "name": "String",
+                  "ofType": null
+                }
+              },
+              "isDeprecated": false,
+              "deprecationReason": null
+            },
+            {
               "name": "collection",
               "description": null,
               "args": [],
@@ -2601,10 +2665,52 @@
               },
               "isDeprecated": false,
               "deprecationReason": null
+            },
+            {
+              "name": "createdAt",
+              "description": null,
+              "args": [],
+              "type": {
+                "kind": "NON_NULL",
+                "name": null,
+                "ofType": {
+                  "kind": "SCALAR",
+                  "name": "AWSDateTime",
+                  "ofType": null
+                }
+              },
+              "isDeprecated": false,
+              "deprecationReason": null
+            },
+            {
+              "name": "updatedAt",
+              "description": null,
+              "args": [],
+              "type": {
+                "kind": "NON_NULL",
+                "name": null,
+                "ofType": {
+                  "kind": "SCALAR",
+                  "name": "AWSDateTime",
+                  "ofType": null
+                }
+              },
+              "isDeprecated": false,
+              "deprecationReason": null
             }
           ],
           "inputFields": null,
           "interfaces": [],
+          "enumValues": null,
+          "possibleTypes": null
+        },
+        {
+          "kind": "SCALAR",
+          "name": "AWSDateTime",
+          "description": "The `AWSDateTime` scalar type provided by AWS AppSync, represents a valid ***extended*** [ISO 8601 DateTime](https://en.wikipedia.org/wiki/ISO_8601#Combined_date_and_time_representations) string. In other words, this scalar type accepts datetime strings of the form `YYYY-MM-DDThh:mm:ss.SSSZ`.  The scalar can also accept \"negative years\" of the form `-YYYY` which correspond to years before `0000`. For example, \"**-2017-01-01T00:00Z**\" and \"**-9999-01-01T00:00Z**\" are both valid datetime strings.  The field after the two digit seconds field is a nanoseconds field. It can accept between 1 and 9 digits. So, for example, \"**1970-01-01T12:00:00.2Z**\", \"**1970-01-01T12:00:00.277Z**\" and \"**1970-01-01T12:00:00.123456789Z**\" are all valid datetime strings.  The seconds and nanoseconds fields are optional (the seconds field must be specified if the nanoseconds field is to be used).  The [time zone offset](https://en.wikipedia.org/wiki/ISO_8601#Time_zone_designators) is compulsory for this scalar. The time zone offset must either be `Z` (representing the UTC time zone) or be in the format `±hh:mm:ss`. The seconds field in the timezone offset will be considered valid even though it is not part of the ISO 8601 standard.",
+          "fields": null,
+          "inputFields": null,
+          "interfaces": null,
           "enumValues": null,
           "possibleTypes": null
         },
@@ -3157,6 +3263,26 @@
               "deprecationReason": null
             },
             {
+              "name": "heirarchy_path",
+              "description": null,
+              "args": [],
+              "type": {
+                "kind": "LIST",
+                "name": null,
+                "ofType": {
+                  "kind": "NON_NULL",
+                  "name": null,
+                  "ofType": {
+                    "kind": "SCALAR",
+                    "name": "String",
+                    "ofType": null
+                  }
+                }
+              },
+              "isDeprecated": false,
+              "deprecationReason": null
+            },
+            {
               "name": "create_date",
               "description": null,
               "args": [],
@@ -3196,6 +3322,38 @@
                 "kind": "OBJECT",
                 "name": "Collection",
                 "ofType": null
+              },
+              "isDeprecated": false,
+              "deprecationReason": null
+            },
+            {
+              "name": "createdAt",
+              "description": null,
+              "args": [],
+              "type": {
+                "kind": "NON_NULL",
+                "name": null,
+                "ofType": {
+                  "kind": "SCALAR",
+                  "name": "AWSDateTime",
+                  "ofType": null
+                }
+              },
+              "isDeprecated": false,
+              "deprecationReason": null
+            },
+            {
+              "name": "updatedAt",
+              "description": null,
+              "args": [],
+              "type": {
+                "kind": "NON_NULL",
+                "name": null,
+                "ofType": {
+                  "kind": "SCALAR",
+                  "name": "AWSDateTime",
+                  "ofType": null
+                }
               },
               "isDeprecated": false,
               "deprecationReason": null
@@ -3510,6 +3668,16 @@
             },
             {
               "name": "manifest_url",
+              "description": null,
+              "type": {
+                "kind": "INPUT_OBJECT",
+                "name": "ModelStringFilterInput",
+                "ofType": null
+              },
+              "defaultValue": null
+            },
+            {
+              "name": "heirarchy_path",
               "description": null,
               "type": {
                 "kind": "INPUT_OBJECT",
@@ -4093,6 +4261,16 @@
             },
             {
               "name": "parent_collection",
+              "description": null,
+              "type": {
+                "kind": "INPUT_OBJECT",
+                "name": "SearchableStringFilterInput",
+                "ofType": null
+              },
+              "defaultValue": null
+            },
+            {
+              "name": "heirarchy_path",
               "description": null,
               "type": {
                 "kind": "INPUT_OBJECT",
@@ -4725,6 +4903,16 @@
             },
             {
               "name": "modified_date",
+              "description": null,
+              "type": {
+                "kind": "INPUT_OBJECT",
+                "name": "SearchableStringFilterInput",
+                "ofType": null
+              },
+              "defaultValue": null
+            },
+            {
+              "name": "heirarchy_path",
               "description": null,
               "type": {
                 "kind": "INPUT_OBJECT",
@@ -5444,6 +5632,26 @@
               "defaultValue": null
             },
             {
+              "name": "create_date",
+              "description": null,
+              "type": {
+                "kind": "INPUT_OBJECT",
+                "name": "ModelStringFilterInput",
+                "ofType": null
+              },
+              "defaultValue": null
+            },
+            {
+              "name": "modified_date",
+              "description": null,
+              "type": {
+                "kind": "INPUT_OBJECT",
+                "name": "ModelStringFilterInput",
+                "ofType": null
+              },
+              "defaultValue": null
+            },
+            {
               "name": "and",
               "description": null,
               "type": {
@@ -5574,6 +5782,26 @@
               "defaultValue": null
             },
             {
+              "name": "create_date",
+              "description": null,
+              "type": {
+                "kind": "INPUT_OBJECT",
+                "name": "SearchableStringFilterInput",
+                "ofType": null
+              },
+              "defaultValue": null
+            },
+            {
+              "name": "modified_date",
+              "description": null,
+              "type": {
+                "kind": "INPUT_OBJECT",
+                "name": "SearchableStringFilterInput",
+                "ofType": null
+              },
+              "defaultValue": null
+            },
+            {
               "name": "and",
               "description": null,
               "type": {
@@ -5669,6 +5897,18 @@
             },
             {
               "name": "map_object",
+              "description": null,
+              "isDeprecated": false,
+              "deprecationReason": null
+            },
+            {
+              "name": "create_date",
+              "description": null,
+              "isDeprecated": false,
+              "deprecationReason": null
+            },
+            {
+              "name": "modified_date",
               "description": null,
               "isDeprecated": false,
               "deprecationReason": null
@@ -6766,6 +7006,34 @@
               "defaultValue": null
             },
             {
+              "name": "create_date",
+              "description": null,
+              "type": {
+                "kind": "NON_NULL",
+                "name": null,
+                "ofType": {
+                  "kind": "SCALAR",
+                  "name": "String",
+                  "ofType": null
+                }
+              },
+              "defaultValue": null
+            },
+            {
+              "name": "modified_date",
+              "description": null,
+              "type": {
+                "kind": "NON_NULL",
+                "name": null,
+                "ofType": {
+                  "kind": "SCALAR",
+                  "name": "String",
+                  "ofType": null
+                }
+              },
+              "defaultValue": null
+            },
+            {
               "name": "collectionmapCollectionId",
               "description": null,
               "type": {
@@ -6812,6 +7080,26 @@
             },
             {
               "name": "map_object",
+              "description": null,
+              "type": {
+                "kind": "SCALAR",
+                "name": "String",
+                "ofType": null
+              },
+              "defaultValue": null
+            },
+            {
+              "name": "create_date",
+              "description": null,
+              "type": {
+                "kind": "SCALAR",
+                "name": "String",
+                "ofType": null
+              },
+              "defaultValue": null
+            },
+            {
+              "name": "modified_date",
               "description": null,
               "type": {
                 "kind": "SCALAR",
@@ -7303,6 +7591,24 @@
               "defaultValue": null
             },
             {
+              "name": "heirarchy_path",
+              "description": null,
+              "type": {
+                "kind": "LIST",
+                "name": null,
+                "ofType": {
+                  "kind": "NON_NULL",
+                  "name": null,
+                  "ofType": {
+                    "kind": "SCALAR",
+                    "name": "String",
+                    "ofType": null
+                  }
+                }
+              },
+              "defaultValue": null
+            },
+            {
               "name": "create_date",
               "description": null,
               "type": {
@@ -7776,6 +8082,24 @@
               "defaultValue": null
             },
             {
+              "name": "heirarchy_path",
+              "description": null,
+              "type": {
+                "kind": "LIST",
+                "name": null,
+                "ofType": {
+                  "kind": "NON_NULL",
+                  "name": null,
+                  "ofType": {
+                    "kind": "SCALAR",
+                    "name": "String",
+                    "ofType": null
+                  }
+                }
+              },
+              "defaultValue": null
+            },
+            {
               "name": "create_date",
               "description": null,
               "type": {
@@ -7952,101 +8276,6 @@
         },
         {
           "kind": "INPUT_OBJECT",
-          "name": "SearchableFloatFilterInput",
-          "description": null,
-          "fields": null,
-          "inputFields": [
-            {
-              "name": "ne",
-              "description": null,
-              "type": {
-                "kind": "SCALAR",
-                "name": "Float",
-                "ofType": null
-              },
-              "defaultValue": null
-            },
-            {
-              "name": "gt",
-              "description": null,
-              "type": {
-                "kind": "SCALAR",
-                "name": "Float",
-                "ofType": null
-              },
-              "defaultValue": null
-            },
-            {
-              "name": "lt",
-              "description": null,
-              "type": {
-                "kind": "SCALAR",
-                "name": "Float",
-                "ofType": null
-              },
-              "defaultValue": null
-            },
-            {
-              "name": "gte",
-              "description": null,
-              "type": {
-                "kind": "SCALAR",
-                "name": "Float",
-                "ofType": null
-              },
-              "defaultValue": null
-            },
-            {
-              "name": "lte",
-              "description": null,
-              "type": {
-                "kind": "SCALAR",
-                "name": "Float",
-                "ofType": null
-              },
-              "defaultValue": null
-            },
-            {
-              "name": "eq",
-              "description": null,
-              "type": {
-                "kind": "SCALAR",
-                "name": "Float",
-                "ofType": null
-              },
-              "defaultValue": null
-            },
-            {
-              "name": "range",
-              "description": null,
-              "type": {
-                "kind": "LIST",
-                "name": null,
-                "ofType": {
-                  "kind": "SCALAR",
-                  "name": "Float",
-                  "ofType": null
-                }
-              },
-              "defaultValue": null
-            }
-          ],
-          "interfaces": null,
-          "enumValues": null,
-          "possibleTypes": null
-        },
-        {
-          "kind": "SCALAR",
-          "name": "Float",
-          "description": "Built-in Float",
-          "fields": null,
-          "inputFields": null,
-          "interfaces": null,
-          "enumValues": null,
-          "possibleTypes": null
-        },
-        {
-          "kind": "INPUT_OBJECT",
           "name": "ModelIntFilterInput",
           "description": null,
           "fields": null,
@@ -8126,6 +8355,101 @@
               "defaultValue": null
             }
           ],
+          "interfaces": null,
+          "enumValues": null,
+          "possibleTypes": null
+        },
+        {
+          "kind": "INPUT_OBJECT",
+          "name": "ModelFloatFilterInput",
+          "description": null,
+          "fields": null,
+          "inputFields": [
+            {
+              "name": "ne",
+              "description": null,
+              "type": {
+                "kind": "SCALAR",
+                "name": "Float",
+                "ofType": null
+              },
+              "defaultValue": null
+            },
+            {
+              "name": "eq",
+              "description": null,
+              "type": {
+                "kind": "SCALAR",
+                "name": "Float",
+                "ofType": null
+              },
+              "defaultValue": null
+            },
+            {
+              "name": "le",
+              "description": null,
+              "type": {
+                "kind": "SCALAR",
+                "name": "Float",
+                "ofType": null
+              },
+              "defaultValue": null
+            },
+            {
+              "name": "lt",
+              "description": null,
+              "type": {
+                "kind": "SCALAR",
+                "name": "Float",
+                "ofType": null
+              },
+              "defaultValue": null
+            },
+            {
+              "name": "ge",
+              "description": null,
+              "type": {
+                "kind": "SCALAR",
+                "name": "Float",
+                "ofType": null
+              },
+              "defaultValue": null
+            },
+            {
+              "name": "gt",
+              "description": null,
+              "type": {
+                "kind": "SCALAR",
+                "name": "Float",
+                "ofType": null
+              },
+              "defaultValue": null
+            },
+            {
+              "name": "between",
+              "description": null,
+              "type": {
+                "kind": "LIST",
+                "name": null,
+                "ofType": {
+                  "kind": "SCALAR",
+                  "name": "Float",
+                  "ofType": null
+                }
+              },
+              "defaultValue": null
+            }
+          ],
+          "interfaces": null,
+          "enumValues": null,
+          "possibleTypes": null
+        },
+        {
+          "kind": "SCALAR",
+          "name": "Float",
+          "description": "Built-in Float",
+          "fields": null,
+          "inputFields": null,
           "interfaces": null,
           "enumValues": null,
           "possibleTypes": null
@@ -8217,52 +8541,12 @@
         },
         {
           "kind": "INPUT_OBJECT",
-          "name": "ModelFloatFilterInput",
+          "name": "SearchableFloatFilterInput",
           "description": null,
           "fields": null,
           "inputFields": [
             {
               "name": "ne",
-              "description": null,
-              "type": {
-                "kind": "SCALAR",
-                "name": "Float",
-                "ofType": null
-              },
-              "defaultValue": null
-            },
-            {
-              "name": "eq",
-              "description": null,
-              "type": {
-                "kind": "SCALAR",
-                "name": "Float",
-                "ofType": null
-              },
-              "defaultValue": null
-            },
-            {
-              "name": "le",
-              "description": null,
-              "type": {
-                "kind": "SCALAR",
-                "name": "Float",
-                "ofType": null
-              },
-              "defaultValue": null
-            },
-            {
-              "name": "lt",
-              "description": null,
-              "type": {
-                "kind": "SCALAR",
-                "name": "Float",
-                "ofType": null
-              },
-              "defaultValue": null
-            },
-            {
-              "name": "ge",
               "description": null,
               "type": {
                 "kind": "SCALAR",
@@ -8282,7 +8566,47 @@
               "defaultValue": null
             },
             {
-              "name": "between",
+              "name": "lt",
+              "description": null,
+              "type": {
+                "kind": "SCALAR",
+                "name": "Float",
+                "ofType": null
+              },
+              "defaultValue": null
+            },
+            {
+              "name": "gte",
+              "description": null,
+              "type": {
+                "kind": "SCALAR",
+                "name": "Float",
+                "ofType": null
+              },
+              "defaultValue": null
+            },
+            {
+              "name": "lte",
+              "description": null,
+              "type": {
+                "kind": "SCALAR",
+                "name": "Float",
+                "ofType": null
+              },
+              "defaultValue": null
+            },
+            {
+              "name": "eq",
+              "description": null,
+              "type": {
+                "kind": "SCALAR",
+                "name": "Float",
+                "ofType": null
+              },
+              "defaultValue": null
+            },
+            {
+              "name": "range",
               "description": null,
               "type": {
                 "kind": "LIST",
@@ -9172,6 +9496,15 @@
           "onField": true
         },
         {
+          "name": "aws_iam",
+          "description": "Tells the service this field/object has access authorized by sigv4 signing.",
+          "locations": ["OBJECT", "FIELD_DEFINITION"],
+          "args": [],
+          "onOperation": false,
+          "onFragment": false,
+          "onField": false
+        },
+        {
           "name": "aws_subscribe",
           "description": "Tells the service which mutation triggers this subscription.",
           "locations": ["FIELD_DEFINITION"],
@@ -9196,26 +9529,8 @@
           "onField": false
         },
         {
-          "name": "aws_api_key",
-          "description": "Tells the service this field/object has access authorized by an API key.",
-          "locations": ["OBJECT", "FIELD_DEFINITION"],
-          "args": [],
-          "onOperation": false,
-          "onFragment": false,
-          "onField": false
-        },
-        {
           "name": "aws_oidc",
           "description": "Tells the service this field/object has access authorized by an OIDC token.",
-          "locations": ["OBJECT", "FIELD_DEFINITION"],
-          "args": [],
-          "onOperation": false,
-          "onFragment": false,
-          "onField": false
-        },
-        {
-          "name": "aws_iam",
-          "description": "Tells the service this field/object has access authorized by sigv4 signing.",
           "locations": ["OBJECT", "FIELD_DEFINITION"],
           "args": [],
           "onOperation": false,
@@ -9236,30 +9551,6 @@
                 "ofType": null
               },
               "defaultValue": "\"No longer supported\""
-            }
-          ],
-          "onOperation": false,
-          "onFragment": false,
-          "onField": false
-        },
-        {
-          "name": "aws_publish",
-          "description": "Tells the service which subscriptions will be published to when this mutation is called. This directive is deprecated use @aws_susbscribe directive instead.",
-          "locations": ["FIELD_DEFINITION"],
-          "args": [
-            {
-              "name": "subscriptions",
-              "description": "List of subscriptions which will be published to when this mutation is called.",
-              "type": {
-                "kind": "LIST",
-                "name": null,
-                "ofType": {
-                  "kind": "SCALAR",
-                  "name": "String",
-                  "ofType": null
-                }
-              },
-              "defaultValue": null
             }
           ],
           "onOperation": false,
@@ -9310,6 +9601,39 @@
               "defaultValue": null
             }
           ],
+          "onOperation": false,
+          "onFragment": false,
+          "onField": false
+        },
+        {
+          "name": "aws_publish",
+          "description": "Tells the service which subscriptions will be published to when this mutation is called. This directive is deprecated use @aws_susbscribe directive instead.",
+          "locations": ["FIELD_DEFINITION"],
+          "args": [
+            {
+              "name": "subscriptions",
+              "description": "List of subscriptions which will be published to when this mutation is called.",
+              "type": {
+                "kind": "LIST",
+                "name": null,
+                "ofType": {
+                  "kind": "SCALAR",
+                  "name": "String",
+                  "ofType": null
+                }
+              },
+              "defaultValue": null
+            }
+          ],
+          "onOperation": false,
+          "onFragment": false,
+          "onField": false
+        },
+        {
+          "name": "aws_api_key",
+          "description": "Tells the service this field/object has access authorized by an API key.",
+          "locations": ["OBJECT", "FIELD_DEFINITION"],
+          "args": [],
           "onOperation": false,
           "onFragment": false,
           "onField": false

--- a/src/graphql/subscriptions.js
+++ b/src/graphql/subscriptions.js
@@ -35,6 +35,8 @@ export const onCreateCollection = /* GraphQL */ `
         id
         collection_id
         map_object
+        create_date
+        modified_date
         collection {
           id
           title
@@ -63,7 +65,11 @@ export const onCreateCollection = /* GraphQL */ `
           modified_date
           heirarchy_path
           collectionmap_id
+          createdAt
+          updatedAt
         }
+        createdAt
+        updatedAt
       }
       archives {
         items {
@@ -97,11 +103,16 @@ export const onCreateCollection = /* GraphQL */ `
           visibility
           thumbnail_path
           manifest_url
+          heirarchy_path
           create_date
           modified_date
+          createdAt
+          updatedAt
         }
         nextToken
       }
+      createdAt
+      updatedAt
     }
   }
 `;
@@ -139,6 +150,8 @@ export const onUpdateCollection = /* GraphQL */ `
         id
         collection_id
         map_object
+        create_date
+        modified_date
         collection {
           id
           title
@@ -167,7 +180,11 @@ export const onUpdateCollection = /* GraphQL */ `
           modified_date
           heirarchy_path
           collectionmap_id
+          createdAt
+          updatedAt
         }
+        createdAt
+        updatedAt
       }
       archives {
         items {
@@ -201,11 +218,16 @@ export const onUpdateCollection = /* GraphQL */ `
           visibility
           thumbnail_path
           manifest_url
+          heirarchy_path
           create_date
           modified_date
+          createdAt
+          updatedAt
         }
         nextToken
       }
+      createdAt
+      updatedAt
     }
   }
 `;
@@ -243,6 +265,8 @@ export const onDeleteCollection = /* GraphQL */ `
         id
         collection_id
         map_object
+        create_date
+        modified_date
         collection {
           id
           title
@@ -271,7 +295,11 @@ export const onDeleteCollection = /* GraphQL */ `
           modified_date
           heirarchy_path
           collectionmap_id
+          createdAt
+          updatedAt
         }
+        createdAt
+        updatedAt
       }
       archives {
         items {
@@ -305,11 +333,16 @@ export const onDeleteCollection = /* GraphQL */ `
           visibility
           thumbnail_path
           manifest_url
+          heirarchy_path
           create_date
           modified_date
+          createdAt
+          updatedAt
         }
         nextToken
       }
+      createdAt
+      updatedAt
     }
   }
 `;
@@ -319,6 +352,8 @@ export const onCreateCollectionmap = /* GraphQL */ `
       id
       collection_id
       map_object
+      create_date
+      modified_date
       collection {
         id
         title
@@ -351,11 +386,19 @@ export const onCreateCollectionmap = /* GraphQL */ `
           id
           collection_id
           map_object
+          create_date
+          modified_date
+          createdAt
+          updatedAt
         }
         archives {
           nextToken
         }
+        createdAt
+        updatedAt
       }
+      createdAt
+      updatedAt
     }
   }
 `;
@@ -365,6 +408,8 @@ export const onUpdateCollectionmap = /* GraphQL */ `
       id
       collection_id
       map_object
+      create_date
+      modified_date
       collection {
         id
         title
@@ -397,11 +442,19 @@ export const onUpdateCollectionmap = /* GraphQL */ `
           id
           collection_id
           map_object
+          create_date
+          modified_date
+          createdAt
+          updatedAt
         }
         archives {
           nextToken
         }
+        createdAt
+        updatedAt
       }
+      createdAt
+      updatedAt
     }
   }
 `;
@@ -411,6 +464,8 @@ export const onDeleteCollectionmap = /* GraphQL */ `
       id
       collection_id
       map_object
+      create_date
+      modified_date
       collection {
         id
         title
@@ -443,11 +498,19 @@ export const onDeleteCollectionmap = /* GraphQL */ `
           id
           collection_id
           map_object
+          create_date
+          modified_date
+          createdAt
+          updatedAt
         }
         archives {
           nextToken
         }
+        createdAt
+        updatedAt
       }
+      createdAt
+      updatedAt
     }
   }
 `;
@@ -484,6 +547,7 @@ export const onCreateArchive = /* GraphQL */ `
       visibility
       thumbnail_path
       manifest_url
+      heirarchy_path
       create_date
       modified_date
       collection {
@@ -518,11 +582,19 @@ export const onCreateArchive = /* GraphQL */ `
           id
           collection_id
           map_object
+          create_date
+          modified_date
+          createdAt
+          updatedAt
         }
         archives {
           nextToken
         }
+        createdAt
+        updatedAt
       }
+      createdAt
+      updatedAt
     }
   }
 `;
@@ -559,6 +631,7 @@ export const onUpdateArchive = /* GraphQL */ `
       visibility
       thumbnail_path
       manifest_url
+      heirarchy_path
       create_date
       modified_date
       collection {
@@ -593,11 +666,19 @@ export const onUpdateArchive = /* GraphQL */ `
           id
           collection_id
           map_object
+          create_date
+          modified_date
+          createdAt
+          updatedAt
         }
         archives {
           nextToken
         }
+        createdAt
+        updatedAt
       }
+      createdAt
+      updatedAt
     }
   }
 `;
@@ -634,6 +715,7 @@ export const onDeleteArchive = /* GraphQL */ `
       visibility
       thumbnail_path
       manifest_url
+      heirarchy_path
       create_date
       modified_date
       collection {
@@ -668,11 +750,19 @@ export const onDeleteArchive = /* GraphQL */ `
           id
           collection_id
           map_object
+          create_date
+          modified_date
+          createdAt
+          updatedAt
         }
         archives {
           nextToken
         }
+        createdAt
+        updatedAt
       }
+      createdAt
+      updatedAt
     }
   }
 `;

--- a/src/pages/collections/CollectionItemsLoader.js
+++ b/src/pages/collections/CollectionItemsLoader.js
@@ -12,7 +12,7 @@ const GetCollectionItems = `query SearchCollectionItems(
   ) {
   searchArchives(
     filter: { 
-      parent_collection: { eq: $parent_id }
+      heirarchy_path: { eq: $parent_id }
     },
     sort: {
       field: identifier,


### PR DESCRIPTION
**Refactor image grid to show images for collection and it's children.**
* * *

**JIRA Ticket**: (https://webapps.es.vt.edu/jira/browse/LIBTD-2255) (:star:)

* Other Relevant Links (Meeting note, project page, related pull requests, etc.)

# What does this Pull Request do? (:star:)
Refactor image grid to show images for collection and it's children.

# What's the changes? (:star:)
* Adds `hierarchy_path` field to Archive table so that each archive will know all of the collections that it belongs to
* Updates query in CollectionItemsLoader.js to include the archives of a collections children as well.


# How should this be tested?
* Changes can be viewed here: https://libtd-2255.djf1n0m63xbku.amplifyapp.com/
* Visit several collection show pages and check that image grid contains archives that belong to the current collection OR any of it's children.

# Additional Notes:
* branch: `LIBTD-2255`
* After this PR is merged and the data model changes are pushed to the dev amplify environment, I think it would probably be easiest to use the DDBtoDDB tool to copy all three tables over from the `leearchive` environment to the `dev` environment.
* In the future when new items are added, the `archiveCollectionHeirarchy` lambda function needs to be run.

# Interested parties
@yinlinchen 

(:star:) Required fields
