### PR TITLE
LIBTD-2407: Frontend adjustment for displaying date metadata

### DIFF
--- a/src/lib/MetadataRenderer.js
+++ b/src/lib/MetadataRenderer.js
@@ -41,6 +41,7 @@ export function titleFormatted(item, category) {
   );
 }
 export function dateFormatted(item) {
+  if (item.display_date) return item.display_date;
   let circa_date = item.circa ? item.circa : "";
   let end_date = item.end_date ? " - " + yearmonthDate(item.end_date) : "";
   let start_date = item.start_date ? yearmonthDate(item.start_date) : "";
@@ -110,6 +111,7 @@ function listValue(category, attr, value, languages) {
 }
 
 function textFormat(item, attr, languages) {
+  if (attr === "display_date" && item[attr] === null) attr = "start_date";
   if (item[attr] === null) return null;
   let category = "archive";
   if (item.collection_category) category = "collection";
@@ -137,7 +139,7 @@ function textFormat(item, attr, languages) {
     );
   } else if (attr === "description") {
     return <MoreLink category={category} item={item} />;
-  } else if (attr === "start_date") {
+  } else if (attr === "display_date" || attr === "start_date") {
     return dateFormatted(item);
   } else if (attr === "size") {
     if (category === "collection") return collectionSizeText(item);


### PR DESCRIPTION
**JIRA Ticket**: (https://webapps.es.vt.edu/jira/browse/LIBTD-2407) (:star:)

# What does this Pull Request do? (:star:)
This PR provides frontend adjustment in order to pick up the newly added "display_date" metadata field. To properly display the "date", we first try to use "display_date" metadata directly if it has value. Otherwise, we display the date using the format by concatenating three metadata fields: "circa", "start_date" and "end_date."

# What's the changes? (:star:)

* Use "display_date" in date display as the first priority
* If no "display_date" field or "display_date" field has empty value, check "start_date"

# How should this be tested?

* Go to SWVA application, see if date is displayed (updated) as expected especially for those with textual content
* Go to IAWA application, see if date is still displayed as previously formatted

# Interested parties
Tag (@yinlinchen ) interested parties

(:star:) Required fields
