### PR TITLE
Mirador config options for admin site

### DIFF
--- a/cypress/integration/admin_homepage_sponsors_config.spec.js
+++ b/cypress/integration/admin_homepage_sponsors_config.spec.js
@@ -58,7 +58,7 @@ describe("Update sponsors fields and revert", function () {
             .parent()
             .click();
         const imgPath = "sitecontent/sponsor4.png";
-        cy.get("button[aria-label='Add sponsor']", { timeout: 2000 }).click();
+        cy.get("button[aria-label='Add sponsor']", { timeout: 5000 }).click();
         cy.get(
             "#sponsor3_form > section > div.fileUploadField > input[type=file]", { timeout: 2000 }
         )

--- a/cypress/integration/admin_mirador_config.spec.js
+++ b/cypress/integration/admin_mirador_config.spec.js
@@ -37,11 +37,11 @@ describe("Updates mirador config fields and reverts", function() {
       done();
       return false;
     });
+    cy.wait(5000);
     cy.get("input[value='edit']")
       .parent()
       .click();
-    cy.get("#selectedTheme")
-      .select("Dark");
+    cy.get("#selectedTheme", { timeout: 5000 }).select("Dark");
     cy.contains("Update Config").click();
     cy.contains("Selected theme: dark", { timeout: 2000 }).should(
       "be.visible");

--- a/cypress/integration/admin_mirador_config.spec.js
+++ b/cypress/integration/admin_mirador_config.spec.js
@@ -1,0 +1,71 @@
+const USERNAME = "devtest";
+const PASSWORD = Cypress.env("password");
+
+describe("Updates mirador config fields and reverts", function() {
+  beforeEach(() => {
+    cy.visit("/siteAdmin");
+    cy.get("amplify-authenticator")
+      .find(selectors.usernameInput, {
+        includeShadowDom: true,
+      })
+      .type(USERNAME);
+
+    cy.get("amplify-authenticator")
+      .find(selectors.signInPasswordInput, {
+        includeShadowDom: true,
+      })
+      .type(PASSWORD, { force: true });
+
+    cy.get("amplify-authenticator")
+      .find(selectors.signInSignInButton, {
+        includeShadowDom: true,
+      })
+      .first()
+      .find("button[type='submit']", { includeShadowDom: true })
+      .click({ force: true });
+
+    cy.get("#content-wrapper > div > div > ul")
+      .find(":nth-child(9) > a")
+      .contains("Mirador Viewer")
+      .click();
+    cy.url({ timeout: 5000 }).should("include", "/siteAdmin");
+  });
+
+  it("Updates theme and reverses update", () => {
+    cy.on("uncaught:exception", (err, runnable) => {
+      expect(err.message).to.include("Cannot read property");
+      done();
+      return false;
+    });
+    cy.get("input[value='edit']")
+      .parent()
+      .click();
+    cy.get("#selectedTheme")
+      .select("Dark");
+    cy.contains("Update Config").click();
+    cy.contains("Selected theme: dark", { timeout: 2000 }).should(
+      "be.visible");
+    cy.get("input[value='edit']")
+      .parent()
+      .click();
+    cy.get("#selectedTheme").select("Light");
+    cy.contains("Update Config").click();
+    cy.contains("Selected theme: light", {
+      timeout: 2000,
+    }).should("be.visible");
+  });
+
+  afterEach("User signout:", () => {
+    cy.get("amplify-sign-out")
+      .find(selectors.signOutButton, { includeShadowDom: true })
+      .contains("Sign Out")
+      .click({ force: true });
+  });
+});
+
+export const selectors = {
+  usernameInput: '[data-test="sign-in-username-input"]',
+  signInPasswordInput: '[data-test="sign-in-password-input"]',
+  signInSignInButton: '[data-test="sign-in-sign-in-button"]',
+  signOutButton: '[data-test="sign-out-button"]',
+};

--- a/src/components/MiradorViewer.js
+++ b/src/components/MiradorViewer.js
@@ -2,59 +2,60 @@ import React, { Component } from "react";
 import "../css/Viewer.scss";
 
 class MiradorViewer extends Component {
-  constructor(props) {
-    super(props);
-    this.state = {
-      annotationTooltipVisible: false,
-      viewTypeControlVisible: false
-    };
-  }
-
   miradorConfig() {
-    let config = {
-      language: "en",
-      id: "mirador_viewer",
-      window: {
-        allowClose: false,
-        allowFullscreen: true,
-        allowMaximize: false,
-        allowWindowSideBar: true,
-        defaultView: "single",
-        panels: {
-          canvas: false,
-          search: false
-        }
-      },
-      views: [{ key: "single", behaviors: ["individuals"] }],
-      windows: [
-        {
-          manifestId: this.props.item.manifest_url
-        }
-      ],
-      thumbnailNavigation: {
-        defaultPosition: "far-bottom"
-      },
-      workspace: {
-        draggingEnabled: false,
-        allowNewWindows: false,
-        isWorkspaceAddVisible: false,
-        showZoomControls: true,
-        type: "mosaic"
-      },
-      workspaceControlPanel: {
-        enabled: false
-      }
-    };
     if (
       this.props.site.miradorOptions &&
-      this.props.site.miradorOptions.windowObjects
+      Object.keys(this.props.site.miradorOptions).length !== 0
     ) {
-      config.windows[0] = Object.assign(
-        config.windows[0],
-        this.props.site.miradorOptions.windowObjects
-      );
+      var adminConfig = JSON.parse(this.props.site.miradorOptions);
+      adminConfig.windows[0].manifestId = this.props.item.manifest_url;
+    } else {
+      var config = {
+        selectedTheme: "light",
+        language: "en",
+        id: "mirador_viewer",
+        window: {
+          allowClose: false,
+          allowFullscreen: true,
+          allowMaximize: false,
+          allowTopMenuButton: true,
+          allowWindowSideBar: true,
+          sideBarPanel: "info",
+          defaultView: "single",
+          sideBarOpen: false,
+          panels: {
+            info: true,
+            attribution: true,
+            canvas: false,
+            annotations: true,
+            search: false,
+            layers: false
+          }
+        },
+        windows: [
+          {
+            manifestId: this.props.item.manifest_url
+          }
+        ],
+        thumbnailNavigation: {
+          defaultPosition: "far-bottom",
+          displaySettings: true,
+          height: 130,
+          width: 100
+        },
+        workspace: {
+          draggingEnabled: false,
+          allowNewWindows: false,
+          isWorkspaceAddVisible: false,
+          showZoomControls: true,
+          type: "mosaic"
+        },
+        workspaceControlPanel: {
+          enabled: false
+        }
+      };
     }
-    return config;
+    return adminConfig || config;
   }
 
   componentDidMount() {

--- a/src/css/adminForms.scss
+++ b/src/css/adminForms.scss
@@ -43,8 +43,11 @@ div.view-section ul li {
 div.view-section ul li span.entry {
   margin-right: 15px;
 }
-.key {
+.view-section .key {
   font-weight: bold;
+}
+.view-section .value {
+  text-transform: capitalize;
 }
 input.showTitleCheckbox {
   margin: 4px 0 0 5px;

--- a/src/pages/admin/MiradorForm.js
+++ b/src/pages/admin/MiradorForm.js
@@ -1,0 +1,503 @@
+import React, { Component } from "react";
+import { withAuthenticator } from "@aws-amplify/ui-react";
+import { Form } from "semantic-ui-react";
+import { getSite } from "../../lib/fetchTools";
+import { updatedDiff } from "deep-object-diff";
+import { API, Auth } from "aws-amplify";
+import * as mutations from "../../graphql/mutations";
+
+const initialFormState = {};
+
+class MiradorForm extends Component {
+  constructor(props) {
+    super(props);
+    this.state = {
+      formState: initialFormState,
+      prevFormState: initialFormState,
+      viewState: "view",
+      site: null
+    };
+  }
+
+  async loadSite() {
+    const site = await getSite();
+    if (site) {
+      if (site.miradorOptions) {
+        const mirador = JSON.parse(site.miradorOptions);
+        let siteInfo = {};
+        try {
+          siteInfo = {
+            selectedTheme: mirador.selectedTheme || "light",
+            language: "en",
+            id: "mirador_viewer",
+            window: {
+              allowClose: false,
+              allowFullscreen: true,
+              allowMaximize: false,
+              allowTopMenuButton: mirador.window.allowTopMenuButton || true,
+              allowWindowSideBar: mirador.window.allowWindowSideBar || true,
+              sideBarPanel: mirador.window.sideBarPanel || "info",
+              defaultView: "single",
+              sideBarOpen: mirador.window.sideBarOpen || false,
+              panels: {
+                info: true,
+                attribution: true,
+                canvas: false,
+                annotations: true,
+                search: false,
+                layers: false
+              }
+            },
+            windows: [
+              {
+                manifestId: ""
+              }
+            ],
+            thumbnailNavigation: {
+              defaultPosition:
+                mirador.thumbnailNavigation.defaultPosition || "far-bottom",
+              displaySettings:
+                mirador.thumbnailNavigation.displaySettings || true,
+              height: mirador.thumbnailNavigation.height || 130,
+              width: mirador.thumbnailNavigation.width || 100
+            },
+            workspace: {
+              draggingEnabled: false,
+              allowNewWindows: false,
+              isWorkspaceAddVisible: false,
+              showZoomControls: true,
+              type: "mosaic"
+            },
+            workspaceControlPanel: {
+              enabled: false
+            }
+          };
+        } catch (error) {
+          console.error(error);
+        }
+        this.setState({
+          formState: siteInfo,
+          prevFormState: siteInfo,
+          site: site
+        });
+      } else {
+        let siteInfo = {
+          selectedTheme: "light",
+          language: "en",
+          id: "mirador_viewer",
+          window: {
+            allowClose: false,
+            allowFullscreen: true,
+            allowMaximize: false,
+            allowTopMenuButton: true,
+            allowWindowSideBar: true,
+            sideBarPanel: "info",
+            defaultView: "single",
+            sideBarOpen: false,
+            panels: {
+              info: true,
+              attribution: true,
+              canvas: false,
+              annotations: true,
+              search: false,
+              layers: false
+            }
+          },
+          windows: [
+            {
+              manifestId: ""
+            }
+          ],
+          thumbnailNavigation: {
+            defaultPosition: "far-bottom",
+            displaySettings: true,
+            height: 130,
+            width: 100
+          },
+          workspace: {
+            draggingEnabled: false,
+            allowNewWindows: false,
+            isWorkspaceAddVisible: false,
+            showZoomControls: true,
+            type: "mosaic"
+          },
+          workspaceControlPanel: {
+            enabled: false
+          }
+        };
+        this.setState({
+          formState: siteInfo,
+          prevFormState: siteInfo,
+          site: site
+        });
+      }
+    }
+  }
+
+  stringToBoolean = value => {
+    switch (value) {
+      case "true":
+        return true;
+      case "false":
+        return false;
+      default:
+        return value;
+    }
+  };
+
+  updateInputValue = event => {
+    let { name, value } = event.target;
+    value = this.stringToBoolean(value);
+    this.setState(prevState => {
+      return {
+        formState: { ...prevState.formState, [name]: value }
+      };
+    });
+  };
+
+  updateWindowValue = event => {
+    let { name, value } = event.target;
+    value = this.stringToBoolean(value);
+    if (parseInt(value)) {
+      value = parseInt(value);
+    }
+    this.setState(prevState => {
+      return {
+        formState: {
+          ...prevState.formState,
+          window: { ...prevState.formState.window, [name]: value }
+        }
+      };
+    });
+  };
+
+  updateThumbnailValue = event => {
+    let { name, value } = event.target;
+    value = this.stringToBoolean(value);
+    if (parseInt(value)) {
+      value = parseInt(value);
+    }
+    this.setState(prevState => {
+      return {
+        formState: {
+          ...prevState.formState,
+          thumbnailNavigation: {
+            ...prevState.formState.thumbnailNavigation,
+            [name]: value
+          }
+        }
+      };
+    });
+  };
+
+  handleSubmit = async () => {
+    this.setState({ viewState: "view" });
+    const siteID = this.state.site.id;
+    let miradorOptions = JSON.stringify(this.state.formState);
+    let siteInfo = { id: siteID, miradorOptions: miradorOptions };
+    await API.graphql({
+      query: mutations.updateSite,
+      variables: { input: siteInfo },
+      authMode: "AMAZON_COGNITO_USER_POOLS"
+    });
+    const newData = updatedDiff(this.state.prevFormState, this.state.formState);
+    const oldData = updatedDiff(this.state.formState, this.state.prevFormState);
+    const eventInfo = Object.keys(newData).reduce((acc, key) => {
+      return {
+        ...acc,
+        [key]: {
+          old: oldData[key],
+          new: newData[key]
+        }
+      };
+    }, {});
+    const userInfo = await Auth.currentUserPoolUser();
+    let historyInfo = {
+      groups: userInfo.signInUserSession.accessToken.payload["cognito:groups"],
+      userEmail: userInfo.attributes.email,
+      siteID: siteID,
+      event: JSON.stringify(eventInfo)
+    };
+
+    await API.graphql({
+      query: mutations.createHistory,
+      variables: { input: historyInfo },
+      authMode: "AMAZON_COGNITO_USER_POOLS"
+    });
+  };
+
+  handleChange = (e, { value }) => {
+    this.setState({ viewState: value });
+  };
+
+  editForm = () => {
+    return (
+      <div>
+        <h2>{`Edit Mirador Viewer Options for ${process.env.REACT_APP_REP_TYPE.toLowerCase()}`}</h2>
+        <form>
+          <section>
+            <h3>Theme</h3>
+            <div className="form-group">
+              <label htmlFor="selectedTheme">Select a theme</label>
+              <select
+                id="selectedTheme"
+                className="form-control"
+                value={this.state.formState.selectedTheme}
+                name="selectedTheme"
+                onChange={this.updateInputValue}
+              >
+                <option value="light">Light</option>
+                <option value="dark">Dark</option>
+              </select>
+            </div>
+          </section>
+          <section>
+            <h3>Window Options</h3>
+            <div className="form-group">
+              <label htmlFor="allowTopMenuButton">Allow top menu button</label>
+              <select
+                className="form-control"
+                id="allowTopMenuButton"
+                value={this.state.formState.window.allowTopMenuButton}
+                name="allowTopMenuButton"
+                onChange={this.updateWindowValue}
+              >
+                <option value={true}>Yes</option>
+                <option value={false}>No</option>
+              </select>
+              <small className="form-text text-muted">
+                Add/remove the button which allows users to toggle view type in
+                top bar.
+              </small>
+            </div>
+            <div className="form-group">
+              <label htmlFor="allowWindowSideBar"> Allow window sidebar</label>
+              <select
+                className="form-control"
+                id="allowWindowSideBar"
+                value={this.state.formState.window.allowWindowSideBar}
+                name="allowWindowSideBar"
+                onChange={this.updateWindowValue}
+              >
+                <option value={true}>Yes</option>
+                <option value={false}>No</option>
+              </select>
+              <small className="form-text text-muted">
+                Add/remove sidebar menu.
+              </small>
+            </div>
+            <div className="form-group">
+              <label htmlFor="sideBarPanel">Sidebar panel</label>
+              <select
+                className="form-control"
+                id="sideBarPanel"
+                value={this.state.formState.window.sideBarPanel}
+                name="sideBarPanel"
+                onChange={this.updateWindowValue}
+              >
+                <option value="info">Info</option>
+                <option value="attribution">Attribution</option>
+                <option value="canvas">Canvas</option>
+                <option value="annotations">Annotations</option>
+                <option value="search">Search</option>
+              </select>
+              <small className="form-text text-muted">
+                Configure which content appears in sidebar upon opening.
+              </small>
+            </div>
+            <div className="form-group">
+              <label htmlFor="sideBarOpen">Sidebar open</label>
+              <select
+                className="form-control"
+                id="sideBarOpen"
+                value={this.state.formState.window.sideBarOpen}
+                name="sideBarOpen"
+                onChange={this.updateWindowValue}
+              >
+                <option value="true">Yes</option>
+                <option value="false">No</option>
+              </select>
+              <small className="form-text text-muted">
+                Configure whether sidebar is initially open or closed.
+              </small>
+            </div>
+
+            <section>
+              <h3>Thumbnail Navigation Options</h3>
+              <div className="form-group">
+                <label htmlFor="defaultPosition">Default position</label>
+                <select
+                  className="form-control"
+                  id="defaultPosition"
+                  value={
+                    this.state.formState.thumbnailNavigation.defaultPosition
+                  }
+                  name="defaultPosition"
+                  onChange={this.updateThumbnailValue}
+                >
+                  <option value="off">Off</option>
+                  <option value="far-bottom">Far-bottom</option>
+                  <option value="far-right">Far-right</option>
+                </select>
+                <small className="form-text text-muted">
+                  Configure the default position of the thumbnail navigation
+                  bar.
+                </small>
+              </div>
+              <div className="form-group">
+                <label htmlFor="displaySettings">Display settings</label>
+                <select
+                  className="form-control"
+                  id="displaySettings"
+                  value={
+                    this.state.formState.thumbnailNavigation.displaySettings
+                  }
+                  name="displaySettings"
+                  onChange={this.updateThumbnailValue}
+                >
+                  <option value="true">Yes</option>
+                  <option value="false">No</option>
+                </select>
+                <small className="form-text text-muted">
+                  Add/remove options in the top bar which allow users to change
+                  the position of thumbnails.
+                </small>
+              </div>
+              <Form.Input
+                id="thumbnailHeight"
+                type="number"
+                label='Height (of thumbnail ribbon in "far-bottom" position)'
+                value={this.state.formState.thumbnailNavigation.height}
+                name="height"
+                placeholder="Enter number of pixels"
+                onChange={this.updateThumbnailValue}
+              />
+              <Form.Input
+                id="thumbnailWidth"
+                type="number"
+                label='Width (of thumbnail ribbon in "far-right" position)'
+                value={this.state.formState.thumbnailNavigation.width}
+                name="width"
+                placeholder="Enter number of pixels"
+                onChange={this.updateThumbnailValue}
+              />
+            </section>
+          </section>
+        </form>
+        <button className="submit" onClick={this.handleSubmit}>
+          Update Config
+        </button>
+      </div>
+    );
+  };
+
+  view = () => {
+    if (this.state.site && this.state.formState) {
+      return (
+        <div className="view-section">
+          <div>
+            <h3>Mirador Viewer Configuration</h3>
+            <h4>Theme</h4>
+            <p>
+              <span className="key">Selected theme:</span>{" "}
+              <span className="value">
+                {this.state.formState.selectedTheme}
+              </span>
+            </p>
+            <h4>Window Options</h4>
+            <p>
+              <span className="key">Allow top menu button:</span>{" "}
+              <span className="value">
+                {this.state.formState.window.allowTopMenuButton ? "Yes" : "No"}
+              </span>
+            </p>
+            <p>
+              <span className="key">Allow window sidebar:</span>{" "}
+              <span className="value">
+                {this.state.formState.window.allowWindowSideBar ? "Yes" : "No"}
+              </span>
+            </p>
+            <p>
+              <span className="key">Sidebar panel:</span>{" "}
+              <span className="value">
+                {this.state.formState.window.sideBarPanel}
+              </span>
+            </p>
+            <p>
+              <span className="key">Sidebar open:</span>{" "}
+              <span className="value">
+                {this.state.formState.window.sideBarOpen ? "Yes" : "No"}
+              </span>
+            </p>
+            <h4>Thumbnail Navigation Options</h4>
+            <p>
+              <span className="key">Default position:</span>{" "}
+              <span className="value">
+                {this.state.formState.thumbnailNavigation.defaultPosition}
+              </span>
+            </p>
+            <p>
+              <span className="key">Display settings:</span>{" "}
+              <span className="value">
+                {this.state.formState.thumbnailNavigation.displaySettings
+                  ? "Yes"
+                  : "No"}
+              </span>
+            </p>
+            <p>
+              <span className="key">
+                Height of thumbnail ribbon in "far-bottom" position:
+              </span>{" "}
+              <span className="value">
+                {this.state.formState.thumbnailNavigation.height}
+              </span>
+            </p>
+            <p>
+              <span className="key">
+                Width of thumbnail ribbon in "far-right" position:
+              </span>{" "}
+              <span className="value">
+                {this.state.formState.thumbnailNavigation.width}
+              </span>
+            </p>
+          </div>
+        </div>
+      );
+    } else {
+      return <div>Error fetching site configurations......</div>;
+    }
+  };
+
+  componentDidMount() {
+    this.loadSite();
+  }
+
+  render() {
+    return (
+      <div className="col-lg-9 col-sm-12 admin-content">
+        <Form>
+          <Form.Group inline>
+            <label>Current mode:</label>
+            <Form.Radio
+              label="Edit"
+              name="viewRadioGroup"
+              value="edit"
+              checked={this.state.viewState === "edit"}
+              onChange={this.handleChange}
+            />
+            <Form.Radio
+              label="View"
+              name="viewRadioGroup"
+              value="view"
+              checked={this.state.viewState === "view"}
+              onChange={this.handleChange}
+            />
+          </Form.Group>
+        </Form>
+        {this.state.viewState === "view" ? this.view() : this.editForm()}
+      </div>
+    );
+  }
+}
+
+export default withAuthenticator(MiradorForm);

--- a/src/pages/admin/MiradorForm.js
+++ b/src/pages/admin/MiradorForm.js
@@ -22,110 +22,56 @@ class MiradorForm extends Component {
   async loadSite() {
     const site = await getSite();
     if (site) {
-      if (site.miradorOptions) {
-        const mirador = JSON.parse(site.miradorOptions);
-        let siteInfo = {
-          selectedTheme: mirador.selectedTheme || "light",
-          language: "en",
-          id: "mirador_viewer",
-          window: {
-            allowClose: false,
-            allowFullscreen: true,
-            allowMaximize: false,
-            allowTopMenuButton: mirador.window.allowTopMenuButton || true,
-            allowWindowSideBar: mirador.window.allowWindowSideBar || true,
-            sideBarPanel: mirador.window.sideBarPanel || "info",
-            defaultView: "single",
-            sideBarOpen: mirador.window.sideBarOpen || false,
-            panels: {
-              info: true,
-              attribution: true,
-              canvas: false,
-              annotations: true,
-              search: false,
-              layers: false
-            }
-          },
-          windows: [
-            {
-              manifestId: ""
-            }
-          ],
-          thumbnailNavigation: {
-            defaultPosition:
-              mirador.thumbnailNavigation.defaultPosition || "far-bottom",
-            displaySettings:
-              mirador.thumbnailNavigation.displaySettings || true,
-            height: mirador.thumbnailNavigation.height || 130,
-            width: mirador.thumbnailNavigation.width || 100
-          },
-          workspace: {
-            draggingEnabled: false,
-            allowNewWindows: false,
-            isWorkspaceAddVisible: false,
-            showZoomControls: true,
-            type: "mosaic"
-          },
-          workspaceControlPanel: {
-            enabled: false
+      let siteInfo = {
+        selectedTheme: "light",
+        language: "en",
+        id: "mirador_viewer",
+        window: {
+          allowClose: false,
+          allowFullscreen: true,
+          allowMaximize: false,
+          allowTopMenuButton: true,
+          allowWindowSideBar: true,
+          sideBarPanel: "info",
+          defaultView: "single",
+          sideBarOpen: false,
+          panels: {
+            info: true,
+            attribution: true,
+            canvas: false,
+            annotations: true,
+            search: false,
+            layers: false
           }
-        };
-        this.setState({
-          formState: siteInfo,
-          prevFormState: siteInfo,
-          site: site
-        });
-      } else {
-        let siteInfo = {
-          selectedTheme: "light",
-          language: "en",
-          id: "mirador_viewer",
-          window: {
-            allowClose: false,
-            allowFullscreen: true,
-            allowMaximize: false,
-            allowTopMenuButton: true,
-            allowWindowSideBar: true,
-            sideBarPanel: "info",
-            defaultView: "single",
-            sideBarOpen: false,
-            panels: {
-              info: true,
-              attribution: true,
-              canvas: false,
-              annotations: true,
-              search: false,
-              layers: false
-            }
-          },
-          windows: [
-            {
-              manifestId: ""
-            }
-          ],
-          thumbnailNavigation: {
-            defaultPosition: "far-bottom",
-            displaySettings: true,
-            height: 130,
-            width: 100
-          },
-          workspace: {
-            draggingEnabled: false,
-            allowNewWindows: false,
-            isWorkspaceAddVisible: false,
-            showZoomControls: true,
-            type: "mosaic"
-          },
-          workspaceControlPanel: {
-            enabled: false
+        },
+        windows: [
+          {
+            manifestId: ""
           }
-        };
-        this.setState({
-          formState: siteInfo,
-          prevFormState: siteInfo,
-          site: site
-        });
-      }
+        ],
+        thumbnailNavigation: {
+          defaultPosition: "far-bottom",
+          displaySettings: true,
+          height: 130,
+          width: 100
+        },
+        workspace: {
+          draggingEnabled: false,
+          allowNewWindows: false,
+          isWorkspaceAddVisible: false,
+          showZoomControls: true,
+          type: "mosaic"
+        },
+        workspaceControlPanel: {
+          enabled: false
+        }
+      };
+      siteInfo = JSON.parse(site.miradorOptions) || siteInfo;
+      this.setState({
+        formState: siteInfo,
+        prevFormState: siteInfo,
+        site: site
+      });
     }
   }
 

--- a/src/pages/admin/MiradorForm.js
+++ b/src/pages/admin/MiradorForm.js
@@ -24,57 +24,52 @@ class MiradorForm extends Component {
     if (site) {
       if (site.miradorOptions) {
         const mirador = JSON.parse(site.miradorOptions);
-        let siteInfo = {};
-        try {
-          siteInfo = {
-            selectedTheme: mirador.selectedTheme || "light",
-            language: "en",
-            id: "mirador_viewer",
-            window: {
-              allowClose: false,
-              allowFullscreen: true,
-              allowMaximize: false,
-              allowTopMenuButton: mirador.window.allowTopMenuButton || true,
-              allowWindowSideBar: mirador.window.allowWindowSideBar || true,
-              sideBarPanel: mirador.window.sideBarPanel || "info",
-              defaultView: "single",
-              sideBarOpen: mirador.window.sideBarOpen || false,
-              panels: {
-                info: true,
-                attribution: true,
-                canvas: false,
-                annotations: true,
-                search: false,
-                layers: false
-              }
-            },
-            windows: [
-              {
-                manifestId: ""
-              }
-            ],
-            thumbnailNavigation: {
-              defaultPosition:
-                mirador.thumbnailNavigation.defaultPosition || "far-bottom",
-              displaySettings:
-                mirador.thumbnailNavigation.displaySettings || true,
-              height: mirador.thumbnailNavigation.height || 130,
-              width: mirador.thumbnailNavigation.width || 100
-            },
-            workspace: {
-              draggingEnabled: false,
-              allowNewWindows: false,
-              isWorkspaceAddVisible: false,
-              showZoomControls: true,
-              type: "mosaic"
-            },
-            workspaceControlPanel: {
-              enabled: false
+        let siteInfo = {
+          selectedTheme: mirador.selectedTheme || "light",
+          language: "en",
+          id: "mirador_viewer",
+          window: {
+            allowClose: false,
+            allowFullscreen: true,
+            allowMaximize: false,
+            allowTopMenuButton: mirador.window.allowTopMenuButton || true,
+            allowWindowSideBar: mirador.window.allowWindowSideBar || true,
+            sideBarPanel: mirador.window.sideBarPanel || "info",
+            defaultView: "single",
+            sideBarOpen: mirador.window.sideBarOpen || false,
+            panels: {
+              info: true,
+              attribution: true,
+              canvas: false,
+              annotations: true,
+              search: false,
+              layers: false
             }
-          };
-        } catch (error) {
-          console.error(error);
-        }
+          },
+          windows: [
+            {
+              manifestId: ""
+            }
+          ],
+          thumbnailNavigation: {
+            defaultPosition:
+              mirador.thumbnailNavigation.defaultPosition || "far-bottom",
+            displaySettings:
+              mirador.thumbnailNavigation.displaySettings || true,
+            height: mirador.thumbnailNavigation.height || 130,
+            width: mirador.thumbnailNavigation.width || 100
+          },
+          workspace: {
+            draggingEnabled: false,
+            allowNewWindows: false,
+            isWorkspaceAddVisible: false,
+            showZoomControls: true,
+            type: "mosaic"
+          },
+          workspaceControlPanel: {
+            enabled: false
+          }
+        };
         this.setState({
           formState: siteInfo,
           prevFormState: siteInfo,
@@ -155,36 +150,19 @@ class MiradorForm extends Component {
     });
   };
 
-  updateWindowValue = event => {
+  updateNestedValue = (event, object) => {
     let { name, value } = event.target;
     value = this.stringToBoolean(value);
     if (parseInt(value)) {
       value = parseInt(value);
     }
+    let tempState = { ...this.state.formState };
+    let tempObject = Object.assign({}, tempState[object]);
     this.setState(prevState => {
       return {
         formState: {
           ...prevState.formState,
-          window: { ...prevState.formState.window, [name]: value }
-        }
-      };
-    });
-  };
-
-  updateThumbnailValue = event => {
-    let { name, value } = event.target;
-    value = this.stringToBoolean(value);
-    if (parseInt(value)) {
-      value = parseInt(value);
-    }
-    this.setState(prevState => {
-      return {
-        formState: {
-          ...prevState.formState,
-          thumbnailNavigation: {
-            ...prevState.formState.thumbnailNavigation,
-            [name]: value
-          }
+          [object]: { ...tempObject, [name]: value }
         }
       };
     });
@@ -260,7 +238,9 @@ class MiradorForm extends Component {
                 id="allowTopMenuButton"
                 value={this.state.formState.window.allowTopMenuButton}
                 name="allowTopMenuButton"
-                onChange={this.updateWindowValue}
+                onChange={e => {
+                  this.updateNestedValue(e, "window");
+                }}
               >
                 <option value={true}>Yes</option>
                 <option value={false}>No</option>
@@ -277,7 +257,9 @@ class MiradorForm extends Component {
                 id="allowWindowSideBar"
                 value={this.state.formState.window.allowWindowSideBar}
                 name="allowWindowSideBar"
-                onChange={this.updateWindowValue}
+                onChange={e => {
+                  this.updateNestedValue(e, "window");
+                }}
               >
                 <option value={true}>Yes</option>
                 <option value={false}>No</option>
@@ -293,7 +275,9 @@ class MiradorForm extends Component {
                 id="sideBarPanel"
                 value={this.state.formState.window.sideBarPanel}
                 name="sideBarPanel"
-                onChange={this.updateWindowValue}
+                onChange={e => {
+                  this.updateNestedValue(e, "window");
+                }}
               >
                 <option value="info">Info</option>
                 <option value="attribution">Attribution</option>
@@ -312,7 +296,9 @@ class MiradorForm extends Component {
                 id="sideBarOpen"
                 value={this.state.formState.window.sideBarOpen}
                 name="sideBarOpen"
-                onChange={this.updateWindowValue}
+                onChange={e => {
+                  this.updateNestedValue(e, "window");
+                }}
               >
                 <option value="true">Yes</option>
                 <option value="false">No</option>
@@ -333,7 +319,9 @@ class MiradorForm extends Component {
                     this.state.formState.thumbnailNavigation.defaultPosition
                   }
                   name="defaultPosition"
-                  onChange={this.updateThumbnailValue}
+                  onChange={e => {
+                    this.updateNestedValue(e, "thumbnailNavigation");
+                  }}
                 >
                   <option value="off">Off</option>
                   <option value="far-bottom">Far-bottom</option>
@@ -353,7 +341,9 @@ class MiradorForm extends Component {
                     this.state.formState.thumbnailNavigation.displaySettings
                   }
                   name="displaySettings"
-                  onChange={this.updateThumbnailValue}
+                  onChange={e => {
+                    this.updateNestedValue(e, "thumbnailNavigation");
+                  }}
                 >
                   <option value="true">Yes</option>
                   <option value="false">No</option>
@@ -370,7 +360,9 @@ class MiradorForm extends Component {
                 value={this.state.formState.thumbnailNavigation.height}
                 name="height"
                 placeholder="Enter number of pixels"
-                onChange={this.updateThumbnailValue}
+                onChange={e => {
+                  this.updateNestedValue(e, "thumbnailNavigation");
+                }}
               />
               <Form.Input
                 id="thumbnailWidth"
@@ -379,7 +371,9 @@ class MiradorForm extends Component {
                 value={this.state.formState.thumbnailNavigation.width}
                 name="width"
                 placeholder="Enter number of pixels"
-                onChange={this.updateThumbnailValue}
+                onChange={e => {
+                  this.updateNestedValue(e, "thumbnailNavigation");
+                }}
               />
             </section>
           </section>

--- a/src/pages/admin/SiteAdmin.js
+++ b/src/pages/admin/SiteAdmin.js
@@ -10,6 +10,7 @@ import SearchPageForm from "./SearchPageForm";
 import BrowseCollectionsForm from "./BrowseCollectionsForm";
 import DisplayedAttributesForm from "./DisplayedAttributesForm";
 import MediaSectionForm from "./MediaSectionForm";
+import MiradorForm from "./MiradorForm";
 
 import "../../css/SiteAdmin.scss";
 
@@ -64,7 +65,8 @@ class SiteAdmin extends Component {
       searchPage: <SearchPageForm />,
       browseCollections: <BrowseCollectionsForm />,
       displayedAttributes: <DisplayedAttributesForm />,
-      mediaSection: <MediaSectionForm />
+      mediaSection: <MediaSectionForm />,
+      mirador: <MiradorForm />
     };
     return forms[this.state.form];
   }
@@ -145,6 +147,11 @@ class SiteAdmin extends Component {
                 to={"/siteAdmin"}
               >
                 Homepage media section
+              </Link>
+            </li>
+            <li>
+              <Link onClick={() => this.setForm("mirador")} to={"/siteAdmin"}>
+                Mirador Viewer
               </Link>
             </li>
           </ul>


### PR DESCRIPTION
**JIRA Ticket**: (link) (:star:)
https://webapps.es.vt.edu/jira/browse/LIBTD-2383

# What does this Pull Request do? (:star:)
Add config options for mirador viewer to admin site. Also updated mirador viewer component to use site props, or use default configuration if no miradorOptions data exists. Two things to note about the mirador config options - users can not add or delete config options since all options must have a value (default values are used initially), users can not change all the options that we are actually configuring since some would break or substantially change the implementation of the viewer. Right now the config options presented in the admin site are limited to mostly stylistic things (i.e. change the theme). There are a lot of other config options we could add if needed in the future (see https://github.com/ProjectMirador/mirador/blob/master/src/config/settings.js)

# What's the changes? (:star:)
-cypress test for mirador config options
-src/components/MiradorViewer.js - added conditional for miradorOptions (and not an empty object), otherwise will default to the supplied configuration for the viewer.
-adminForms.scss - updates css
-MiradorForm - the config options
-SiteAdmin.js - adds the form the site routing

# How should this be tested?
-The config form will load with the default config values already in place. Change the values and then look up an item and you should see that the viewer has changed. 

# Additional Notes:
branch is LIBTD-2383

# Interested parties
@yinlinchen 

(:star:) Required fields
