### PR TITLE
LIBTD-2304_refactor: Use 'heirarchy_path' attribute to get all the it…

### DIFF
--- a/src/lib/fetchTools.js
+++ b/src/lib/fetchTools.js
@@ -151,12 +151,8 @@ export const fetchSearchResults = async (
     } else if (key === "category") {
       category = filter.category;
     } else if (key === "collection") {
-      if (filter[key] === "Leonard J. Currie Slides") {
-        filters["identifier"] = { matchPhrasePrefix: "LJC_" };
-      } else {
-        let parent_collection_id = await getCollectionIDByTitle(filter[key]);
-        filters["parent_collection"] = { eq: parent_collection_id };
-      }
+      let parent_collection_id = await getCollectionIDByTitle(filter[key]);
+      filters["heirarchy_path"] = { eq: parent_collection_id };
       objectFilter = archiveFilter;
     } else if (key === "title" || key === "description") {
       filters[key] = { matchPhrase: filter[key] };
@@ -193,8 +189,7 @@ export const fetchSearchResults = async (
   if (category === "collection") {
     const item_fields = ["format", "medium", "resource_type", "tags"];
     if (
-      filters.hasOwnProperty("parent_collection") ||
-      filters.hasOwnProperty("identifier") ||
+      filters.hasOwnProperty("heirarchy_path") ||
       (filters.hasOwnProperty("and") &&
         item_fields.some(e => Object.keys(filter).indexOf(e) > -1))
     ) {
@@ -214,7 +209,10 @@ export const fetchSearchResults = async (
         searchResults = Collections.data.searchCollections;
       }
     }
-  } else if (category === "archive") {
+  } else if (
+    category === "archive" ||
+    filters.hasOwnProperty("heirarchy_path")
+  ) {
     options["filter"] = { ...archiveFilter, ...filters };
     let Archives = null;
     if (allFields) {

--- a/src/pages/admin/SiteForm.js
+++ b/src/pages/admin/SiteForm.js
@@ -88,15 +88,19 @@ class SiteForm extends Component {
   };
 
   viewSite = () => {
-    return (
-      <div>
+    if (this.state.site) {
+      return (
         <div>
-          <p>SiteId: iawa</p>
-          <p>Site Title: {this.state.formState.siteTitle}</p>
-          <p>Site Name: {this.state.formState.siteName}</p>
+          <div>
+            <p>SiteId: {this.state.site.siteId} </p>
+            <p>Site Title: {this.state.formState.siteTitle}</p>
+            <p>Site Name: {this.state.formState.siteName}</p>
+          </div>
         </div>
-      </div>
-    );
+      );
+    } else {
+      return <div>Error fetching site configurations......</div>;
+    }
   };
 
   render() {


### PR DESCRIPTION
…ems in a collection

**JIRA Ticket**: (https://webapps.es.vt.edu/jira/browse/LIBTD-2304) (:star:)

Preview branch generated at https://LIBTD-2304-refactor.djf1n0m63xbku.amplifyapp.com

* Other Relevant Links (Meeting note, project page, related pull requests, etc.)
This PR is built on top of [previous PR](https://github.com/VTUL/dlp-access/pull/171) but uses new attribute 'heirarchy_path' in the Archive table to correctly get all the items in a collection.

# What does this Pull Request do? (:star:)
This PR refactors "Collection" search facet functionality for SWVA application by using recently added "heirarchy_path" attribute for Archive model.

# What's the changes? (:star:)

* src/lib/fetchTools.js: Use "heirarchy_path" instead of "parent_collection" to search for all the items within a collection
* src/pages/admin/SiteForm.js: Fix a bug that gets the siteId properly instead of hardcoded string

# How should this be tested?

* Go to SWVA application's SEARCH page
* Click on "Collection" search filter and check the filtered search results

# Interested parties
Tag (@yinlinchen ) interested parties

(:star:) Required fields
