### PR TITLE
LIBTD-2314: Provide site configuration update function with amplify auth

### DIFF
--- a/src/App.js
+++ b/src/App.js
@@ -7,13 +7,14 @@ import Header from "./components/Header";
 import Footer from "./components/Footer";
 import { buildRoutes } from "./lib/CustomPageRoutes";
 import HomePage from "./pages/HomePage";
-import SiteAdmin from "./pages/SiteAdmin";
+import SiteAdmin from "./pages/admin/SiteAdmin";
 
 import CollectionsListLoader from "./pages/collections/CollectionsListLoader";
 import CollectionsShowLoader from "./pages/collections/CollectionsShowLoader";
 
 import SearchLoader from "./pages/search/SearchLoader";
 import ArchivePage from "./pages/archives/ArchivePage";
+import { getSite } from "./lib/fetchTools";
 
 import "./App.css";
 
@@ -22,8 +23,14 @@ class App extends Component {
     super(props);
     this.state = {
       siteDetails: null,
+      site: null,
       paginationClick: null
     };
+  }
+
+  async loadSite() {
+    const site = await getSite();
+    this.setState({ site: site });
   }
 
   setColor(color) {
@@ -41,18 +48,20 @@ class App extends Component {
 
   componentDidMount() {
     fetchSiteDetails(this, process.env.REACT_APP_REP_TYPE);
+    this.loadSite();
   }
 
   render() {
-    if (this.state.siteDetails !== null) {
+    if (this.state.siteDetails && this.state.site) {
       this.setColor(this.state.siteDetails.siteColor);
-      const customRoutes = buildRoutes(this.state.siteDetails);
+      const customRoutes = buildRoutes(this.state.siteDetails, this.state.site);
       return (
         <Router>
           <AnalyticsConfig analyticsID={this.state.siteDetails.analyticsID} />
           <ScrollToTop paginationClick={this.state.paginationClick} />
           <Header
             siteDetails={this.state.siteDetails}
+            site={this.state.site}
             location={window.location}
           />
           <main style={{ minHeight: "500px", padding: "1em 1em 0 1em" }}>
@@ -63,7 +72,10 @@ class App extends Component {
                   path="/"
                   exact
                   render={props => (
-                    <HomePage siteDetails={this.state.siteDetails} />
+                    <HomePage
+                      siteDetails={this.state.siteDetails}
+                      site={this.state.site}
+                    />
                   )}
                 />
                 <Route
@@ -73,6 +85,7 @@ class App extends Component {
                     <CollectionsListLoader
                       scrollUp={this.setPaginationClick.bind(this)}
                       siteDetails={this.state.siteDetails}
+                      site={this.state.site}
                     />
                   )}
                 />
@@ -81,6 +94,7 @@ class App extends Component {
                   render={props => (
                     <CollectionsShowLoader
                       siteDetails={this.state.siteDetails}
+                      site={this.state.site}
                       customKey={props.match.params.customKey}
                     />
                   )}
@@ -92,6 +106,7 @@ class App extends Component {
                     <SearchLoader
                       scrollUp={this.setPaginationClick.bind(this)}
                       siteDetails={this.state.siteDetails}
+                      site={this.state.site}
                     />
                   )}
                 />
@@ -101,11 +116,12 @@ class App extends Component {
                   render={props => (
                     <ArchivePage
                       siteDetails={this.state.siteDetails}
+                      site={this.state.site}
                       customKey={props.match.params.customKey}
                     />
                   )}
                 />
-                <Route exact path="/siteAdmin" component={SiteAdmin} />
+                <Route path="/siteAdmin" exact component={SiteAdmin} />
               </Switch>
             </div>
           </main>

--- a/src/components/ContactSection.js
+++ b/src/components/ContactSection.js
@@ -16,7 +16,7 @@ class ContactSection extends Component {
             aria-labelledby="contact-section-heading"
           >
             <h2 className="contact-heading" id="contact-section-heading">
-              Contact {this.props.siteDetails.siteTitle}
+              Contact {this.props.site.siteTitle}
             </h2>
             {this.props.siteDetails.contact.map((contact, index) => (
               <div key={index}>

--- a/src/components/Header.js
+++ b/src/components/Header.js
@@ -103,6 +103,7 @@ class Header extends Component {
             <div className="gateway">
               <HeaderBreadcrumbs
                 siteDetails={this.props.siteDetails}
+                site={this.props.site}
                 location={this.props.location}
               />
             </div>

--- a/src/components/HeaderBreadcrumbs.js
+++ b/src/components/HeaderBreadcrumbs.js
@@ -83,7 +83,7 @@ class HeaderBreadcrumbs extends Breadcrumbs {
       custom_key: null
     });
     baseList.push({
-      title: this.props.siteDetails.siteTitle,
+      title: this.props.site.siteTitle,
       url: "/",
       custom_key: null
     });

--- a/src/lib/CustomPageRoutes.js
+++ b/src/lib/CustomPageRoutes.js
@@ -10,7 +10,7 @@ const pageComponents = {
   AdditionalPages: AdditionalPages
 };
 
-function route(siteDetails, key, path, PageComponent, childKey = null) {
+function route(siteDetails, site, key, path, PageComponent, childKey = null) {
   let elemKey = key;
   if (childKey) {
     elemKey += "." + childKey;
@@ -23,6 +23,7 @@ function route(siteDetails, key, path, PageComponent, childKey = null) {
       render={props => (
         <PageComponent
           siteDetails={siteDetails}
+          site={site}
           parentKey={key}
           childKey={childKey}
         />
@@ -31,17 +32,18 @@ function route(siteDetails, key, path, PageComponent, childKey = null) {
   );
 }
 
-export function buildRoutes(siteDetails) {
+export function buildRoutes(siteDetails, site) {
   let routes = [];
   for (const [key, obj] of Object.entries(siteDetails.sitePages)) {
     const pageComponent = pageComponents[obj.component];
-    routes.push(route(siteDetails, key, obj.local_url, pageComponent));
+    routes.push(route(siteDetails, site, key, obj.local_url, pageComponent));
     if (obj.children) {
       for (const [childKey, childObj] of Object.entries(obj.children)) {
         const childPageComponent = pageComponents[childObj.component];
         routes.push(
           route(
             siteDetails,
+            site,
             key,
             childObj.local_url,
             childPageComponent,

--- a/src/lib/fetchTools.js
+++ b/src/lib/fetchTools.js
@@ -304,3 +304,18 @@ export const fetchHeirarchyPathMembers = async collection => {
 
   return retVal;
 };
+
+export const getSite = async () => {
+  const REP_TYPE = process.env.REACT_APP_REP_TYPE;
+  const apiData = await API.graphql({
+    query: queries.siteBySiteId,
+    variables: { siteId: REP_TYPE.toLowerCase(), limit: 1 }
+  });
+  const {
+    data: {
+      siteBySiteId: { items }
+    }
+  } = apiData;
+  const site = items[0];
+  return site;
+};

--- a/src/pages/AboutPage.js
+++ b/src/pages/AboutPage.js
@@ -24,12 +24,9 @@ class AboutPage extends Component {
     return (
       <div className="row about-page-wrapper">
         <div className="col-12 about-heading">
-          <SiteTitle
-            siteTitle={this.props.siteDetails.siteTitle}
-            pageTitle="About"
-          />
+          <SiteTitle siteTitle={this.props.site.siteTitle} pageTitle="About" />
           <h1 id="about-heading">
-            About <span>{this.props.siteDetails.siteTitle}</span>
+            About <span>{this.props.site.siteTitle}</span>
           </h1>
         </div>
         <div className="col-md-8" role="region" aria-labelledby="about-heading">
@@ -39,7 +36,10 @@ class AboutPage extends Component {
           ></div>
         </div>
         <div className="col-md-4 contact-section-wrapper">
-          <ContactSection siteDetails={this.props.siteDetails} />
+          <ContactSection
+            siteDetails={this.props.siteDetails}
+            site={this.props.site}
+          />
           {this.props.siteDetails.sitePages.terms ? (
             <a href="/permissions" className="about-terms-link">
               Permissions

--- a/src/pages/HomePage.js
+++ b/src/pages/HomePage.js
@@ -31,10 +31,7 @@ class HomePage extends Component {
     }
     return (
       <>
-        <SiteTitle
-          siteTitle={this.props.siteDetails.siteTitle}
-          pageTitle="Home"
-        />
+        <SiteTitle siteTitle={this.props.site.siteTitle} pageTitle="Home" />
         <div
           className={
             this.props.siteDetails.homePage.staticImage.showTitle
@@ -45,7 +42,7 @@ class HomePage extends Component {
           <div className="home-featured-image-wrapper">
             <FeaturedStaticImage staticImage={staticImage} />
             <div id="home-site-title-wrapper">
-              <h1>{this.props.siteDetails.siteName}</h1>
+              <h1>{this.props.site.siteName}</h1>
             </div>
           </div>
           <div className="home-search-wrapper">

--- a/src/pages/PermissionsPage.js
+++ b/src/pages/PermissionsPage.js
@@ -32,7 +32,7 @@ class PermissionsPage extends Component {
         <div className="row terms-page-wrapper">
           <div className="col-12 terms-heading">
             <SiteTitle
-              siteTitle={this.props.siteDetails.siteTitle}
+              siteTitle={this.props.site.siteTitle}
               pageTitle="Permissions"
             />
             <h1 id="permissions-heading">Permissions</h1>

--- a/src/pages/admin/SiteAdmin.js
+++ b/src/pages/admin/SiteAdmin.js
@@ -1,6 +1,7 @@
 import React, { useState, useEffect } from "react";
 import { Auth } from "aws-amplify";
 import { withAuthenticator, AmplifySignOut } from "@aws-amplify/ui-react";
+import SiteForm from "./SiteForm";
 
 function SiteAdmin() {
   useEffect(() => {
@@ -28,9 +29,7 @@ function SiteAdmin() {
   return (
     <div>
       <h1>
-        {authorized
-          ? "Update Site Configurations"
-          : "Not authorized to access this page!"}
+        {authorized ? <SiteForm /> : "Not authorized to access this page!"}
       </h1>
       <AmplifySignOut />
     </div>

--- a/src/pages/admin/SiteForm.js
+++ b/src/pages/admin/SiteForm.js
@@ -1,0 +1,133 @@
+import React, { Component } from "react";
+import { withAuthenticator } from "@aws-amplify/ui-react";
+import { Form } from "semantic-ui-react";
+import { API } from "aws-amplify";
+import { getSite } from "../../lib/fetchTools";
+import * as mutations from "../../graphql/mutations";
+
+class SiteForm extends Component {
+  constructor(props) {
+    super(props);
+    this.state = {
+      formState: {
+        siteTitle: "",
+        siteName: ""
+      },
+      viewState: "viewSite",
+      site: null
+    };
+  }
+
+  async loadSite() {
+    const site = await getSite();
+    if (site) {
+      this.setState({
+        formState: {
+          siteTitle: site.siteTitle,
+          siteName: site.siteName
+        },
+        site: site
+      });
+    }
+  }
+
+  componentDidMount() {
+    this.loadSite();
+  }
+
+  updateInputValue = event => {
+    const { name, value } = event.target;
+    this.setState(prevState => {
+      return {
+        formState: { ...prevState.formState, [name]: value }
+      };
+    });
+  };
+
+  handleSubmit = async () => {
+    const { siteTitle, siteName } = this.state.formState;
+    if (!siteTitle || !siteName) return;
+
+    this.setState({ viewState: "viewSite" });
+    let siteInfo = { id: this.state.site.id, ...this.state.formState };
+    await API.graphql({
+      query: mutations.updateSite,
+      variables: { input: siteInfo },
+      authMode: "AMAZON_COGNITO_USER_POOLS"
+    });
+  };
+
+  handleChange = (e, { value }) => {
+    this.setState({ viewState: value });
+  };
+
+  editSiteForm = () => {
+    return (
+      <div>
+        <h2>{`Edit Site with SiteId: ${process.env.REACT_APP_REP_TYPE.toLowerCase()}`}</h2>
+        <Form onSubmit={this.handleSubmit}>
+          <Form.Input
+            label="Site Title"
+            value={this.state.formState.siteTitle}
+            name="siteTitle"
+            placeholder="Enter Site Title"
+            onChange={this.updateInputValue}
+          />
+
+          <Form.TextArea
+            label="Site Name"
+            value={this.state.formState.siteName}
+            name="siteName"
+            placeholder="Enter Site Name"
+            onChange={this.updateInputValue}
+          />
+          <Form.Button>Update Site</Form.Button>
+        </Form>
+      </div>
+    );
+  };
+
+  viewSite = () => {
+    return (
+      <div>
+        <div>
+          <p>SiteId: iawa</p>
+          <p>Site Title: {this.state.formState.siteTitle}</p>
+          <p>Site Name: {this.state.formState.siteName}</p>
+        </div>
+      </div>
+    );
+  };
+
+  render() {
+    return (
+      <div>
+        <Form>
+          <Form.Group inline>
+            <label>Switch between view and edit</label>
+            <Form.Radio
+              label="Edit Site"
+              name="viewStateRadioGroup"
+              value="editSite"
+              checked={this.state.viewState === "editSite"}
+              onChange={this.handleChange}
+            />
+
+            <Form.Radio
+              label="View Site"
+              name="viewStateRadioGroup"
+              value="viewSite"
+              checked={this.state.viewState === "viewSite"}
+              onChange={this.handleChange}
+            />
+          </Form.Group>
+        </Form>
+        {this.state.viewState === "viewSite"
+          ? this.viewSite()
+          : this.editSiteForm()}
+      </div>
+    );
+  }
+}
+
+export default withAuthenticator(SiteForm);

--- a/src/pages/archives/ArchivePage.js
+++ b/src/pages/archives/ArchivePage.js
@@ -179,7 +179,7 @@ class ArchivePage extends Component {
             return (
               <div className="item-page-wrapper">
                 <SiteTitle
-                  siteTitle={this.props.siteDetails.siteTitle}
+                  siteTitle={this.props.site.siteTitle}
                   pageTitle={item.title}
                 />
                 <SearchBar

--- a/src/pages/collections/CollectionsListLoader.js
+++ b/src/pages/collections/CollectionsListLoader.js
@@ -105,7 +105,7 @@ class CollectionsListLoader extends Component {
       return (
         <div>
           <SiteTitle
-            siteTitle={this.props.siteDetails.siteTitle}
+            siteTitle={this.props.site.siteTitle}
             pageTitle="Collections"
           />
           <CollectionsListPage

--- a/src/pages/collections/CollectionsShowLoader.js
+++ b/src/pages/collections/CollectionsShowLoader.js
@@ -34,7 +34,7 @@ class CollectionsShowLoader extends Component {
           return (
             <>
               <SiteTitle
-                siteTitle={this.props.siteDetails.siteTitle}
+                siteTitle={this.props.site.siteTitle}
                 pageTitle={collection.title}
               />
               <CollectionsShowPage

--- a/src/pages/search/SearchLoader.js
+++ b/src/pages/search/SearchLoader.js
@@ -187,10 +187,7 @@ class SearchLoader extends Component {
     if (this.state.items !== null) {
       return (
         <div>
-          <SiteTitle
-            siteTitle={this.props.siteDetails.siteTitle}
-            pageTitle="Search"
-          />
+          <SiteTitle siteTitle={this.props.site.siteTitle} pageTitle="Search" />
           <SearchResults
             items={this.state.items}
             total={this.state.total}


### PR DESCRIPTION
**JIRA Ticket**: (https://webapps.es.vt.edu/jira/browse/LIBTD-2314) (:star:)

Amplify preview: https://libtd-2314.djf1n0m63xbku.amplifyapp.com/

# What does this Pull Request do? (:star:)
This PR provides "edit/update" functionality to allow "SiteAdmin" users to modify site configurations using Amplify @auth. Currently, only two fields, "siteTitle" and "siteName" are editable. 

# What's the changes? (:star:)

* schema.graphql: Add "Site" model with @key and @auth 
* amplify/backend/auth/userPoolGroups/user-pool-group-precedence.json: Change User groups' precedence to: Admin(1), Editor(2) and SiteAdmin(3) 
* src/pages/HomePage.js: Obtain siteTitle and siteName from DynamoDB table instead of config file 
* src/pages/admin/SiteForm.js:  Provide edit form for updating Site configurations

# How should this be tested?

* Sign up as a "SiteAdmin" user and then go to "SiteAdmin" page to see if you can edit the "siteTitle" and "siteName"
* Go to Home page and check if the siteTitle and siteName have been updated as expected

# Interested parties
Tag (@yinlinchen ) interested parties

(:star:) Required fields
