### PR TITLE
LIBTD-2357: Hide the collapsible arrow beside facet field if no facet…

### DIFF
--- a/src/components/Collapsible.js
+++ b/src/components/Collapsible.js
@@ -100,6 +100,26 @@ class Collapsible extends Component {
     }
   }
 
+  collapsibleArrow = () => {
+    if (this.props.facetNodes.length) {
+      return this.state.expanded ? (
+        <FontAwesomeIcon
+          icon={faAngleDoubleRight}
+          size="1x"
+          color="var(--darker-gray)"
+          className="float-right"
+        />
+      ) : (
+        <FontAwesomeIcon
+          icon={faAngleDoubleDown}
+          size="1x"
+          color="var(--darker-gray)"
+          className="float-right"
+        />
+      );
+    } else return <></>;
+  };
+
   render() {
     const DisplayAllLess = () => {
       if (this.props.facetNodes.length > 5) {
@@ -143,21 +163,7 @@ class Collapsible extends Component {
               {labelAttr(this.props.filterField)}
             </button>
           </h3>
-          {this.state.expanded ? (
-            <FontAwesomeIcon
-              icon={faAngleDoubleRight}
-              size="1x"
-              color="var(--darker-gray)"
-              className="float-right"
-            />
-          ) : (
-            <FontAwesomeIcon
-              icon={faAngleDoubleDown}
-              size="1x"
-              color="var(--darker-gray)"
-              className="float-right"
-            />
-          )}
+          {this.collapsibleArrow()}
         </div>
         {this.state.expanded ? (
           <div>


### PR DESCRIPTION
… values are selectable

**JIRA Ticket**: (https://webapps.es.vt.edu/jira/browse/LIBTD-2357) (:star:)

# What does this Pull Request do? (:star:)
This PR improves search facets interface by making the collapsible arrows beside the facet fields disappear if no selectable facet values under this facet field. This will prevent users from clicking on the empty facet field and reduce confusion. 

# What's the changes? (:star:)

* Hide or show the collapsible button based on if there is any applicable facet values under the facet field

# How should this be tested?

* Go to "Search" page, choose some facet value under a facet field, observe some other facet field displayed without the collapsible button. For example, choose "collection" under "category", then the arrows beside the "Format", "Medium", "Tags", and "Type" facet fields would disappear as these fields are only applicable to "Item" category.

# Interested parties
Tag (@yinlinchen) interested parties

(:star:) Required fields
