### PR TITLE
LIBTD-2356: Fix 'collection' search facet by including 'heirarchy_pat…

### DIFF
--- a/amplify/backend/api/collectionarchives/schema.graphql
+++ b/amplify/backend/api/collectionarchives/schema.graphql
@@ -8,6 +8,7 @@ interface Object {
   circa: String
   start_date: String
   end_date: String
+  subject: [String!]
   location: [String!]
   rights_statement: String
   language: [String!]
@@ -18,6 +19,7 @@ interface Object {
   rights_holder: String
   custom_key: String
   visibility: Boolean!
+  heirarchy_path: [String!]
   thumbnail_path: String
   parent_collection: [String!]
   create_date: String!
@@ -93,6 +95,7 @@ type Archive implements Object
   circa: String
   start_date: String
   end_date: String
+  subject: [String!]
   rights_statement: String
   language: [String!]
   resource_type: [String!]
@@ -160,7 +163,6 @@ type Query {
     filter: SearchableObjectFilterInput
     limit: Int
     nextToken: String
-    category: String
   ): SearchableObjectConnection
   fulltextCollections(
     allFields: String
@@ -207,6 +209,7 @@ input SearchableObjectFilterInput {
   format: SearchableStringFilterInput
   custom_key: SearchableStringFilterInput
   visibility: SearchableBooleanFilterInput
+  heirarchy_path: SearchableStringFilterInput
   thumbnail_path: SearchableStringFilterInput
   parent_collection: SearchableStringFilterInput
   create_date: SearchableStringFilterInput
@@ -308,6 +311,7 @@ enum SearchableCollectionSortableFields {
   custom_key
   collection_category
   visibility
+  heirarchy_path
   thumbnail_path
   parent_collection
   create_date
@@ -331,6 +335,7 @@ input SearchableArchiveFilterInput {
   circa: SearchableStringFilterInput
   start_date: SearchableStringFilterInput
   end_date: SearchableStringFilterInput
+  subject: SearchableStringFilterInput
   rights_statement: SearchableStringFilterInput
   language: SearchableStringFilterInput
   resource_type: SearchableStringFilterInput
@@ -375,6 +380,7 @@ enum SearchableArchiveSortableFields {
   circa
   start_date
   end_date
+  subject
   rights_statement
   language
   resource_type
@@ -393,6 +399,7 @@ enum SearchableArchiveSortableFields {
   parent_collection
   item_category
   visibility
+  heirarchy_path
   thumbnail_path
   manifest_url
   create_date

--- a/src/graphql/mutations.js
+++ b/src/graphql/mutations.js
@@ -83,6 +83,7 @@ export const createCollection = /* GraphQL */ `
           circa
           start_date
           end_date
+          subject
           rights_statement
           language
           resource_type
@@ -198,6 +199,7 @@ export const updateCollection = /* GraphQL */ `
           circa
           start_date
           end_date
+          subject
           rights_statement
           language
           resource_type
@@ -313,6 +315,7 @@ export const deleteCollection = /* GraphQL */ `
           circa
           start_date
           end_date
+          subject
           rights_statement
           language
           resource_type
@@ -527,6 +530,7 @@ export const createArchive = /* GraphQL */ `
       circa
       start_date
       end_date
+      subject
       rights_statement
       language
       resource_type
@@ -611,6 +615,7 @@ export const updateArchive = /* GraphQL */ `
       circa
       start_date
       end_date
+      subject
       rights_statement
       language
       resource_type
@@ -695,6 +700,7 @@ export const deleteArchive = /* GraphQL */ `
       circa
       start_date
       end_date
+      subject
       rights_statement
       language
       resource_type

--- a/src/graphql/queries.js
+++ b/src/graphql/queries.js
@@ -8,7 +8,6 @@ export const searchObjects = /* GraphQL */ `
     $filter: SearchableObjectFilterInput
     $limit: Int
     $nextToken: String
-    $category: String
   ) {
     searchObjects(
       allFields: $allFields
@@ -16,7 +15,6 @@ export const searchObjects = /* GraphQL */ `
       filter: $filter
       limit: $limit
       nextToken: $nextToken
-      category: $category
     ) {
       items {
         id
@@ -28,6 +26,7 @@ export const searchObjects = /* GraphQL */ `
         circa
         start_date
         end_date
+        subject
         location
         rights_statement
         language
@@ -38,14 +37,13 @@ export const searchObjects = /* GraphQL */ `
         rights_holder
         custom_key
         visibility
+        heirarchy_path
         thumbnail_path
         parent_collection
         create_date
         modified_date
         ... on Collection {
-          subject
           collection_category
-          heirarchy_path
           collectionmap_id
           collectionmap {
             id
@@ -72,7 +70,6 @@ export const searchObjects = /* GraphQL */ `
           contributor
           item_category
           manifest_url
-          heirarchy_path
           collection {
             id
             title
@@ -202,6 +199,7 @@ export const fulltextArchives = /* GraphQL */ `
         circa
         start_date
         end_date
+        subject
         rights_statement
         language
         resource_type
@@ -346,6 +344,7 @@ export const getCollection = /* GraphQL */ `
           circa
           start_date
           end_date
+          subject
           rights_statement
           language
           resource_type
@@ -553,6 +552,7 @@ export const getArchive = /* GraphQL */ `
       circa
       start_date
       end_date
+      subject
       rights_statement
       language
       resource_type
@@ -642,6 +642,7 @@ export const listArchives = /* GraphQL */ `
         circa
         start_date
         end_date
+        subject
         rights_statement
         language
         resource_type
@@ -791,6 +792,7 @@ export const archiveByIdentifier = /* GraphQL */ `
         circa
         start_date
         end_date
+        subject
         rights_statement
         language
         resource_type
@@ -995,6 +997,7 @@ export const searchArchives = /* GraphQL */ `
         circa
         start_date
         end_date
+        subject
         rights_statement
         language
         resource_type

--- a/src/graphql/schema.json
+++ b/src/graphql/schema.json
@@ -69,16 +69,6 @@
                     "ofType": null
                   },
                   "defaultValue": null
-                },
-                {
-                  "name": "category",
-                  "description": null,
-                  "type": {
-                    "kind": "SCALAR",
-                    "name": "String",
-                    "ofType": null
-                  },
-                  "defaultValue": null
                 }
               ],
               "type": {
@@ -1112,6 +1102,26 @@
               "deprecationReason": null
             },
             {
+              "name": "subject",
+              "description": null,
+              "args": [],
+              "type": {
+                "kind": "LIST",
+                "name": null,
+                "ofType": {
+                  "kind": "NON_NULL",
+                  "name": null,
+                  "ofType": {
+                    "kind": "SCALAR",
+                    "name": "String",
+                    "ofType": null
+                  }
+                }
+              },
+              "isDeprecated": false,
+              "deprecationReason": null
+            },
+            {
               "name": "location",
               "description": null,
               "args": [],
@@ -1270,6 +1280,26 @@
                   "kind": "SCALAR",
                   "name": "Boolean",
                   "ofType": null
+                }
+              },
+              "isDeprecated": false,
+              "deprecationReason": null
+            },
+            {
+              "name": "heirarchy_path",
+              "description": null,
+              "args": [],
+              "type": {
+                "kind": "LIST",
+                "name": null,
+                "ofType": {
+                  "kind": "NON_NULL",
+                  "name": null,
+                  "ofType": {
+                    "kind": "SCALAR",
+                    "name": "String",
+                    "ofType": null
+                  }
                 }
               },
               "isDeprecated": false,
@@ -1755,6 +1785,16 @@
               "type": {
                 "kind": "INPUT_OBJECT",
                 "name": "SearchableBooleanFilterInput",
+                "ofType": null
+              },
+              "defaultValue": null
+            },
+            {
+              "name": "heirarchy_path",
+              "description": null,
+              "type": {
+                "kind": "INPUT_OBJECT",
+                "name": "SearchableStringFilterInput",
                 "ofType": null
               },
               "defaultValue": null
@@ -3118,6 +3158,26 @@
               "deprecationReason": null
             },
             {
+              "name": "subject",
+              "description": null,
+              "args": [],
+              "type": {
+                "kind": "LIST",
+                "name": null,
+                "ofType": {
+                  "kind": "NON_NULL",
+                  "name": null,
+                  "ofType": {
+                    "kind": "SCALAR",
+                    "name": "String",
+                    "ofType": null
+                  }
+                }
+              },
+              "isDeprecated": false,
+              "deprecationReason": null
+            },
+            {
               "name": "rights_statement",
               "description": null,
               "args": [],
@@ -3671,6 +3731,16 @@
             },
             {
               "name": "end_date",
+              "description": null,
+              "type": {
+                "kind": "INPUT_OBJECT",
+                "name": "ModelStringFilterInput",
+                "ofType": null
+              },
+              "defaultValue": null
+            },
+            {
+              "name": "subject",
               "description": null,
               "type": {
                 "kind": "INPUT_OBJECT",
@@ -4711,6 +4781,12 @@
               "deprecationReason": null
             },
             {
+              "name": "heirarchy_path",
+              "description": null,
+              "isDeprecated": false,
+              "deprecationReason": null
+            },
+            {
               "name": "thumbnail_path",
               "description": null,
               "isDeprecated": false,
@@ -4886,6 +4962,16 @@
             },
             {
               "name": "end_date",
+              "description": null,
+              "type": {
+                "kind": "INPUT_OBJECT",
+                "name": "SearchableStringFilterInput",
+                "ofType": null
+              },
+              "defaultValue": null
+            },
+            {
+              "name": "subject",
               "description": null,
               "type": {
                 "kind": "INPUT_OBJECT",
@@ -5267,6 +5353,12 @@
               "deprecationReason": null
             },
             {
+              "name": "subject",
+              "description": null,
+              "isDeprecated": false,
+              "deprecationReason": null
+            },
+            {
               "name": "rights_statement",
               "description": null,
               "isDeprecated": false,
@@ -5370,6 +5462,12 @@
             },
             {
               "name": "visibility",
+              "description": null,
+              "isDeprecated": false,
+              "deprecationReason": null
+            },
+            {
+              "name": "heirarchy_path",
               "description": null,
               "isDeprecated": false,
               "deprecationReason": null
@@ -8364,6 +8462,24 @@
               "defaultValue": null
             },
             {
+              "name": "subject",
+              "description": null,
+              "type": {
+                "kind": "LIST",
+                "name": null,
+                "ofType": {
+                  "kind": "NON_NULL",
+                  "name": null,
+                  "ofType": {
+                    "kind": "SCALAR",
+                    "name": "String",
+                    "ofType": null
+                  }
+                }
+              },
+              "defaultValue": null
+            },
+            {
               "name": "rights_statement",
               "description": null,
               "type": {
@@ -8863,6 +8979,24 @@
                 "kind": "SCALAR",
                 "name": "String",
                 "ofType": null
+              },
+              "defaultValue": null
+            },
+            {
+              "name": "subject",
+              "description": null,
+              "type": {
+                "kind": "LIST",
+                "name": null,
+                "ofType": {
+                  "kind": "NON_NULL",
+                  "name": null,
+                  "ofType": {
+                    "kind": "SCALAR",
+                    "name": "String",
+                    "ofType": null
+                  }
+                }
               },
               "defaultValue": null
             },
@@ -9923,101 +10057,6 @@
         },
         {
           "kind": "INPUT_OBJECT",
-          "name": "ModelFloatFilterInput",
-          "description": null,
-          "fields": null,
-          "inputFields": [
-            {
-              "name": "ne",
-              "description": null,
-              "type": {
-                "kind": "SCALAR",
-                "name": "Float",
-                "ofType": null
-              },
-              "defaultValue": null
-            },
-            {
-              "name": "eq",
-              "description": null,
-              "type": {
-                "kind": "SCALAR",
-                "name": "Float",
-                "ofType": null
-              },
-              "defaultValue": null
-            },
-            {
-              "name": "le",
-              "description": null,
-              "type": {
-                "kind": "SCALAR",
-                "name": "Float",
-                "ofType": null
-              },
-              "defaultValue": null
-            },
-            {
-              "name": "lt",
-              "description": null,
-              "type": {
-                "kind": "SCALAR",
-                "name": "Float",
-                "ofType": null
-              },
-              "defaultValue": null
-            },
-            {
-              "name": "ge",
-              "description": null,
-              "type": {
-                "kind": "SCALAR",
-                "name": "Float",
-                "ofType": null
-              },
-              "defaultValue": null
-            },
-            {
-              "name": "gt",
-              "description": null,
-              "type": {
-                "kind": "SCALAR",
-                "name": "Float",
-                "ofType": null
-              },
-              "defaultValue": null
-            },
-            {
-              "name": "between",
-              "description": null,
-              "type": {
-                "kind": "LIST",
-                "name": null,
-                "ofType": {
-                  "kind": "SCALAR",
-                  "name": "Float",
-                  "ofType": null
-                }
-              },
-              "defaultValue": null
-            }
-          ],
-          "interfaces": null,
-          "enumValues": null,
-          "possibleTypes": null
-        },
-        {
-          "kind": "SCALAR",
-          "name": "Float",
-          "description": "Built-in Float",
-          "fields": null,
-          "inputFields": null,
-          "interfaces": null,
-          "enumValues": null,
-          "possibleTypes": null
-        },
-        {
-          "kind": "INPUT_OBJECT",
           "name": "SearchableIntFilterInput",
           "description": null,
           "fields": null,
@@ -10254,6 +10293,101 @@
             },
             {
               "name": "range",
+              "description": null,
+              "type": {
+                "kind": "LIST",
+                "name": null,
+                "ofType": {
+                  "kind": "SCALAR",
+                  "name": "Float",
+                  "ofType": null
+                }
+              },
+              "defaultValue": null
+            }
+          ],
+          "interfaces": null,
+          "enumValues": null,
+          "possibleTypes": null
+        },
+        {
+          "kind": "SCALAR",
+          "name": "Float",
+          "description": "Built-in Float",
+          "fields": null,
+          "inputFields": null,
+          "interfaces": null,
+          "enumValues": null,
+          "possibleTypes": null
+        },
+        {
+          "kind": "INPUT_OBJECT",
+          "name": "ModelFloatFilterInput",
+          "description": null,
+          "fields": null,
+          "inputFields": [
+            {
+              "name": "ne",
+              "description": null,
+              "type": {
+                "kind": "SCALAR",
+                "name": "Float",
+                "ofType": null
+              },
+              "defaultValue": null
+            },
+            {
+              "name": "eq",
+              "description": null,
+              "type": {
+                "kind": "SCALAR",
+                "name": "Float",
+                "ofType": null
+              },
+              "defaultValue": null
+            },
+            {
+              "name": "le",
+              "description": null,
+              "type": {
+                "kind": "SCALAR",
+                "name": "Float",
+                "ofType": null
+              },
+              "defaultValue": null
+            },
+            {
+              "name": "lt",
+              "description": null,
+              "type": {
+                "kind": "SCALAR",
+                "name": "Float",
+                "ofType": null
+              },
+              "defaultValue": null
+            },
+            {
+              "name": "ge",
+              "description": null,
+              "type": {
+                "kind": "SCALAR",
+                "name": "Float",
+                "ofType": null
+              },
+              "defaultValue": null
+            },
+            {
+              "name": "gt",
+              "description": null,
+              "type": {
+                "kind": "SCALAR",
+                "name": "Float",
+                "ofType": null
+              },
+              "defaultValue": null
+            },
+            {
+              "name": "between",
               "description": null,
               "type": {
                 "kind": "LIST",
@@ -11143,6 +11277,15 @@
           "onField": true
         },
         {
+          "name": "aws_api_key",
+          "description": "Tells the service this field/object has access authorized by an API key.",
+          "locations": ["OBJECT", "FIELD_DEFINITION"],
+          "args": [],
+          "onOperation": false,
+          "onFragment": false,
+          "onField": false
+        },
+        {
           "name": "deprecated",
           "description": null,
           "locations": ["FIELD_DEFINITION", "ENUM_VALUE"],
@@ -11156,6 +11299,30 @@
                 "ofType": null
               },
               "defaultValue": "\"No longer supported\""
+            }
+          ],
+          "onOperation": false,
+          "onFragment": false,
+          "onField": false
+        },
+        {
+          "name": "aws_auth",
+          "description": "Directs the schema to enforce authorization on a field",
+          "locations": ["FIELD_DEFINITION"],
+          "args": [
+            {
+              "name": "cognito_groups",
+              "description": "List of cognito user pool groups which have access on this field",
+              "type": {
+                "kind": "LIST",
+                "name": null,
+                "ofType": {
+                  "kind": "SCALAR",
+                  "name": "String",
+                  "ofType": null
+                }
+              },
+              "defaultValue": null
             }
           ],
           "onOperation": false,
@@ -11196,56 +11363,8 @@
           "onField": false
         },
         {
-          "name": "aws_subscribe",
-          "description": "Tells the service which mutation triggers this subscription.",
-          "locations": ["FIELD_DEFINITION"],
-          "args": [
-            {
-              "name": "mutations",
-              "description": "List of mutations which will trigger this subscription when they are called.",
-              "type": {
-                "kind": "LIST",
-                "name": null,
-                "ofType": {
-                  "kind": "SCALAR",
-                  "name": "String",
-                  "ofType": null
-                }
-              },
-              "defaultValue": null
-            }
-          ],
-          "onOperation": false,
-          "onFragment": false,
-          "onField": false
-        },
-        {
-          "name": "aws_auth",
-          "description": "Directs the schema to enforce authorization on a field",
-          "locations": ["FIELD_DEFINITION"],
-          "args": [
-            {
-              "name": "cognito_groups",
-              "description": "List of cognito user pool groups which have access on this field",
-              "type": {
-                "kind": "LIST",
-                "name": null,
-                "ofType": {
-                  "kind": "SCALAR",
-                  "name": "String",
-                  "ofType": null
-                }
-              },
-              "defaultValue": null
-            }
-          ],
-          "onOperation": false,
-          "onFragment": false,
-          "onField": false
-        },
-        {
-          "name": "aws_api_key",
-          "description": "Tells the service this field/object has access authorized by an API key.",
+          "name": "aws_oidc",
+          "description": "Tells the service this field/object has access authorized by an OIDC token.",
           "locations": ["OBJECT", "FIELD_DEFINITION"],
           "args": [],
           "onOperation": false,
@@ -11277,10 +11396,25 @@
           "onField": false
         },
         {
-          "name": "aws_oidc",
-          "description": "Tells the service this field/object has access authorized by an OIDC token.",
-          "locations": ["OBJECT", "FIELD_DEFINITION"],
-          "args": [],
+          "name": "aws_subscribe",
+          "description": "Tells the service which mutation triggers this subscription.",
+          "locations": ["FIELD_DEFINITION"],
+          "args": [
+            {
+              "name": "mutations",
+              "description": "List of mutations which will trigger this subscription when they are called.",
+              "type": {
+                "kind": "LIST",
+                "name": null,
+                "ofType": {
+                  "kind": "SCALAR",
+                  "name": "String",
+                  "ofType": null
+                }
+              },
+              "defaultValue": null
+            }
+          ],
           "onOperation": false,
           "onFragment": false,
           "onField": false

--- a/src/graphql/subscriptions.js
+++ b/src/graphql/subscriptions.js
@@ -83,6 +83,7 @@ export const onCreateCollection = /* GraphQL */ `
           circa
           start_date
           end_date
+          subject
           rights_statement
           language
           resource_type
@@ -198,6 +199,7 @@ export const onUpdateCollection = /* GraphQL */ `
           circa
           start_date
           end_date
+          subject
           rights_statement
           language
           resource_type
@@ -313,6 +315,7 @@ export const onDeleteCollection = /* GraphQL */ `
           circa
           start_date
           end_date
+          subject
           rights_statement
           language
           resource_type
@@ -527,6 +530,7 @@ export const onCreateArchive = /* GraphQL */ `
       circa
       start_date
       end_date
+      subject
       rights_statement
       language
       resource_type
@@ -611,6 +615,7 @@ export const onUpdateArchive = /* GraphQL */ `
       circa
       start_date
       end_date
+      subject
       rights_statement
       language
       resource_type
@@ -695,6 +700,7 @@ export const onDeleteArchive = /* GraphQL */ `
       circa
       start_date
       end_date
+      subject
       rights_statement
       language
       resource_type

--- a/src/lib/fetchTools.js
+++ b/src/lib/fetchTools.js
@@ -157,7 +157,6 @@ export const fetchSearchResults = async (
     } else if (key === "collection") {
       let parent_collection_id = await getCollectionIDByTitle(filter[key]);
       filters["heirarchy_path"] = { eq: parent_collection_id };
-      objectFilter = archiveFilter;
     } else if (key === "title" || key === "description") {
       filters[key] = { matchPhrase: filter[key] };
     } else if (Array.isArray(filter[key])) {
@@ -193,9 +192,8 @@ export const fetchSearchResults = async (
   if (category === "collection") {
     const item_fields = ["format", "medium", "resource_type", "tags"];
     if (
-      filters.hasOwnProperty("heirarchy_path") ||
-      (filters.hasOwnProperty("and") &&
-        item_fields.some(e => Object.keys(filter).indexOf(e) > -1))
+      filters.hasOwnProperty("and") &&
+      item_fields.some(e => Object.keys(filter).indexOf(e) > -1)
     ) {
       searchResults = {
         items: [],
@@ -213,10 +211,7 @@ export const fetchSearchResults = async (
         searchResults = Collections.data.searchCollections;
       }
     }
-  } else if (
-    category === "archive" ||
-    filters.hasOwnProperty("heirarchy_path")
-  ) {
+  } else if (category === "archive") {
     options["filter"] = { ...archiveFilter, ...filters };
     let Archives = null;
     if (allFields) {


### PR DESCRIPTION
…h' field in Object interface type

**JIRA Ticket**: (https://webapps.es.vt.edu/jira/browse/LIBTD-2356) (:star:)

# What does this Pull Request do? (:star:)
This PR addresses the issue that in SWVA site, "Collection" search facet does not return proper search results when "Collection" category is chosen. It is fixed by including "heirarchy_path" field in Object interface in schema so that no matter which category (collection/archive/both) is chosen, the corresponding search results will be returned. 

# What's the changes? (:star:)

* schema.graphql: Adds "heirarchy_path" field in Object type and "subject" in Archive type
* src/lib/fetchTools.js: Simply sets "heirarchy_path" filter without checking for category conditions

# How should this be tested?

* Go to SWVA site, and then "Search" page
* Check if "Collection" search facet returns correct search results when changing category choices: collection, item or no choice

# Interested parties
Tag (@yinlinchen) interested parties

(:star:) Required fields
