### PR TITLE
fix metadata renderer to support better testing

### DIFF
--- a/cypress/integration/language_config.spec.js
+++ b/cypress/integration/language_config.spec.js
@@ -22,7 +22,7 @@ describe('Selecting English loads English results', () => {
       .click();
     cy.url({ timeout: 2000 }).should("include", "/archive/");
     cy.get('div.details-section-metadata > table[aria-label="Item Metadata"] tbody')
-      .find(':nth-child(6) td a')
+      .find('tr.language td a')
       .invoke('text')
       .should('equal', 'English');
   });

--- a/src/lib/MetadataRenderer.js
+++ b/src/lib/MetadataRenderer.js
@@ -199,7 +199,10 @@ const RenderAttrDetailed = ({ item, attribute, languages, type }) => {
       ) {
         return item_value.map((i_value, idx) => {
           return (
-            <tr key={`${item_label}_${idx}`}>
+            <tr
+              key={`${item_label}_${idx}`}
+              className={item_label[idx].toLowerCase().replace(" ", "_")}
+            >
               <th className="collection-detail-key" scope="row">
                 {item_label[idx]}
               </th>
@@ -211,7 +214,10 @@ const RenderAttrDetailed = ({ item, attribute, languages, type }) => {
         });
       } else {
         return (
-          <tr key={item_label}>
+          <tr
+            key={item_label}
+            className={item_label.toLowerCase().replace(" ", "_")}
+          >
             <th className="collection-detail-key" scope="row">
               {item_label}
             </th>
@@ -223,7 +229,11 @@ const RenderAttrDetailed = ({ item, attribute, languages, type }) => {
       }
     } else if (type === "grid") {
       return (
-        <div className="collection-detail-entry">
+        <div
+          className={`collection-detail-entry ${item_label
+            .toLowerCase()
+            .replace(" ", "_")}`}
+        >
           <div className="collection-detail-key">{item_label}</div>
           <div className={`collection-detail-value ${value_style}`}>
             {textFormat(item, attribute.field, languages)}


### PR DESCRIPTION
**fix metadata renderer to support better testing.**
* * *

**JIRA Ticket**: (link) (:star:)

* Other Relevant Links (Meeting note, project page, related pull requests, etc.)

# What does this Pull Request do? (:star:)
fix metadata renderer to support better testing

# What's the changes? (:star:)
* Adds the metadata label as a class on the `tr` element so that we can query them by name in our tests. This is more reliable than querying for `:nth-child(n)` which can change if someone adds/removes a metadata entry

# How should this be tested?

A description of what steps someone could take to:
* Check that the metadata attributes on the archive and collection show pages are still rendering correctly
* Run the tests

# Additional Notes:
* branch: `lang_test_fix`

# Interested parties
@yinlinchen 

(:star:) Required fields
