### PR TITLE
LIBTD-2433: Pick Kalture video with specified entry_id

### DIFF
--- a/src/components/KalturaPlayer.js
+++ b/src/components/KalturaPlayer.js
@@ -3,7 +3,11 @@ import "../css/Viewer.scss";
 
 class KalturaPlayer extends Component {
   getURL() {
-    return `${this.props.manifest_url}?iframeembed=true&playerId=kaltura_player&entry_id=1_qvxfd4bn&flashvars[streamerType]=auto&amp;flashvars[localizationCode]=en&amp;flashvars[leadWithHTML5]=true&amp;flashvars[sideBarContainer.plugin]=true&amp;flashvars[sideBarContainer.position]=left&amp;flashvars[sideBarContainer.clickToClose]=true&amp;flashvars[chapters.plugin]=true&amp;flashvars[chapters.layout]=vertical&amp;flashvars[chapters.thumbnailRotator]=false&amp;flashvars[streamSelector.plugin]=true&amp;flashvars[EmbedPlayer.SpinnerTarget]=videoHolder&amp;flashvars[dualScreen.plugin]=true&amp;flashvars[Kaltura.addCrossoriginToIframe]=true&amp;&wid=1_x2fmman0`;
+    const entry_id = this.props.manifest_url.replace(
+      "https://video.vt.edu/media/",
+      ""
+    );
+    return `https://cdnapisec.kaltura.com/p/2375811/sp/237581100/embedIframeJs/uiconf_id/41951101/partner_id/2375811?iframeembed=true&playerId=kaltura_player&entry_id=${entry_id}&flashvars[streamerType]=auto&amp;flashvars[localizationCode]=en&amp;flashvars[leadWithHTML5]=true&amp;flashvars[sideBarContainer.plugin]=true&amp;flashvars[sideBarContainer.position]=left&amp;flashvars[sideBarContainer.clickToClose]=true&amp;flashvars[chapters.plugin]=true&amp;flashvars[chapters.layout]=vertical&amp;flashvars[chapters.thumbnailRotator]=false&amp;flashvars[streamSelector.plugin]=true&amp;flashvars[EmbedPlayer.SpinnerTarget]=videoHolder&amp;flashvars[dualScreen.plugin]=true&amp;flashvars[Kaltura.addCrossoriginToIframe]=true&amp;&wid=1_x2fmman0`;
   }
   render() {
     return (

--- a/src/pages/archives/ArchivePage.js
+++ b/src/pages/archives/ArchivePage.js
@@ -102,7 +102,7 @@ class ArchivePage extends Component {
   }
 
   isKalturaURL(url) {
-    return url.match(/\.(kaltura.com)/) != null;
+    return url.match(/(video.vt.edu\/media)/) != null;
   }
 
   isPdfURL(url) {


### PR DESCRIPTION
**JIRA Ticket**: (https://webapps.es.vt.edu/jira/browse/LIBTD-2433) (:star:)

# What does this Pull Request do? (:star:)
This PR fixes Kaltura embed which originally does not pick up the unique entry_id for each video. Also for convenience, we use the video.vt.edu/media links instead of the rather long kaltura video links in our DynamoDB record.

# What's the changes? (:star:)

* Changes the video link
* Uses entry_id to identify the video

# How should this be tested?

* Go to hokies repo
* Go to archive/v2764b5m, check if video loaded properly

# Interested parties
Tag (@yinlinchen) interested parties

(:star:) Required fields
