### PR TITLE
LIBTD-2371: Restrict site admins to access their own admin page only but not other sites' admin pages

### DIFF
--- a/cypress/integration/admin_homepage_collectionHighlights_config.spec.js
+++ b/cypress/integration/admin_homepage_collectionHighlights_config.spec.js
@@ -1,7 +1,7 @@
 const USERNAME = "devtest";
 const PASSWORD = Cypress.env("password");
 
-describe("Update featured items fields and revert", function () {
+describe("Update collection highlights fields and revert", function () {
     beforeEach(() => {
         cy.visit("/siteAdmin");
         cy.get("amplify-authenticator")

--- a/cypress/integration/admin_homepage_top_config.spec.js
+++ b/cypress/integration/admin_homepage_top_config.spec.js
@@ -47,16 +47,16 @@ describe("Update Homepage fields and revert", function() {
 
   it("Update Show title", () => {
     cy.get("input[value='edit']").parent().click();
-    cy.get("input[name='staticImageShowTitle']", { timeout: 5000 }).uncheck();
-    cy.contains("Update Config", { timeout: 5000 }).click();
-    cy.contains("Show title: false", { timeout: 5000 }).should('be.visible');
+    cy.get("input[name='staticImageShowTitle']").uncheck();
+    cy.contains("Update Config").click();
+    cy.contains("Show title: false", { timeout: 8000 }).should('be.visible');
   })
 
   it("Change Show title back", () => {
     cy.get("input[value='edit']").parent().click();
-    cy.get("input[name='staticImageShowTitle']", { timeout: 2000 }).check();
-    cy.contains("Update Config", { timeout: 2000 }).click();
-    cy.contains("Show title: true", { timeout: 2000 }).should('be.visible');
+    cy.get("input[name='staticImageShowTitle']").check();
+    cy.contains("Update Config").click();
+    cy.contains("Show title: true", { timeout: 8000 }).should('be.visible');
   })
 
   it("displays successful upload", () => {

--- a/src/pages/admin/BrowseCollectionsForm.js
+++ b/src/pages/admin/BrowseCollectionsForm.js
@@ -109,6 +109,7 @@ class BrowseCollectionsForm extends Component {
 
     const userInfo = await Auth.currentUserPoolUser();
     let historyInfo = {
+      groups: userInfo.signInUserSession.accessToken.payload["cognito:groups"],
       userEmail: userInfo.attributes.email,
       siteID: siteID,
       event: JSON.stringify(eventInfo)

--- a/src/pages/admin/ContentUpload.js
+++ b/src/pages/admin/ContentUpload.js
@@ -60,6 +60,8 @@ class ContentUpload extends Component {
       this.setState({ isUploaded: true });
       const userInfo = await Auth.currentUserPoolUser();
       let historyInfo = {
+        groups:
+          userInfo.signInUserSession.accessToken.payload["cognito:groups"],
         userEmail: userInfo.attributes.email,
         siteID: this.state.site.id,
         event: JSON.stringify(eventInfo)

--- a/src/pages/admin/DisplayedAttributesForm.js
+++ b/src/pages/admin/DisplayedAttributesForm.js
@@ -130,6 +130,7 @@ class DisplayedAttributesForm extends Component {
     }, {});
 
     let historyInfo = {
+      groups: userInfo.signInUserSession.accessToken.payload["cognito:groups"],
       userEmail: userInfo.attributes.email,
       siteID: siteID,
       event: JSON.stringify(eventInfo)

--- a/src/pages/admin/FileUploadField.js
+++ b/src/pages/admin/FileUploadField.js
@@ -50,6 +50,8 @@ class FileUploadField extends Component {
       });
       const userInfo = await Auth.currentUserPoolUser();
       let historyInfo = {
+        groups:
+          userInfo.signInUserSession.accessToken.payload["cognito:groups"],
         userEmail: userInfo.attributes.email,
         siteID: this.props.site.id,
         event: JSON.stringify(eventInfo)

--- a/src/pages/admin/HomepageForm.js
+++ b/src/pages/admin/HomepageForm.js
@@ -234,6 +234,7 @@ class HomepageForm extends Component {
     }, {});
     const userInfo = await Auth.currentUserPoolUser();
     let historyInfo = {
+      groups: userInfo.signInUserSession.accessToken.payload["cognito:groups"],
       userEmail: userInfo.attributes.email,
       siteID: siteID,
       event: JSON.stringify(eventInfo)

--- a/src/pages/admin/MediaSectionForm.js
+++ b/src/pages/admin/MediaSectionForm.js
@@ -86,6 +86,7 @@ class MediaSectionForm extends Component {
     }, {});
     const userInfo = await Auth.currentUserPoolUser();
     let historyInfo = {
+      groups: userInfo.signInUserSession.accessToken.payload["cognito:groups"],
       userEmail: userInfo.attributes.email,
       siteID: siteID,
       event: JSON.stringify(eventInfo)

--- a/src/pages/admin/SearchFacetsForm.js
+++ b/src/pages/admin/SearchFacetsForm.js
@@ -115,6 +115,7 @@ class SearchFacetsForm extends Component {
 
     const userInfo = await Auth.currentUserPoolUser();
     let historyInfo = {
+      groups: userInfo.signInUserSession.accessToken.payload["cognito:groups"],
       userEmail: userInfo.attributes.email,
       siteID: siteID,
       event: JSON.stringify(eventInfo)

--- a/src/pages/admin/SiteAdmin.js
+++ b/src/pages/admin/SiteAdmin.js
@@ -27,7 +27,16 @@ class SiteAdmin extends Component {
       const data = await Auth.currentUserPoolUser();
       const groups =
         data.signInUserSession.accessToken.payload["cognito:groups"];
-      if (groups.indexOf("SiteAdmin") !== -1) {
+      let adminGroup = "";
+      const repo_type = process.env.REACT_APP_REP_TYPE.toLowerCase();
+      if (repo_type === "default") {
+        adminGroup = "demoSiteAdmin";
+      } else if (repo_type === "podcasts") {
+        adminGroup = "podcastSiteAdmin";
+      } else {
+        adminGroup = `${repo_type}SiteAdmin`;
+      }
+      if (groups && groups.indexOf(adminGroup) !== -1) {
         this.setAuthorized(true);
       } else {
         this.setAuthorized(false);

--- a/src/pages/admin/SiteForm.js
+++ b/src/pages/admin/SiteForm.js
@@ -94,7 +94,9 @@ class SiteForm extends Component {
       };
     }, {});
     const userInfo = await Auth.currentUserPoolUser();
+    console.log("userInfo", userInfo);
     let historyInfo = {
+      groups: userInfo.signInUserSession.accessToken.payload["cognito:groups"],
       userEmail: userInfo.attributes.email,
       siteID: siteID,
       event: JSON.stringify(eventInfo)

--- a/src/pages/admin/SitePagesForm.js
+++ b/src/pages/admin/SitePagesForm.js
@@ -133,6 +133,7 @@ class SitePagesForm extends Component {
 
     const userInfo = await Auth.currentUserPoolUser();
     let historyInfo = {
+      groups: userInfo.signInUserSession.accessToken.payload["cognito:groups"],
       userEmail: userInfo.attributes.email,
       siteID: siteID,
       event: JSON.stringify(eventInfo)


### PR DESCRIPTION

**JIRA Ticket**: (https://webapps.es.vt.edu/jira/browse/LIBTD-2371) (:star:)

# What does this Pull Request do? (:star:)
This PR utilizes amplify dynamic group authorization rule to restrict site admins to access the admin page of their own site but not to the admin pages of other sites.

# What's the changes? (:star:)
* pages/admin/SiteAdmin.js: On Site admin landing page, check if the signed-in user belongs to the siteAdmin group of this site to enable/disable access permission
* pages/admin/*Form.js: Add "groups" field to the newly created History record as only users belong to the corresponding siteAdmin group can create History records 

# How should this be tested?

* Go to siteAdmin page of a repo, e.g., IAWA.
* Sign-in with a user belongs to the corresponding siteAdmin group: "iawaSiteAdmin", then "update" permission is guaranteed; if the user does not belong to the group, access to the siteAdmin page is not allowed.

# Interested parties
Tag (@yinlinchen ) interested parties

(:star:) Required fields
