### PR TITLE
Fix broken contact section in permission page

### DIFF
--- a/src/App.js
+++ b/src/App.js
@@ -64,7 +64,7 @@ class App extends Component {
       return (
         <Router>
           <RouteListener setPathname={this.setPathname} context={this} />
-          <AnalyticsConfig analyticsID={this.state.siteDetails.analyticsID} />
+          <AnalyticsConfig analyticsID={this.state.site.analyticsID} />
           <ScrollToTop paginationClick={this.state.paginationClick} />
           <Header
             siteDetails={this.state.siteDetails}

--- a/src/components/MiradorViewer.js
+++ b/src/components/MiradorViewer.js
@@ -19,7 +19,7 @@ class MiradorViewer extends Component {
       data: [
         {
           manifestUri: this.props.item.manifest_url,
-          location: this.props.siteDetails.siteId.toUpperCase()
+          location: this.props.site.siteId.toUpperCase()
         }
       ],
       windowObjects: [

--- a/src/pages/PermissionsPage.js
+++ b/src/pages/PermissionsPage.js
@@ -48,7 +48,10 @@ class PermissionsPage extends Component {
             ></div>
           </div>
           <div className="col-md-4 contact-section-wrapper">
-            <ContactSection siteDetails={this.props.siteDetails} />
+            <ContactSection
+              siteDetails={this.props.siteDetails}
+              site={this.props.site}
+            />
             {download ? (
               <div role="region" aria-labelledby="terms-downloads-section">
                 <h2

--- a/src/pages/archives/ArchivePage.js
+++ b/src/pages/archives/ArchivePage.js
@@ -93,7 +93,11 @@ class ArchivePage extends Component {
     let tracks = [];
     if (this.isJsonURL(item.manifest_url)) {
       display = (
-        <MiradorViewer item={item} siteDetails={this.props.siteDetails} />
+        <MiradorViewer
+          item={item}
+          siteDetails={this.props.siteDetails}
+          site={this.props.site}
+        />
       );
     } else if (this.isImgURL(item.manifest_url)) {
       display = (


### PR DESCRIPTION
Preview branch is deployed at: https://contact-fix.djf1n0m63xbku.amplifyapp.com/

# What does this Pull Request do? (:star:)
This PR fixes the broken Permissions page due to failing to pass the site prop to ContactSection component.

# What's the changes? (:star:)

* Adds site prop to ContactSection and MiradorViewer components
* Adds back the site.analyticsID in previous conflict merge

# How should this be tested?

* Check if Permissions page is loaded properly 
* Check if Mirador viewer in an item display page works fine

# Interested parties
Tag (@yinlinchen) interested parties

(:star:) Required fields
