### PR TITLE
Refactor functions that iterate through heirarchy to use one query

### DIFF
--- a/src/lib/fetchTools.js
+++ b/src/lib/fetchTools.js
@@ -268,3 +268,39 @@ const getCollectionIDByTitle = async title => {
   }
   return id;
 };
+
+export const getTopLevelParentForCollection = async collection => {
+  const topLevelId = collection.heirarchy_path[0];
+  let retVal = null;
+  const response = await API.graphql(
+    graphqlOperation(queries.getCollection, {
+      id: topLevelId
+    })
+  );
+  try {
+    retVal = response.data.getCollection;
+  } catch (error) {
+    console.error(`Error getting top level parent for: ${collection.id}`);
+  }
+  return retVal;
+};
+
+export const fetchHeirarchyPathMembers = async collection => {
+  let retVal = null;
+  const orArray = [];
+  for (var idx in collection.heirarchy_path) {
+    orArray.push({ id: { eq: collection.heirarchy_path[idx] } });
+  }
+  const response = await API.graphql(
+    graphqlOperation(queries.searchCollections, {
+      filter: { or: orArray }
+    })
+  );
+  try {
+    retVal = response.data.searchCollections.items;
+  } catch (error) {
+    console.error(`Error getting heirarchy path for: ${collection.id}`);
+  }
+
+  return retVal;
+};


### PR DESCRIPTION
**Refactor functions that iterate through heirarchy to use one query instead.**
* * *

**JIRA Ticket**: (https://webapps.es.vt.edu/jira/browse/LIBTD-2328) (:star:)

* Other Relevant Links (Meeting note, project page, related pull requests, etc.)

# What does this Pull Request do? (:star:)
Uses the new `heirarchy_path` field to refactor functions to use one query instead of an undetermined number of queries in an iteration. It simplifies the code and speeds up the application.

# What's the changes? (:star:)
* adds `getTopLevelParentForCollection` to the fetchTools lib file and uses this in CollectionsShowPage.js and in SubCollectionsLoader.js
* adds `fetchHeirarchyPathMembers` to the fetchTools lib file and uses this in Breadcrumbs.js
* refactors code to work with these lib functions

# How should this be tested?
* Visit collection show pages and check that:
  * Collection hierarchy on right side still renders correctly
  * Breadcrumbs at the top of the page still render correctly
  * Title at top of metadata section still renders correctly
* Visit archive show page and check that breadcrumbs at top still render correctly

# Additional Notes:
* branch: `LIBTD-2328`

# Interested parties
@yinlinchen 

(:star:) Required fields
