### PR TITLE
add alt tag

### DIFF
--- a/src/components/MediaElement.js
+++ b/src/components/MediaElement.js
@@ -49,7 +49,11 @@ export default class MediaElement extends Component {
   audioImg() {
     return (
       <div className="audio-img-wrapper">
-        <img className="audio-img" src={this.props.poster} />
+        <img
+          className="audio-img"
+          src={this.props.poster}
+          alt={this.props.title}
+        />
       </div>
     );
   }

--- a/src/pages/archives/ArchivePage.js
+++ b/src/pages/archives/ArchivePage.js
@@ -85,11 +85,11 @@ class ArchivePage extends Component {
     track["src"] = url.replace(nameExt, name + ".srt");
     track["srclang"] = "en";
     track["poster"] = thumbnail_path;
-    console.log(track);
     return track;
   }
 
   mediaDisplay(item) {
+    console.log(item);
     let display = null;
     let config = {};
     let tracks = [];
@@ -102,7 +102,13 @@ class ArchivePage extends Component {
     } else if (this.isAudioURL(item.manifest_url)) {
       const track = this.buildTrack(item.manifest_url, item.thumbnail_path);
       tracks.push(track);
-      display = this.mediaElement(item.manifest_url, "audio", config, tracks);
+      display = this.mediaElement(
+        item.manifest_url,
+        "audio",
+        config,
+        tracks,
+        item.title
+      );
     } else if (this.isVideoURL(item.manifest_url)) {
       const track = this.buildTrack(item.manifest_url, item.thumbnail_path);
       tracks.push(track);
@@ -128,7 +134,7 @@ class ArchivePage extends Component {
     return url.pathname.split("/").reverse()[0];
   }
 
-  mediaElement(src, type, config, tracks) {
+  mediaElement(src, type, config, tracks, title = "") {
     const filename = this.fileNameFromUrl(src);
     const typeString = `${type}/${this.fileExtensionFromFileName(filename)}`;
     const srcArray = [{ src: src, type: typeString }];
@@ -144,6 +150,7 @@ class ArchivePage extends Component {
         sources={JSON.stringify(srcArray)}
         options={JSON.stringify(config)}
         tracks={JSON.stringify(tracks)}
+        title={title}
       />
     );
   }


### PR DESCRIPTION
**Adds alt tag to audio record thumbnail img.**
* * *

**JIRA Ticket**: (link) (:star:)

* Other Relevant Links (Meeting note, project page, related pull requests, etc.)

# What does this Pull Request do? (:star:)
Adds alt tag to audio record thumbnail img.

# What's the changes? (:star:)
* Adds alt tag to audio record thumbnail img.

# How should this be tested?
* Check any audio record show page, such as `/archive/m69xyh01`
* Right click on the thumbnail image and choose "Inspect"
* In dev tools check that the img element has a value for it's alt attribute

# Additional Notes:
* branch: `fix_img_alt`

# Interested parties
@yinlinchen 

(:star:) Required fields
