### PR TITLE
LIBTD-2394: Map DLP terms to DC/Display Fields if sub-label exists fo…

### DIFF
--- a/cypress/integration/admin_collectionpage_filter_sort_config.spec.js
+++ b/cypress/integration/admin_collectionpage_filter_sort_config.spec.js
@@ -26,7 +26,7 @@ describe("Displays and updates browse collections page configurations", () => {
 
     cy.get("#content-wrapper > div > div > ul")
       .find(":nth-child(6) > a")
-      .contains("Filter and Sort Config for Browse Collections Page")
+      .contains("Browse Collections Page")
       .click();
     cy.wait(500);
     cy.url().should("include", "/siteAdmin");

--- a/cypress/integration/admin_page_searchfacets_config.spec.js
+++ b/cypress/integration/admin_page_searchfacets_config.spec.js
@@ -1,7 +1,7 @@
 const USERNAME = "devtest";
 const PASSWORD = Cypress.env("password");
 
-describe("Displays and updates sitepages configurations", () => {
+describe("Displays and updates search page configurations", () => {
   beforeEach(() => {
     cy.visit("/siteAdmin");
     cy.get("amplify-authenticator")
@@ -26,7 +26,7 @@ describe("Displays and updates sitepages configurations", () => {
 
     cy.get("#content-wrapper > div > div > ul")
       .find(":nth-child(5) > a")
-      .contains("Search Facets Config")
+      .contains("Search Page Config")
       .click();
     cy.url({ timeout: 2000 }).should("include", "/siteAdmin");
   });

--- a/cypress/integration/collection_metadata_display.spec.js
+++ b/cypress/integration/collection_metadata_display.spec.js
@@ -18,11 +18,11 @@ describe('A single Collection Show page metadata section', () => {
 
   it('displays the identifier field and its corresponding value', () => {
     cy.get('@metadataSection')
-      .find(':nth-child(7) > th.collection-detail-key')
+      .find(':nth-child(6) > th.collection-detail-key')
       .invoke('text')
       .should('equal', 'Identifier');
     cy.get('@metadataSection')
-      .find(':nth-child(7) > td.collection-detail-value').click();
+      .find(':nth-child(6) > td.collection-detail-value').click();
     cy.url({ timeout: 2000 }).should('include', '/collection/vb765t25demo');
   })
 })

--- a/src/lib/MetadataRenderer.js
+++ b/src/lib/MetadataRenderer.js
@@ -42,9 +42,15 @@ export function titleFormatted(item, category) {
 }
 export function dateFormatted(item) {
   let circa_date = item.circa ? item.circa : "";
-  let end_date = item.end_date ? " - " + parseInt(item.end_date) : "";
-  let start_date = item.start_date ? parseInt(item.start_date) : "";
+  let end_date = item.end_date ? " - " + yearmonthDate(item.end_date) : "";
+  let start_date = item.start_date ? yearmonthDate(item.start_date) : "";
   return circa_date + start_date + end_date;
+}
+
+function yearmonthDate(date) {
+  if (date.length === 6) {
+    return [date.slice(0, 4), "/", date.slice(4)].join("");
+  } else return date;
 }
 
 export function collectionSizeText(collection) {
@@ -131,7 +137,7 @@ function textFormat(item, attr, languages) {
     );
   } else if (attr === "description") {
     return <MoreLink category={category} item={item} />;
-  } else if (attr === "date") {
+  } else if (attr === "start_date") {
     return dateFormatted(item);
   } else if (attr === "size") {
     if (category === "collection") return collectionSizeText(item);
@@ -156,7 +162,8 @@ const MoreLink = ({ category, item }) => {
 };
 
 const RenderAttribute = ({ item, attribute, languages }) => {
-  if (textFormat(item, attribute.field, languages)) {
+  const item_value = textFormat(item, attribute.field, languages);
+  if (item_value) {
     let value_style = attribute.field === "identifier" ? "identifier" : "";
     return (
       <div className="collection-detail">
@@ -167,7 +174,7 @@ const RenderAttribute = ({ item, attribute, languages }) => {
                 {attribute.label}:
               </th>
               <td className={`collection-detail-value ${value_style}`}>
-                {textFormat(item, attribute.field, languages)}
+                {item_value}
               </td>
             </tr>
           </tbody>
@@ -180,23 +187,44 @@ const RenderAttribute = ({ item, attribute, languages }) => {
 };
 
 const RenderAttrDetailed = ({ item, attribute, languages, type }) => {
+  const item_value = item[attribute.field];
+  const item_label = attribute.label;
   if (textFormat(item, attribute.field, languages)) {
     let value_style = attribute.field === "identifier" ? "identifier" : "";
     if (type === "table") {
-      return (
-        <tr>
-          <th className="collection-detail-key" scope="row">
-            {attribute.label}
-          </th>
-          <td className={`collection-detail-value ${value_style}`}>
-            {textFormat(item, attribute.field, languages)}
-          </td>
-        </tr>
-      );
+      if (
+        Array.isArray(item_label) &&
+        Array.isArray(item_value) &&
+        item_label.length >= item_value.length
+      ) {
+        return item_value.map((i_value, idx) => {
+          return (
+            <tr key={`${item_label}_${idx}`}>
+              <th className="collection-detail-key" scope="row">
+                {item_label[idx]}
+              </th>
+              <td className={`collection-detail-value ${value_style}`}>
+                {i_value}
+              </td>
+            </tr>
+          );
+        });
+      } else {
+        return (
+          <tr key={item_label}>
+            <th className="collection-detail-key" scope="row">
+              {item_label}
+            </th>
+            <td className={`collection-detail-value ${value_style}`}>
+              {textFormat(item, attribute.field, languages)}
+            </td>
+          </tr>
+        );
+      }
     } else if (type === "grid") {
       return (
         <div className="collection-detail-entry">
-          <div className="collection-detail-key">{attribute.label}</div>
+          <div className="collection-detail-key">{item_label}</div>
           <div className={`collection-detail-value ${value_style}`}>
             {textFormat(item, attribute.field, languages)}
           </div>
@@ -209,7 +237,7 @@ const RenderAttrDetailed = ({ item, attribute, languages, type }) => {
 };
 export const RenderItems = ({ keyArray, item, languages }) => {
   let render_items = [];
-  for (const [index, value] of keyArray.entries()) {
+  keyArray.forEach((value, index) => {
     render_items.push(
       <RenderAttribute
         item={item}
@@ -218,7 +246,7 @@ export const RenderItems = ({ keyArray, item, languages }) => {
         languages={languages}
       />
     );
-  }
+  });
   return render_items;
 };
 
@@ -229,7 +257,7 @@ export const RenderItemsDetailed = ({
   type = "table"
 }) => {
   let render_items_detailed = [];
-  for (const [index, value] of keyArray.entries()) {
+  keyArray.forEach((value, index) => {
     render_items_detailed.push(
       <RenderAttrDetailed
         item={item}
@@ -239,6 +267,6 @@ export const RenderItemsDetailed = ({
         type={type}
       />
     );
-  }
+  });
   return render_items_detailed;
 };

--- a/src/pages/admin/BrowseCollectionsForm.js
+++ b/src/pages/admin/BrowseCollectionsForm.js
@@ -351,7 +351,7 @@ class BrowseCollectionsForm extends Component {
   render() {
     return (
       <div className="col-lg-9 col-sm-12 admin-content">
-        <h1>{`Browse Collections page's filter and sort: ${process.env.REACT_APP_REP_TYPE.toLowerCase()}`}</h1>
+        <h1>{`Browse Collections page's filter and sort for ${process.env.REACT_APP_REP_TYPE.toLowerCase()}`}</h1>
         <Form>
           <Form.Group inline>
             <label>Current mode:</label>

--- a/src/pages/admin/SiteAdmin.js
+++ b/src/pages/admin/SiteAdmin.js
@@ -109,7 +109,7 @@ class SiteAdmin extends Component {
                 onClick={() => this.setForm("searchFacets")}
                 to={"/siteAdmin"}
               >
-                Search Facets Config
+                Search Page Config
               </Link>
             </li>
             <li
@@ -121,7 +121,7 @@ class SiteAdmin extends Component {
                 onClick={() => this.setForm("browseCollections")}
                 to={"/siteAdmin"}
               >
-                Filter and Sort Config for Browse Collections Page
+                Browse Collections Page
               </Link>
             </li>
             <li>

--- a/src/pages/search/SearchLoader.js
+++ b/src/pages/search/SearchLoader.js
@@ -180,7 +180,6 @@ class SearchLoader extends Component {
   }
 
   componentDidMount() {
-    console.log(this.props);
     fetchLanguages(this, this.props.site, "name", this.loadItems);
     this.loadItems();
   }


### PR DESCRIPTION
…r a multi-value field

**JIRA Ticket**: (https://webapps.es.vt.edu/jira/browse/LIBTD-2394) (:star:)

* Other Relevant Links (Meeting note, project page, related pull requests, etc.)

# What does this Pull Request do? (:star:)
This PR enables sub-label configurations for displayed attributes. For example, for a multi-value field: provenance, if it has three values, with each of them can be labeled correspondingly across the collection, e.g., "Data Provider", "Repository" and "Donor Information", it can be configured in our site configuration database. This PR also displays date information truly according to the data stored in the "start_date", "end_date" and "circa" fields.

# What's the changes? (:star:)

* Changes how date being displayed
* Added sub-label displays for a multi-valued field

# How should this be tested?

* REACT_APP_REP_TYPE=SWVA npm start
* Make sure the metadata is labeled according to DLP-DCTerms Mapping file, such as File Format, Accession Number, Rights, Data Provider, Repository and Donor Information
* Make sure date is displayed as exactly from the metadata input 

# Interested parties
Tag (@yinlinchen) interested parties

(:star:) Required fields
