### PR TITLE
Do not display identifier from non-items

### DIFF
--- a/cypress/integration/browse_collections.spec.js
+++ b/cypress/integration/browse_collections.spec.js
@@ -19,7 +19,7 @@ describe('Browse collections page', () => {
     cy.get('@firstCollection').click();
     cy.url({ timeout: 2000 })
       .should('include', '/collection/vb765t25demo');
-    cy.contains('Ms1988_017_Pfeiffer');
+    cy.contains('Pfeiffer, Alberta Raffl, 1899-1994');
   })
 
   it('renders the first 10 collections by default number of results to be showed', () => {

--- a/cypress/integration/collection_metadata_display.spec.js
+++ b/cypress/integration/collection_metadata_display.spec.js
@@ -16,11 +16,8 @@ describe('A single Collection Show page metadata section', () => {
       .contains('Collections:');
   })
 
-  it('displays the identifier field and its corresponding value', () => {
-    cy.get('@metadataSection')
-      .find(':nth-child(6) > th.collection-detail-key')
-      .invoke('text')
-      .should('equal', 'Identifier');
+  it('displays not display the identifier field in the collection page', () => {
+    cy.contains('Identifier').should('not.exist');;
     cy.get('@metadataSection')
       .find(':nth-child(6) > td.collection-detail-value').click();
     cy.url({ timeout: 2000 }).should('include', '/collection/vb765t25demo');

--- a/src/lib/MetadataRenderer.js
+++ b/src/lib/MetadataRenderer.js
@@ -132,11 +132,15 @@ function textFormat(item, attr, languages, collectionCustomKey) {
       </div>
     );
   } else if (attr === "identifier") {
-    return (
-      <a href={`/${category}/${arkLinkFormatted(item.custom_key)}`}>
-        {item[attr]}
-      </a>
-    );
+    if (category === "archive") {
+      return (
+        <a href={`/${category}/${arkLinkFormatted(item.custom_key)}`}>
+          {item[attr]}
+        </a>
+      );
+    } else {
+      return "";
+    }
   } else if (attr === "rights_statement") {
     return htmlParsedValue(item[attr]);
   } else if (attr === "custom_key") {


### PR DESCRIPTION
**JIRA Ticket**: (https://webapps.es.vt.edu/jira/browse/LIBTD-2418) (:star:)

# What does this Pull Request do? (:star:)
Only show identifier in the item page

# What's the changes? (:star:)
1. Do not display identifier in the collection page.
2. Change test cases to reflect this change.

# How should this be tested?
1. Pull and start the server, see any collection page. There is no identifier anymore.
2. See preview in the Amplify console

# Interested parties
Tag (@VTUL/dld-dev ) interested parties

(:star:) Required fields
