### PR TITLE
refactor collection hierarchy sort

### DIFF
--- a/src/pages/collections/SubCollectionsLoader.js
+++ b/src/pages/collections/SubCollectionsLoader.js
@@ -80,9 +80,17 @@ class SubCollectionsLoader extends Component {
   }
 
   sortChildren(children) {
-    return children.sort((a, b) =>
-      a.name.toUpperCase() > b.name.toUpperCase() ? 1 : -1
-    );
+    return children.sort(function(a, b) {
+      let aArray = a.name.split(" ");
+      let bArray = b.name.split(" ");
+      let aNum = parseInt(aArray[aArray.length - 1]);
+      let bNum = parseInt(bArray[bArray.length - 1]);
+      if (!isNaN(aNum) && !isNaN(bNum)) {
+        return aNum > bNum ? 1 : -1;
+      } else {
+        return a.name.toUpperCase() > b.name.toUpperCase() ? 1 : -1;
+      }
+    });
   }
 
   buildLabel(node) {


### PR DESCRIPTION
**If the string ends in a number parse it and order by that.**
* * *

**JIRA Ticket**: (https://webapps.es.vt.edu/jira/browse/LIBTD-2325) (:star:)

* Other Relevant Links (Meeting note, project page, related pull requests, etc.)

# What does this Pull Request do? (:star:)
Sorts collections by ending number if present.

# What's the changes? (:star:)
* Checks if collection titles end with a number that that can be parsed
* Sorts by those numbers if they exist
* Sorts alphabetically otherwise

# How should this be tested?
* Visit IAWA collection show pages
* Check in hierarchy tree if the numbers are sorted correctly (1,2,3) instead of (1,10,11)

# Additional Notes:
* branch: `LIBTD-2325`

# Interested parties
@yinlinchen 

(:star:) Required fields
