### PR TITLE
Updated to Mirador 3

### DIFF
--- a/cypress/integration/admin_collectionpage_filter_sort_config.spec.js
+++ b/cypress/integration/admin_collectionpage_filter_sort_config.spec.js
@@ -119,6 +119,7 @@ describe("Displays and updates sitepages configurations", () => {
       cy.get("#content-wrapper > div > div > div > form > ul > section:nth-child(4)")
         .contains("Delete Sort Field")
         .click();
+      cy.wait(1000);
       cy.contains("Update Filter and Sort Fields").click();
       cy.wait(1000);
       cy.contains("Sort Field: identifier").should("not.be.visible");

--- a/cypress/integration/archive_media_views.spec.js
+++ b/cypress/integration/archive_media_views.spec.js
@@ -50,11 +50,11 @@ describe('Archive pdf embed', () => {
 describe('Archive Mirador viewer', () => {
   it('renders viewer if manifest.json', () => {
     cy.visit('/archive/5v709r98');
-    cy.get('div#mirador_viewer')
+    cy.get('div#mirador_viewer > div > main')
       .eq(0)
-      .should('have.class', 'mirador-container')
+      .should('have.class', 'mirador-viewer')
       .should('be.visible');
-    cy.get('div.workspace-container > div > div > div.window > div.content-container > div.view-container > div.image-view')
+    cy.get('div.mirador-primary-window > section.mirador-osd-container > div.openseadragon-container > div.openseadragon-canvas > canvas')
       .eq(0)
       .should('be.visible');
   });

--- a/cypress/integration/collection_metadata_display.spec.js
+++ b/cypress/integration/collection_metadata_display.spec.js
@@ -18,11 +18,11 @@ describe('A single Collection Show page metadata section', () => {
 
   it('displays the identifier field and its corresponding value', () => {
     cy.get('@metadataSection')
-      .find(':nth-child(7) > th.collection-detail-key')
+      .find(':nth-child(6) > th.collection-detail-key')
       .invoke('text')
       .should('equal', 'Identifier');
     cy.get('@metadataSection')
-      .find(':nth-child(7) > td.collection-detail-value').click();
+      .find(':nth-child(6) > td.collection-detail-value').click();
     cy.url().should('include', '/collection/vb765t25');
   })
 })

--- a/public/index.html
+++ b/public/index.html
@@ -129,7 +129,7 @@
 </script>
 
 <script type="text/javascript" src="%PUBLIC_URL%/js/one.js"></script>
-<script src="https://static.lib.vt.edu/iawa/js/mirador.js"></script>
+<script src="https://unpkg.com/mirador@latest/dist/mirador.min.js"></script>
 
 <script type="text/javascript">
 

--- a/src/components/Citation.js
+++ b/src/components/Citation.js
@@ -37,7 +37,7 @@ class Citation extends Component {
                 tabIndex="0"
               >
                 <span className="help-icon">
-                  <i class="fas fa-question-circle"></i>
+                  <i className="fas fa-question-circle"></i>
                 </span>
               </Tooltip>
             </MuiThemeProvider>

--- a/src/components/MiradorViewer.js
+++ b/src/components/MiradorViewer.js
@@ -12,84 +12,54 @@ class MiradorViewer extends Component {
 
   miradorConfig() {
     let config = {
+      language: "en",
       id: "mirador_viewer",
-      mainMenuSettings: {
-        show: false
+      window: {
+        allowClose: false,
+        allowFullscreen: true,
+        allowMaximize: false,
+        allowWindowSideBar: true,
+        defaultView: "single",
+        panels: {
+          canvas: false,
+          search: false
+        }
       },
-      data: [
+      views: [{ key: "single", behaviors: ["individuals"] }],
+      windows: [
         {
-          manifestUri: this.props.item.manifest_url,
-          location: this.props.site.siteId.toUpperCase()
+          manifestId: this.props.item.manifest_url
         }
       ],
-      windowObjects: [
-        {
-          loadedManifest: this.props.item.manifest_url,
-          viewType: "ImageView",
-          displayLayout: false,
-          bottomPanel: false,
-          bottomPanelAvailable: false,
-          bottomPanelVisible: false,
-          sidePanel: false,
-          annotationLayer: false
-        }
-      ],
-      showAddFromURLBox: false
+      thumbnailNavigation: {
+        defaultPosition: "far-bottom"
+      },
+      workspace: {
+        draggingEnabled: false,
+        allowNewWindows: false,
+        isWorkspaceAddVisible: false,
+        showZoomControls: true,
+        type: "mosaic"
+      },
+      workspaceControlPanel: {
+        enabled: false
+      }
     };
     if (
       this.props.site.miradorOptions &&
       this.props.site.miradorOptions.windowObjects
     ) {
-      config.windowObjects[0] = Object.assign(
-        config.windowObjects[0],
+      config.windows[0] = Object.assign(
+        config.windows[0],
         this.props.site.miradorOptions.windowObjects
       );
     }
     return config;
   }
 
-  hideElement(elementClassName) {
-    window.setTimeout(function() {
-      try {
-        let elem = document.getElementsByClassName(elementClassName)[0];
-        elem.style.display = "none";
-      } catch (error) {
-        console.log(`error hiding ${elementClassName}`);
-      }
-    }, 500);
-  }
-
-  setOptionState(option) {
-    if (
-      this.props.site.miradorOptions &&
-      option in this.props.site.miradorOptions
-    ) {
-      let stateObj = {};
-      stateObj[option] = this.props.site.miradorOptions[option];
-
-      this.setState(stateObj, function() {
-        this.setOptionVisibility();
-      });
-    } else {
-      this.setOptionVisibility();
-    }
-  }
-
-  setOptionVisibility() {
-    if (!this.state.annotationTooltipVisible) {
-      this.hideElement("mirador-osd-annotation-controls");
-    }
-    if (!this.state.viewTypeControlVisible) {
-      this.hideElement("mirador-icon-view-type");
-    }
-  }
-
   componentDidMount() {
     this.miradorConfig();
-    window.Mirador(this.miradorConfig());
-
-    this.setOptionState("annotationTooltipVisible");
-    this.setOptionState("viewTypeControlVisible");
+    window.Mirador.viewer(this.miradorConfig());
   }
 
   render() {

--- a/src/css/ArchivePage.css
+++ b/src/css/ArchivePage.css
@@ -6,7 +6,7 @@
   margin-top: 40px;
   background-color: var(--light-gray);
   border: solid 1px #707070;
-  padding: 1.5em;
+  padding: 0.5em;
 }
 
 div.item-image-section div.breadcrumbs-wrapper {
@@ -27,7 +27,7 @@ div.item-image-section img.item-img {
   padding: 40px 0 40px 0;
 }
 
-.details-section-description h1 {
+.details-section-description h2 {
   font-family: "gineso-condensed", sans-serif;
   font-size: 1.3125rem;
 }
@@ -76,6 +76,12 @@ div.item-image-section img.item-img {
   word-break: break-all;
 }
 
+@media (min-width: 576px) {
+  .item-image-section {
+    padding: 1.5em;
+  }
+}
+
 @media (min-width: 992px) {
   div.details-section-metadata {
     border-left: 1px solid grey;
@@ -83,8 +89,6 @@ div.item-image-section img.item-img {
   }
 
   div.item-image-section div.breadcrumbs-wrapper {
-    padding: 0 0 1.5em 0;
-    font-family: "gineso-condensed", sans-serif;
     font-size: 1.09rem;
   }
 }

--- a/src/css/Viewer.css
+++ b/src/css/Viewer.css
@@ -1,5 +1,11 @@
 #mirador_viewer {
-  height: 700px;
+  height: 600px;
   width: 100%;
   position: relative;
+}
+
+@media (min-width: 768px) {
+  #mirador_viewer {
+    height: 800px;
+  }
 }

--- a/src/pages/archives/ArchivePage.js
+++ b/src/pages/archives/ArchivePage.js
@@ -212,7 +212,7 @@ class ArchivePage extends Component {
                   aria-label="Item details"
                 >
                   <div className="col-lg-6 details-section-description">
-                    <h1>{item.title}</h1>
+                    <h2>{item.title}</h2>
                     {addNewlineInDesc(item.description)}
                   </div>
                   <div className="col-lg-6 details-section-metadata">


### PR DESCRIPTION
**JIRA Ticket**: (link) (:star:)
https://webapps.es.vt.edu/jira/browse/LIBTD-2315

# What does this Pull Request do? (:star:)
Changes IIIF viewer to Mirador which offers better accessibility features.

# What's the changes? (:star:)
-Updates cypress test for mirador viewer
-Updates script to load viewer
-Revises viewer configuration and uses the new settings available for this version.
-changes a couple of CSS styles
-includes one unrelated fix for className in citation component. 

# How should this be tested?
Viewer should show up on each archive page which has a manifest. If the object has multiple images, the thumbnails should show in a ribbon. All controls in Mirador 3 should be keyboard accessible by default.

# Additional Notes:
Branch in LIBTD-2315

# Interested parties
@yinlinchen 

(:star:) Required fields
