### PR TITLE
Podcast media component and styles

### DIFF
--- a/src/components/PodcastMediaElement.js
+++ b/src/components/PodcastMediaElement.js
@@ -112,7 +112,6 @@ export default class PodcastMediaElement extends Component {
             className="media-player"
             dangerouslySetInnerHTML={{ __html: mediaHtml }}
           ></div>
-          {console.log(props.sources)}
           <div className="media-buttons">
             {this.transcriptButton()}
             <a

--- a/src/components/PodcastMediaElement.js
+++ b/src/components/PodcastMediaElement.js
@@ -1,0 +1,131 @@
+import React, { Component } from "react";
+import flvjs from "flv.js";
+import hlsjs from "hls.js";
+import "mediaelement";
+
+import "mediaelement/build/mediaelementplayer.min.css";
+import "mediaelement/build/mediaelement-flash-video.swf";
+import "../css/podcastMediaElement.scss";
+
+export default class PodcastMediaElement extends Component {
+  constructor(props) {
+    super(props);
+    this.state = {
+      player: null
+    };
+  }
+
+  success(media, node, instance) {
+    console.log(instance);
+  }
+
+  error(media) {
+    console.log(media);
+  }
+
+  componentDidMount() {
+    const { MediaElementPlayer } = global;
+    if (!MediaElementPlayer) {
+      return;
+    }
+
+    const options = Object.assign({}, JSON.parse(this.props.options), {
+      pluginPath: "./static/media/",
+      success: (media, node, instance) => this.success(media, node, instance),
+      error: (media, node) => this.error(media, node)
+    });
+
+    window.flvjs = flvjs;
+    window.Hls = hlsjs;
+    this.setState({ player: new MediaElementPlayer(this.props.id, options) });
+  }
+
+  componentWillUnmount() {
+    if (this.state.player) {
+      this.state.player.remove();
+      this.setState({ player: null });
+    }
+  }
+
+  audioImg() {
+    return (
+      <div className="audio-img-wrapper">
+        <img
+          className="audio-img"
+          src={this.props.poster}
+          alt={this.props.title}
+        />
+      </div>
+    );
+  }
+
+  transcriptButton() {
+    if (this.props.transcript) {
+      return (
+        <button type="button" className="transcript-button">
+          <i class="fas fa-file-alt" aria-label="Transcript"></i>
+        </button>
+      );
+    }
+  }
+
+  render() {
+    const props = this.props,
+      sources = JSON.parse(props.sources),
+      tracks = JSON.parse(props.tracks),
+      sourceTags = [],
+      tracksTags = [];
+    for (let i = 0, total = sources.length; i < total; i++) {
+      const source = sources[i];
+      sourceTags.push(`<source src="${source.src}" type="${source.type}">`);
+    }
+
+    for (let i = 0, total = tracks.length; i < total; i++) {
+      const track = tracks[i];
+      tracksTags.push(
+        `<track src="${track.src}" kind="${track.kind}" srclang="${
+          track.lang
+        }"${track.label ? ` label=${track.label}` : ""}>`
+      );
+    }
+
+    const mediaBody = `${sourceTags.join("\n")}
+        ${tracksTags.join("\n")}`,
+      mediaHtml =
+        props.mediaType === "video"
+          ? `<video id="${props.id}" width="${props.width}" height="${
+              props.height
+            }"${props.poster ? ` poster=${props.poster}` : ""}
+          ${props.controls ? " controls" : ""}${
+              props.preload ? ` preload="${props.preload}"` : ""
+            }>
+          ${mediaBody}
+        </video>`
+          : `<audio id="${props.id}" width="${props.width}" controls>
+            ${mediaBody}
+          </audio>`;
+    return (
+      <div className="media-element-container">
+        {props.mediaType === "audio" && this.audioImg()}
+        <div className="media-player-wrapper">
+          <div
+            className="media-player"
+            dangerouslySetInnerHTML={{ __html: mediaHtml }}
+          ></div>
+          {console.log(props.sources)}
+          <div className="media-buttons">
+            {this.transcriptButton()}
+            <a
+              href={sources[0].src}
+              className="download-link"
+              download
+              aria-label="Download episode"
+            >
+              <i className="fa fa-download"></i>
+            </a>
+          </div>
+        </div>
+      </div>
+    );
+  }
+}

--- a/src/css/ArchivePage.scss
+++ b/src/css/ArchivePage.scss
@@ -76,26 +76,6 @@ div.item-image-section img.item-img {
   word-break: break-all;
 }
 
-div.audio-img-wrapper {
-  position: relative;
-  display: block;
-  width: 100%;
-}
-img.audio-img {
-  display: block;
-  max-width: 50%;
-  margin: 0 auto;
-}
-div.obj-wrapper {
-  position: relative;
-  display: block;
-  margin: 0 auto;
-  section {
-    padding: 0;
-    border: none;
-  }
-}
-
 @media (min-width: 576px) {
   .item-image-section {
     padding: 1.5em;

--- a/src/css/ArchivePage.scss
+++ b/src/css/ArchivePage.scss
@@ -76,6 +76,29 @@ div.item-image-section img.item-img {
   word-break: break-all;
 }
 
+div.audio-img-wrapper {
+  position: relative;
+  display: block;
+  width: 100%;
+}
+
+img.audio-img {
+  display: block;
+  max-width: 50%;
+  margin: 0 auto;
+}
+
+div.obj-wrapper {
+  position: relative;
+  display: block;
+  margin: 0 auto;
+
+  section {
+    padding: 0;
+    border: none;
+  }
+}
+
 @media (min-width: 576px) {
   .item-image-section {
     padding: 1.5em;

--- a/src/css/podcastMediaElement.scss
+++ b/src/css/podcastMediaElement.scss
@@ -60,16 +60,16 @@
     margin-top: 0px;
     width: 110px;
     text-align: left;
+    line-height: 1px;
   }
 }
 
 .download-link {
   color: white !important;
-  font-size: 1.75em;
+  font-size: 1.4em;
   background-color: var(--themeHighlightColor);
-  padding: 0px 7px 4px 7px;
+  padding: 5px 10px 5px 10px;
   border-radius: 25px;
-  vertical-align: middle;
 }
 
 .transcript-button {

--- a/src/css/podcastMediaElement.scss
+++ b/src/css/podcastMediaElement.scss
@@ -1,11 +1,9 @@
 .media-element-container {
   display: flex;
-  justify-content: center;
-  align-items: baseline;
   flex-wrap: wrap;
 }
 
-.audio-img-wrapper {
+.media-element-container div.audio-img-wrapper {
   max-width: 100%;
   margin-bottom: 30px;
 }
@@ -15,12 +13,13 @@
     flex-wrap: nowrap;
   }
 
-  .audio-img-wrapper {
+  .media-element-container div.audio-img-wrapper {
     max-width: 33%;
+    margin-bottom: 0;
   }
 }
 
-img.audio-img {
+.media-element-container img.audio-img {
   max-width: 100%;
   margin: 0 auto;
 }
@@ -103,15 +102,4 @@ div.feed-button-wrapper {
   margin: 0 10px 10px 0;
   color: black;
   font-weight: 500;
-}
-
-div.obj-wrapper {
-  position: relative;
-  display: block;
-  margin: 0 auto;
-
-  section {
-    padding: 0;
-    border: none;
-  }
 }

--- a/src/css/podcastMediaElement.scss
+++ b/src/css/podcastMediaElement.scss
@@ -1,0 +1,117 @@
+.media-element-container {
+  display: flex;
+  justify-content: center;
+  align-items: baseline;
+  flex-wrap: wrap;
+}
+
+.audio-img-wrapper {
+  max-width: 100%;
+  margin-bottom: 30px;
+}
+
+@media (min-width: 768px) {
+  .media-element-container {
+    flex-wrap: nowrap;
+  }
+
+  .audio-img-wrapper {
+    max-width: 33%;
+  }
+}
+
+img.audio-img {
+  max-width: 100%;
+  margin: 0 auto;
+}
+
+.media-player-wrapper {
+  width: 100%;
+  display: flex;
+  flex-wrap: wrap;
+  align-items: center;
+}
+
+.media-player {
+  width: 100%;
+}
+
+@media (min-width: 576px) {
+  .media-player {
+    width: calc(100% - 130px);
+  }
+}
+
+@media (min-width: 768px) {
+  .media-player {
+    padding-left: 15px;
+  }
+}
+
+.media-buttons {
+  vertical-align: middle;
+  margin-left: 20px;
+  margin-top: 15px;
+  width: 100%;
+  text-align: right;
+}
+
+@media (min-width: 576px) {
+  .media-buttons {
+    margin-top: 0px;
+    width: 110px;
+    text-align: left;
+  }
+}
+
+.download-link {
+  color: white !important;
+  font-size: 1.75em;
+  background-color: var(--themeHighlightColor);
+  padding: 0px 7px 4px 7px;
+  border-radius: 25px;
+  vertical-align: middle;
+}
+
+.transcript-button {
+  border: none;
+  background-color: var(--light-gray);
+  font-size: 2.3em;
+  color: var(--themeHighlightColor);
+  margin-right: 10px;
+  padding: 0px 10px 0px 10px;
+  vertical-align: middle;
+}
+
+div.feed-button-wrapper {
+  margin-top: 20px;
+  width: 100%;
+  margin-left: -15px;
+}
+
+@media (min-width: 768px) {
+  div.feed-button-wrapper {
+    margin-left: 0px;
+    text-align: right;
+  }
+}
+
+.feed-button-wrapper button {
+  background-color: white;
+  border: solid 2px var(--dark-gray);
+  border-radius: 4px;
+  margin: 0 10px 10px 0;
+  color: black;
+  font-weight: 500;
+}
+
+div.obj-wrapper {
+  position: relative;
+  display: block;
+  margin: 0 auto;
+
+  section {
+    padding: 0;
+    border: none;
+  }
+}

--- a/src/pages/archives/ArchivePage.js
+++ b/src/pages/archives/ArchivePage.js
@@ -211,7 +211,11 @@ class ArchivePage extends Component {
     const filename = this.fileNameFromUrl(src);
     const typeString = `${type}/${this.fileExtensionFromFileName(filename)}`;
     const srcArray = [{ src: src, type: typeString }];
-    return this.state.item.type !== "podcast" ? (
+    let podcast = false;
+    podcast = this.state.item.resource_type
+      ? this.state.item.resource_type.find(item => item === "podcast")
+      : false;
+    return podcast !== "podcast" ? (
       <MediaElement
         id="player1"
         mediaType={type}
@@ -238,7 +242,7 @@ class ArchivePage extends Component {
         options={JSON.stringify(config)}
         tracks={JSON.stringify(tracks)}
         title={title}
-        transcript={this.state.item.transcript}
+        transcript={false}
       />
     );
   }

--- a/src/pages/archives/ArchivePage.js
+++ b/src/pages/archives/ArchivePage.js
@@ -211,8 +211,7 @@ class ArchivePage extends Component {
     const filename = this.fileNameFromUrl(src);
     const typeString = `${type}/${this.fileExtensionFromFileName(filename)}`;
     const srcArray = [{ src: src, type: typeString }];
-    let library = process.env.REACT_APP_REP_TYPE;
-    return library !== "podcasts" ? (
+    return this.state.item.type !== "podcast" ? (
       <MediaElement
         id="player1"
         mediaType={type}

--- a/src/pages/archives/ArchivePage.js
+++ b/src/pages/archives/ArchivePage.js
@@ -5,6 +5,7 @@ import KalturaPlayer from "../../components/KalturaPlayer";
 import MiradorViewer from "../../components/MiradorViewer";
 import { OBJModel } from "react-3d-viewer";
 import MediaElement from "../../components/MediaElement";
+import PodcastMediaElement from "../../components/PodcastMediaElement";
 import SearchBar from "../../components/SearchBar";
 import Breadcrumbs from "../../components/Breadcrumbs.js";
 import SiteTitle from "../../components/SiteTitle";
@@ -210,7 +211,8 @@ class ArchivePage extends Component {
     const filename = this.fileNameFromUrl(src);
     const typeString = `${type}/${this.fileExtensionFromFileName(filename)}`;
     const srcArray = [{ src: src, type: typeString }];
-    return (
+    let library = process.env.REACT_APP_REP_TYPE;
+    return library !== "podcasts" ? (
       <MediaElement
         id="player1"
         mediaType={type}
@@ -223,6 +225,21 @@ class ArchivePage extends Component {
         options={JSON.stringify(config)}
         tracks={JSON.stringify(tracks)}
         title={title}
+      />
+    ) : (
+      <PodcastMediaElement
+        id="player1"
+        mediaType={type}
+        preload="none"
+        controls
+        width="100%"
+        height="640"
+        poster={tracks[0].poster}
+        sources={JSON.stringify(srcArray)}
+        options={JSON.stringify(config)}
+        tracks={JSON.stringify(tracks)}
+        title={title}
+        transcript={this.state.item.transcript}
       />
     );
   }


### PR DESCRIPTION
**JIRA Ticket**: (link) (:star:)
https://webapps.es.vt.edu/jira/browse/LIBTD-2099

* Other Relevant Links (Meeting note, project page, related pull requests, etc.)
wireframe - https://xd.adobe.com/view/518fe7b0-04fc-4066-a14d-c13bd8bb17c2-04dc/screen/822f3957-8c6a-4615-a651-605df08ab19b/

# What does this Pull Request do? (:star:)
Creates a component to render the podcasts on archive pages.

# What's the changes? (:star:)
-PodcastMediaElement - a customized media component that renders items from the podcast library. Changes styling and adds download button. Note that this component will also include a link to a transcript and links to other feeds for the show once that information is provided by the stakeholders.
-ArchivePage - implements PodcastMediaElement for the podcast library.

# How should this be tested?
Podcasts should display in the customized podcast page and other audio/video files in other libraries should render normally.

# Additional Notes:
Branch is LIBTD-2099

# Interested parties
@yinlinchen 

(:star:) Required fields
