### PR TITLE
Adds support for rendering .x3d files 

### DIFF
--- a/cypress/integration/archive_media_views.spec.js
+++ b/cypress/integration/archive_media_views.spec.js
@@ -72,10 +72,19 @@ describe('Archive Mirador viewer', () => {
   });
 });
 
-describe('Archive 3d viewer', () => {
-  it('renders 3d viewer for 3d records', () => {
+describe('Archive 3d .obj viewer', () => {
+  it('renders 3d viewer for 3d .obj records', () => {
     cy.visit('http://localhost:3000/archive/cz94zm9p');
     cy.get('div.obj-wrapper canvas')
+      .eq(0)
+      .should('be.visible');
+  });
+});
+
+describe('Archive 3d .x3d viewer', () => {
+  it('renders 3d viewer for 3d .x3d records', () => {
+    cy.visit('http://localhost:3000/archive/h387pp1c');
+    cy.get('div.obj-wrapper x3d#x3dElement canvas')
       .eq(0)
       .should('be.visible');
   });

--- a/package-lock.json
+++ b/package-lock.json
@@ -19307,6 +19307,11 @@
         "async-limiter": "~1.0.0"
       }
     },
+    "x3dom": {
+      "version": "1.8.1",
+      "resolved": "https://registry.npmjs.org/x3dom/-/x3dom-1.8.1.tgz",
+      "integrity": "sha512-rlKMA0pWkBUqoC75fjSm1rRJhdlnqXcCgEP5MHsspcO5pdkr0J52oO5EmmR1eOCzex5U4qAlyG8aFVoZy8wtfA=="
+    },
     "xml-name-validator": {
       "version": "3.0.0",
       "resolved": "https://registry.npmjs.org/xml-name-validator/-/xml-name-validator-3.0.0.tgz",

--- a/package.json
+++ b/package.json
@@ -42,7 +42,8 @@
     "semantic-ui-react": "^0.88.2",
     "slick-carousel": "^1.8.1",
     "typescript": "^3.7.4",
-    "uuid": "^3.3.3"
+    "uuid": "^3.3.3",
+    "x3dom": "^1.8.1"
   },
   "lint-staged": {
     "src/**/*.{js,jsx,ts,tsx,json,css,scss,md}": [

--- a/src/components/MtlElement.js
+++ b/src/components/MtlElement.js
@@ -1,0 +1,55 @@
+import React, { Component } from "react";
+import { MTLModel } from "react-3d-viewer";
+
+export default class MtlElement extends Component {
+  constructor(props) {
+    super(props);
+    this.state = {
+      mtl: "",
+      src: "",
+      rotation: { x: 0, y: 0, z: 0 },
+      width: window.innerWidth * 1,
+      texPath: ""
+    };
+  }
+  render() {
+    var { width } = this.state;
+    if (width > 600) width = 600;
+    // mtl={this.state.mtl}
+    // src={this.state.src}
+    // texPath={this.state.texPath}
+    return (
+      <section>
+        <div className="model-container">
+          <MTLModel
+            enableZoom={true}
+            position={{ x: 0, y: 0, z: 0 }}
+            width={width}
+            height={width}
+            mtl="/3d_viewer/SmallAmethyst.mtl"
+            src="/3d_viewer/SmallAmethyst.obj"
+            texPath="/3d_viewer/"
+            onProgress={xhr => {
+              console.log("objmtl", xhr);
+            }}
+            onLoad={() => {
+              console.log("on load");
+            }}
+          />
+        </div>
+      </section>
+    );
+  }
+  componentDidMount() {
+    const objURL = this.props.mtl.replace(".mtl", ".obj");
+    const texPath = this.props.mtl.substr(
+      0,
+      this.props.mtl.lastIndexOf("/") + 1
+    );
+    this.setState({
+      mtl: this.props.mtl,
+      src: objURL,
+      texPath: texPath
+    });
+  }
+}

--- a/src/components/X3DElement.js
+++ b/src/components/X3DElement.js
@@ -1,0 +1,76 @@
+import React, { Component } from "react";
+
+//  VTU_GSC_000005
+export default class X3DElement extends Component {
+  constructor(props) {
+    super(props);
+    this.state = {
+      url: ""
+    };
+    this.x3dLoaded = this.x3dLoaded.bind(this);
+  }
+
+  x3dLoaded(e) {
+    console.log("loaded");
+    console.log(e);
+  }
+
+  componentDidMount() {
+    this.setState({ url: this.props.url });
+
+    const script = document.createElement("script");
+    script.src = "https://www.x3dom.org/download/x3dom.js";
+    script.async = true;
+    document.head.appendChild(script);
+
+    const styles = document.createElement("link");
+    styles.rel = "stylesheet";
+    styles.type = "text/css";
+    styles.href = "https://www.x3dom.org/download/x3dom.css";
+    document.head.appendChild(script);
+  }
+
+  render() {
+    return (
+      <section>
+        <div className="model-container x3d">
+          <x3d
+            id="x3dElement"
+            is="x3d"
+            width={`${this.props.frameSize}px`}
+            height={`${this.props.frameSize}px`}
+          >
+            <scene is="x3d">
+              <navigationInfo type="EXAMINE" is="x3d" />
+              <viewpoint
+                id="viewPoint"
+                is="x3d"
+                centerOfRotation="0, 0, 0"
+                position="-2.25 1.0 -3.0"
+                orientation="0.03886, 0.99185, 0.12133, 3.7568"
+                isActive="true"
+              />
+              <inline
+                id="x3dInline"
+                DEF="x3dInline"
+                nameSpaceName="tanatloc"
+                is="x3d"
+                mapDEFToID="true"
+                url={this.props.url}
+                onload={this.x3dLoaded}
+              />
+              <loadSensor
+                is="x3d"
+                DEF="InlineLoadSensor"
+                isLoaded={this.x3dLoaded}
+                timeOut="5"
+              >
+                <inline is="x3d" USE="x3dInline" containerField="watchList" />
+              </loadSensor>
+            </scene>
+          </x3d>
+        </div>
+      </section>
+    );
+  }
+}

--- a/src/css/ArchivePage.scss
+++ b/src/css/ArchivePage.scss
@@ -90,7 +90,10 @@ div.obj-wrapper {
   position: relative;
   display: block;
   margin: 0 auto;
-  max-width: 50%;
+  section {
+    padding: 0;
+    border: none;
+  }
 }
 
 @media (min-width: 576px) {

--- a/src/pages/archives/ArchivePage.js
+++ b/src/pages/archives/ArchivePage.js
@@ -17,6 +17,8 @@ import { fetchLanguages } from "../../lib/fetchTools";
 import { searchArchives } from "../../graphql/queries";
 import RelatedItems from "../../components/RelatedItems";
 import Citation from "../../components/Citation";
+import MtlElement from "../../components/MtlElement";
+import X3DElement from "../../components/X3DElement";
 
 import "../../css/ArchivePage.scss";
 
@@ -76,8 +78,14 @@ class ArchivePage extends Component {
     return url.match(/\.(json)$/) != null;
   }
 
-  is3DURL(url) {
+  isObjURL(url) {
     return url.match(/\.(obj|OBJ)$/) != null;
+  }
+  isMtlUrl(url) {
+    return url.match(/\.(mtl)$/) != null;
+  }
+  isX3DUrl(url) {
+    return url.match(/\.(x3d|X3D)$/) != null;
   }
 
   buildTrack(url, thumbnail_path) {
@@ -97,6 +105,10 @@ class ArchivePage extends Component {
     let display = null;
     let config = {};
     let tracks = [];
+    let width = Math.min(
+      document.getElementById("content-wrapper").offsetWidth - 50,
+      720
+    );
     if (this.isJsonURL(item.manifest_url)) {
       display = <MiradorViewer item={item} site={this.props.site} />;
     } else if (this.isImgURL(item.manifest_url)) {
@@ -123,10 +135,26 @@ class ArchivePage extends Component {
       display = (
         <PDFViewer manifest_url={item.manifest_url} title={item.title} />
       );
-    } else if (this.is3DURL(item.manifest_url)) {
+    } else if (this.isObjURL(item.manifest_url)) {
+      const texPath = item.manifest_url.substr(
+        0,
+        item.manifest_url.lastIndexOf("/") + 1
+      );
       display = (
-        <div className="obj-wrapper">
-          <OBJModel src={item.manifest_url} texPath="" />
+        <div className="obj-wrapper" style={{ width: `${width}px` }}>
+          <OBJModel src={item.manifest_url} texPath={texPath} />
+        </div>
+      );
+    } else if (this.isMtlUrl(item.manifest_url)) {
+      display = (
+        <div className="obj-wrapper" style={{ width: `${width}px` }}>
+          <MtlElement mtl={item.manifest_url} />
+        </div>
+      );
+    } else if (this.isX3DUrl(item.manifest_url)) {
+      display = (
+        <div className="obj-wrapper" style={{ width: `${width}px` }}>
+          <X3DElement url={item.manifest_url} frameSize={width} />
         </div>
       );
     } else {
@@ -217,6 +245,7 @@ class ArchivePage extends Component {
                   <div className="row">
                     <div
                       className="col-sm-12"
+                      id="item-media-col"
                       role="region"
                       aria-label="Item media"
                     >


### PR DESCRIPTION
**Adds support for rendering .x3d files.**
* * *

**JIRA Ticket**: (link) (:star:)

* Other Relevant Links (Meeting note, project page, related pull requests, etc.)

# What does this Pull Request do? (:star:)
Adds support for rendering .x3d files 

# What's the changes? (:star:)
* Loads x3dom js and css files dynamically (only when .x3d records are being viewed)
* Adds dom nodes to load and render .x3d files

# How should this be tested?
* Visit `/archive/h387pp1c` and check that blister beetle 3d image is rendering correctly. (Note: this image does not match the record which is for "Amethyst."  Blister beetle was the only properly formatted, valid .x3d file that I could find so far.

# Additional Notes:
* branch `color_3d`

# Interested parties
@yinlinchen 

(:star:) Required fields
