### PR TITLE
adds thumbnail representations for audio and video records

### DIFF
--- a/cypress/integration/archive_media_views.spec.js
+++ b/cypress/integration/archive_media_views.spec.js
@@ -9,6 +9,13 @@ describe('Archive static img view', () => {
 });
 
 describe('Archive audio player', () => {
+  it('renders audio file thumbnail', () => {
+    cy.visit('/archive/m69xyh01');
+    cy.get('div.audio-img-wrapper')
+      .find('img')
+      .should('have.class', 'audio-img')
+      .should('be.visible');
+  });
   it('renders html5 audio player', () => {
     cy.visit('/archive/m69xyh01');
     cy.get('audio')
@@ -25,6 +32,11 @@ describe('Archive video player', () => {
       .should('have.id', 'player1_html5')
       .should('be.visible');
   });
+  it('renders with img placeholder', () => {
+    cy.visit('/archive/m70xyh12');
+    cy.get('video')
+      .invoke('attr', 'poster').should('eq', 'http://i3.ytimg.com/vi/iWO5N3n1DXU/hqdefault.jpg')
+  })
 });
 
 describe('Archive kaltura embed', () => {

--- a/src/components/MediaElement.js
+++ b/src/components/MediaElement.js
@@ -46,6 +46,14 @@ export default class MediaElement extends Component {
     }
   }
 
+  audioImg() {
+    return (
+      <div className="audio-img-wrapper">
+        <img className="audio-img" src={this.props.poster} />
+      </div>
+    );
+  }
+
   render() {
     const props = this.props,
       sources = JSON.parse(props.sources),
@@ -81,6 +89,11 @@ export default class MediaElement extends Component {
           : `<audio id="${props.id}" width="${props.width}" controls>
           ${mediaBody}
         </audio>`;
-    return <div dangerouslySetInnerHTML={{ __html: mediaHtml }}></div>;
+    return (
+      <div>
+        {props.mediaType === "audio" && this.audioImg()}
+        <div dangerouslySetInnerHTML={{ __html: mediaHtml }}></div>
+      </div>
+    );
   }
 }

--- a/src/css/ArchivePage.css
+++ b/src/css/ArchivePage.css
@@ -76,6 +76,17 @@ div.item-image-section img.item-img {
   word-break: break-all;
 }
 
+div.audio-img-wrapper {
+  position: relative;
+  display: block;
+  width: 100%;
+}
+img.audio-img {
+  display: block;
+  max-width: 50%;
+  margin: 0 auto;
+}
+
 @media (min-width: 576px) {
   .item-image-section {
     padding: 1.5em;

--- a/src/pages/archives/ArchivePage.js
+++ b/src/pages/archives/ArchivePage.js
@@ -75,7 +75,7 @@ class ArchivePage extends Component {
     return url.match(/\.(json)$/) != null;
   }
 
-  buildTrack(url) {
+  buildTrack(url, thumbnail_path) {
     const nameExt = this.fileNameFromUrl(url);
     const name = nameExt.split(".")[0];
 
@@ -84,6 +84,8 @@ class ArchivePage extends Component {
     track["label"] = "English";
     track["src"] = url.replace(nameExt, name + ".srt");
     track["srclang"] = "en";
+    track["poster"] = thumbnail_path;
+    console.log(track);
     return track;
   }
 
@@ -98,11 +100,11 @@ class ArchivePage extends Component {
         <img className="item-img" src={item.manifest_url} alt={item.title} />
       );
     } else if (this.isAudioURL(item.manifest_url)) {
-      const track = this.buildTrack(item.manifest_url);
+      const track = this.buildTrack(item.manifest_url, item.thumbnail_path);
       tracks.push(track);
       display = this.mediaElement(item.manifest_url, "audio", config, tracks);
     } else if (this.isVideoURL(item.manifest_url)) {
-      const track = this.buildTrack(item.manifest_url);
+      const track = this.buildTrack(item.manifest_url, item.thumbnail_path);
       tracks.push(track);
       display = this.mediaElement(item.manifest_url, "video", config, tracks);
     } else if (this.isKalturaURL(item.manifest_url)) {
@@ -128,7 +130,6 @@ class ArchivePage extends Component {
 
   mediaElement(src, type, config, tracks) {
     const filename = this.fileNameFromUrl(src);
-    console.log(filename);
     const typeString = `${type}/${this.fileExtensionFromFileName(filename)}`;
     const srcArray = [{ src: src, type: typeString }];
     return (
@@ -139,7 +140,7 @@ class ArchivePage extends Component {
         controls
         width="100%"
         height="640"
-        poster=""
+        poster={tracks[0].poster}
         sources={JSON.stringify(srcArray)}
         options={JSON.stringify(config)}
         tracks={JSON.stringify(tracks)}


### PR DESCRIPTION
**adds thumbnail representations for audio and video records.**
* * *

**JIRA Ticket**: (https://webapps.es.vt.edu/jira/browse/LIBTD-2388) (:star:)

* Other Relevant Links (Meeting note, project page, related pull requests, etc.)

# What does this Pull Request do? (:star:)
adds thumbnail representations for audio and video records

# What's the changes? (:star:)
* Sets the "poster" attribute to the value of the item.thumbnail_image for video records
* Adds an additional div above audio player with img tag that renders with the item.thumbnail_image as it's source for audio records

# How should this be tested?

A description of what steps someone could take to:
* visit "/archive/m70xyh12" and check that static img is rendering as video placeholder
* visit "/archive/m69aah01" (or any of the other podcast items) and check that static img is rendering above audio player

# Additional Notes:
* branch: `LIBTD-2388`

# Interested parties
@yinlinchen 

(:star:) Required fields
