### PR TITLE
Accessibility fixes for WCAG 2.0

### DIFF
--- a/cypress/integration/category_select_checkbox.spec.js
+++ b/cypress/integration/category_select_checkbox.spec.js
@@ -18,7 +18,7 @@ describe('Object category options are mutually exclusive facet checkboxes', () =
       .should('contain', 'category=collection');
     cy.get("[data-cy=search-filter-field-value-pairs]")
       .invoke("text")
-      .should("contain", "category › collection");
+      .should("contain", "category", "collection");
   });
 
   it('prevents from selecting more than one categories(checkboxes)', () => {
@@ -32,7 +32,7 @@ describe('Object category options are mutually exclusive facet checkboxes', () =
         .should('not.contain', 'category=collection');
     cy.get("[data-cy=search-filter-field-value-pairs]")
       .invoke("text")
-      .should("contain", "category › archive")
-      .should("not.contain", "category › collection");
+      .should("contain", "category", "archive")
+      .should("not.contain", "collection");
   });
 });

--- a/cypress/integration/multi_select_checkbox_spec.js
+++ b/cypress/integration/multi_select_checkbox_spec.js
@@ -15,7 +15,7 @@ describe('Multi-selectable checkboxes correspond to mulitple facet values of a f
       .should('contain', 'medium=Colored+pencil');
     cy.get('[data-cy=search-filter-field-value-pairs]')
       .invoke('text')
-      .should('contain', 'medium › Colored pencil')
+      .should('contain', 'medium', 'Colored pencil')
   })
 
   it('allows to select more than one checkboxes', () => {
@@ -33,7 +33,7 @@ describe('Multi-selectable checkboxes correspond to mulitple facet values of a f
       .and('contain', 'medium=Marker+pen')
     cy.get('[data-cy=search-filter-field-value-pairs]')
       .invoke('text')
-      .should('contain', 'medium › Colored pencil')
-      .and('contain', 'medium › Marker pen')
+      .should('contain', 'medium', 'Colored pencil')
+      .and('contain', 'medium', 'Marker pen')
   })
 })

--- a/src/components/Collapsible.js
+++ b/src/components/Collapsible.js
@@ -171,7 +171,11 @@ class Collapsible extends Component {
                 .slice(0, this.partialListLength())
                 .map(value => (
                   <Checkbox
-                    label={`${labelAttr(value["label"])} (${value["count"]})`}
+                    label={`${labelAttr(
+                      value["label"],
+                      this.props.filterField,
+                      this.props.languages
+                    )} (${value["count"]})`}
                     name={value["label"]}
                     selected={value["selected"]}
                     onCheckboxChange={this.handleCheckboxChange}

--- a/src/components/Pagination.js
+++ b/src/components/Pagination.js
@@ -18,15 +18,25 @@ class Pagination extends Component {
     const Displaying = () => {
       let displayingCopy = "";
       if (this.props.numResults === 0) {
-        displayingCopy = <div>No results found</div>;
+        displayingCopy = (
+          <div role={this.props.atBottom ? "alert" : null}>
+            No results found
+          </div>
+        );
       } else {
         const textBefore = this.props.isSearch
           ? "Search Results:"
           : "Displaying:";
         displayingCopy = (
-          <div className="pagination-text">
-            {textBefore} {this.lowerBound()} {this.upperBound()} of{" "}
-            {this.props.total}
+          <div
+            className="pagination-text"
+            aria-live={this.props.atBottom ? "polite" : "off"}
+          >
+            <p>
+              {`${textBefore} ${this.lowerBound()} ${this.upperBound()} of ${
+                this.props.total
+              }`}
+            </p>
           </div>
         );
       }
@@ -35,7 +45,9 @@ class Pagination extends Component {
     const Previous = () => {
       if (this.props.page > 0) {
         return (
-          <Button onClick={this.props.previousPage}>&laquo; Previous</Button>
+          <Button onClick={this.props.previousPage} aria-live="off">
+            <i className="fas fa-angle-double-left"></i> Previous
+          </Button>
         );
       } else {
         return <div></div>;
@@ -43,7 +55,11 @@ class Pagination extends Component {
     };
     const Next = () => {
       if (this.props.page < this.props.totalPages - 1) {
-        return <Button onClick={this.props.nextPage}>Next &raquo;</Button>;
+        return (
+          <Button onClick={this.props.nextPage} aria-live="off">
+            Next <i className="fas fa-angle-double-right"></i>
+          </Button>
+        );
       } else {
         return <div></div>;
       }

--- a/src/components/Thumbnail.js
+++ b/src/components/Thumbnail.js
@@ -22,7 +22,7 @@ class Thumbnail extends Component {
         <img
           className={this.props.className}
           src={this.props.item.thumbnail_path}
-          alt={this.props.item.title}
+          alt={this.props.altText ? this.props.item.title : ""}
         />
       </div>
     );

--- a/src/css/ListPages.css
+++ b/src/css/ListPages.css
@@ -100,11 +100,16 @@ a.more-link {
 
 .pagination-section .ui.button {
   font-family: "gineso-condensed", sans-serif;
-  font-weight: 400;
+  font-weight: 500;
   padding: 10px;
   border: solid 1px #707070;
   background-color: #f8f8f8;
   color: #000000;
+}
+
+.pagination-section .fa-angle-double-right,
+.pagination-section .fa-angle-double-left {
+  transform: translateY(1px);
 }
 
 @media (min-width: 768px) {

--- a/src/css/SearchResult.css
+++ b/src/css/SearchResult.css
@@ -221,6 +221,10 @@ div.masonry div.card {
   background-color: var(--light-gray);
 }
 
+.facet-navbar-section {
+  width: 100%;
+}
+
 .facet-navbar {
   background-color: white;
   width: 100%;
@@ -254,14 +258,18 @@ div.masonry div.card {
   padding-right: 20px;
   float: left;
 }
+
 .facet-navbar-facets .facet-navbar-name {
   text-transform: capitalize;
 }
 
 .facet-navbar-facets .facet-navbar-arrow {
+  padding: 3.5px;
+}
+.facet-navbar-facets .facet-navbar-arrow .fa-angle-right {
   font-weight: 800;
-  font-size: 18px;
-  line-height: 14px;
+  font-size: 1.1rem;
+  transform: translateY(1px);
 }
 
 .facet-navbar-clear {

--- a/src/lib/MetadataRenderer.js
+++ b/src/lib/MetadataRenderer.js
@@ -3,13 +3,14 @@ import qs from "query-string";
 import "../css/ListPages.css";
 import ReactHtmlParser from "react-html-parser";
 
-export function labelAttr(attr) {
+export function labelAttr(attr, filter, languages) {
   if (attr === "resource_type") return "Type";
   else if (attr === "rights_statement") return "Rights";
   else if (attr === "custom_key") return "Permanent Link";
   else if (attr === "related_url") return "Relation";
   else if (attr === "start_date") return "Date";
   else if (attr === "archive") return "Item";
+  else if (filter === "language") return (attr = languages[attr]);
   else return (attr.charAt(0).toUpperCase() + attr.slice(1)).replace("_", " ");
 }
 

--- a/src/pages/collections/CollectionItemsLoader.js
+++ b/src/pages/collections/CollectionItemsLoader.js
@@ -132,17 +132,19 @@ class CollectionItemsLoader extends Component {
             items={this.state.items}
             collection={this.props.collection}
           />
-          <Pagination
-            numResults={this.state.items.length}
-            total={this.state.total}
-            page={this.state.page}
-            limit={this.state.limit}
-            previousPage={this.previousPage.bind(this)}
-            nextPage={this.nextPage.bind(this)}
-            totalPages={this.state.totalPages}
-            isSearch={false}
-            atBottom={true}
-          />
+          <div aria-live="polite">
+            <Pagination
+              numResults={this.state.items.length}
+              total={this.state.total}
+              page={this.state.page}
+              limit={this.state.limit}
+              previousPage={this.previousPage.bind(this)}
+              nextPage={this.nextPage.bind(this)}
+              totalPages={this.state.totalPages}
+              isSearch={false}
+              atBottom={true}
+            />
+          </div>
         </div>
       );
     } else if (this.state.total === 0) {

--- a/src/pages/collections/CollectionsListPage.js
+++ b/src/pages/collections/CollectionsListPage.js
@@ -106,7 +106,9 @@ class CollectionsListPage extends Component {
             })}
           </div>
         </div>
-        <CollectionsPaginationDisplay atBottom={true} />
+        <div aria-live="polite">
+          <CollectionsPaginationDisplay atBottom={true} />
+        </div>
       </div>
     );
   }

--- a/src/pages/collections/CollectionsShowPage.js
+++ b/src/pages/collections/CollectionsShowPage.js
@@ -249,10 +249,7 @@ class CollectionsShowPage extends Component {
             aria-labelledby="collection-page-title"
           >
             <div className="collection-img-col col-sm-4">
-              <img
-                src={this.collectionImg()}
-                alt={`${this.state.collection} header`}
-              />
+              <img src={this.collectionImg()} alt="" />
             </div>
             <div className="collection-details-col col-sm-8">
               <h1 className="collection-title" id="collection-page-title">

--- a/src/pages/search/MasonryView.js
+++ b/src/pages/search/MasonryView.js
@@ -18,6 +18,7 @@ class MasonryView extends Component {
               category={this.props.category}
               label={this.props.label}
               className="card-img"
+              altText="true"
             />
           </a>
         </div>

--- a/src/pages/search/SearchFacets.js
+++ b/src/pages/search/SearchFacets.js
@@ -4,6 +4,7 @@ import Collapsible from "../../components/Collapsible";
 import { NavLink } from "react-router-dom";
 import qs from "query-string";
 import FocusLock from "react-focus-lock";
+
 import "../../css/ListPages.css";
 import "../../css/SearchResult.css";
 
@@ -139,16 +140,16 @@ class SearchFacets extends Component {
           <div
             className="facet-wrapper"
             role="region"
-            aria-labelledby="filters"
+            aria-labelledby="filters-heading"
           >
-            <h2 className="facet-heading" id="filters">
+            <h2 className="facet-heading" id="filters-heading">
               Filter My Results
             </h2>
             <div
               className="facet-fields"
               data-cy="filter-collapsibles"
               role="group"
-              aria-label="filters"
+              aria-label="Choose and apply filters"
             >
               {facetFields.map((field, idx) => (
                 <Collapsible
@@ -157,6 +158,7 @@ class SearchFacets extends Component {
                   updateFormState={this.props.updateFormState}
                   facetNodes={this.state[`${field.name}List`]}
                   key={idx}
+                  languages={this.props.languages}
                 />
               ))}
               <div

--- a/src/pages/search/SearchResults.js
+++ b/src/pages/search/SearchResults.js
@@ -10,7 +10,7 @@ import ItemsList from "./ItemsList";
 import { fetchLanguages } from "../../lib/fetchTools";
 import { FontAwesomeIcon } from "@fortawesome/react-fontawesome";
 import { faFilter } from "@fortawesome/free-solid-svg-icons";
-
+import { labelAttr } from "../../lib/MetadataRenderer";
 import "../../css/ListPages.css";
 import "../../css/SearchResult.css";
 
@@ -93,10 +93,11 @@ class SearchResults extends Component {
                           <div role="gridcell" tabIndex="-1">
                             <span className="facet-navbar-name">{key}</span>
                             <span className="facet-navbar-arrow">
-                              {" "}
-                              &#8250;{" "}
+                              <i className="fas fa-angle-right"></i>
                             </span>
-                            {val}
+                            <span className="facet-navbar-selection">
+                              {labelAttr(val, key, this.state.languages)}
+                            </span>
                           </div>
                         </div>
                       );
@@ -106,8 +107,12 @@ class SearchResults extends Component {
                       <div key={key} role="row">
                         <div role="gridcell" tabIndex="-1">
                           <span className="facet-navbar-name">{key}</span>
-                          <span className="facet-navbar-arrow"> &#8250; </span>
-                          {value}
+                          <span className="facet-navbar-arrow">
+                            <i className="fas fa-angle-right"></i>
+                          </span>
+                          <span className="facet-navbar-selection">
+                            {labelAttr(value, key, this.state.languages)}
+                          </span>
                         </div>
                       </div>
                     );
@@ -124,6 +129,7 @@ class SearchResults extends Component {
                     aria-labelledby="clearButton"
                     role="button"
                     aria-controls="facet-navbar-grid"
+                    aria-live="off"
                   >
                     <i className="fas fa-times"></i>
                   </NavLink>
@@ -135,73 +141,86 @@ class SearchResults extends Component {
       } else return null;
     };
 
-    return (
-      <div className="search-result-wrapper">
-        <SearchBar
-          filters={this.props.filters}
-          view={this.props.view}
-          field={this.props.field}
-          q={this.props.q}
-          setPage={this.props.setPage}
-          updateFormState={this.props.updateFormState}
-        />
-        <div className="container search-results">
-          <div className="row">
-            <div id="sidebar" className="col-lg-3 col-sm-12">
-              <SearchFacets
-                filters={this.props.filters}
-                field={this.props.field}
-                q={this.props.q}
-                total={this.props.total}
-                view={this.props.view}
-                updateFormState={this.props.updateFormState}
-                isActive={this.state.isActive}
-                updateModal={this.updateModal}
-                defaultSearch={defaultSearch}
-                searchFacets={this.props.searchPage.facets}
-              />
-            </div>
-            <div id="content" className="col-lg-9 col-sm-12">
-              <div
-                className="navbar navbar-light justify-content-between"
-                role="region"
-                aria-label="Search Tools"
-                aria-controls="search-results"
-              >
-                <div className="navbar-text text-dark">
-                  <ItemsPaginationDisplay atBottom={false} />
-                </div>
-                <div className="facet-button-navbar" onClick={this.updateModal}>
-                  <button
-                    type="button"
-                    data-toggle="tooltip"
-                    title="Filters"
-                    aria-label="Filters"
-                    aria-pressed={this.state.isActive}
-                  >
-                    <FontAwesomeIcon
-                      icon={faFilter}
-                      color="var(--themeHighlightColor)"
-                    />
-                  </button>
-                </div>
-                <div className="form-inline view-options">
-                  <ViewBar
-                    view={this.props.view}
-                    updateFormState={this.props.updateFormState}
-                    pageViews={["Gallery", "List", "Masonry"]}
-                  />
-                  <ResultsNumberDropdown setLimit={this.props.setLimit} />
-                </div>
-                <FiltersDisplay />
+    if (this.state.languages) {
+      return (
+        <div className="search-result-wrapper">
+          <SearchBar
+            filters={this.props.filters}
+            view={this.props.view}
+            field={this.props.field}
+            q={this.props.q}
+            setPage={this.props.setPage}
+            updateFormState={this.props.updateFormState}
+          />
+          <div className="container search-results">
+            <div className="row">
+              <div id="sidebar" className="col-lg-3 col-sm-12">
+                <SearchFacets
+                  filters={this.props.filters}
+                  field={this.props.field}
+                  q={this.props.q}
+                  total={this.props.total}
+                  view={this.props.view}
+                  updateFormState={this.props.updateFormState}
+                  isActive={this.state.isActive}
+                  updateModal={this.updateModal}
+                  defaultSearch={defaultSearch}
+                  searchFacets={this.props.searchPage.facets}
+                  languages={this.state.languages}
+                />
               </div>
-              <ItemsList items={this.props.items} view={this.props.view} />
+              <div id="content" className="col-lg-9 col-sm-12">
+                <div
+                  className="navbar navbar-light justify-content-between"
+                  id="search-tools"
+                  role="region"
+                  aria-label="Search Tools"
+                  aria-controls="search-results"
+                >
+                  <div className="navbar-text text-dark">
+                    <ItemsPaginationDisplay atBottom={false} />
+                  </div>
+                  <div
+                    className="facet-button-navbar"
+                    onClick={this.updateModal}
+                  >
+                    <button
+                      type="button"
+                      data-toggle="tooltip"
+                      title="Filters"
+                      aria-label="Filters"
+                      aria-pressed={this.state.isActive}
+                    >
+                      <FontAwesomeIcon
+                        icon={faFilter}
+                        color="var(--themeHighlightColor)"
+                      />
+                    </button>
+                  </div>
+                  <div className="form-inline view-options">
+                    <ViewBar
+                      view={this.props.view}
+                      updateFormState={this.props.updateFormState}
+                      pageViews={["Gallery", "List", "Masonry"]}
+                    />
+                    <ResultsNumberDropdown setLimit={this.props.setLimit} />
+                  </div>
+                  <div className="facet-navbar-section" aria-live="polite">
+                    <FiltersDisplay />
+                  </div>
+                </div>
+                <ItemsList items={this.props.items} view={this.props.view} />
+              </div>
+            </div>
+            <div aria-live="polite">
+              <ItemsPaginationDisplay atBottom={true} />
             </div>
           </div>
-          <ItemsPaginationDisplay atBottom={true} />
         </div>
-      </div>
-    );
+      );
+    } else {
+      return <> </>;
+    }
   }
 }
 


### PR DESCRIPTION
**JIRA Ticket**: (link) (:star:)
https://webapps.es.vt.edu/jira/browse/LIBTD-2324

# What does this Pull Request do? (:star:)
Hides images which should be considered decorative, changes glyphs to font awesome icons so screen reader doesn't read them, adds aria-live sections to announce certain dynamic changes which include important messages, converts abbreviations for languages to the full word for each language in the search facets.

# What's the changes? (:star:)
-Collapsible.js - adds additional argument to function call
-Pagination.js - conditionally renders aria roles/attributes for some elements, adds font awesome icons
-Thumbnail.js - conditionally inserts alt text
-ListPages.css - some CSS to integrate font awsome icons in pagination buttons
-SearchResult.css - some CSS for the new sections and icons
-MetadataRenderer.js - adds parameters and an if/else clause to reformat the languages
-CollectionItemsLoader.js and CollectionsListPage.js - add an aria-live section around the pagination.
-CollectionsShowPage.js - makes graphic decorative
-MasonryView.js - adds props to display alt text
-SearchFacets.js - edits a few aria labels, and adds props for languages
-SearchResults.js - changes glyphs to font awesome icons, adds labelattr function to format filter labels, adds aria-live section around pagination, and surrounds return stmt with conditional to ensure languages load before rendering elements.

# How should this be tested?
-search facets will now show "English" instead of "En"; 'Filtering by' section in navbar will show the same update.
-Screen reader will not try to read the arrow brackets in the 'Filtering by' section or in the pagination previous/next buttons.
-Screen read will announce changes in pagination sections throughout site. If no items are found screen reader will announce an alert. Aria-live="off" removes certain elements from the announcements so just the relevant info is included.
-Images in all search results (except masonry view) are decorative will not be read by screen reader, which removes duplication of information

# Interested parties
@yinlinchen 

(:star:) Required fields
