### PR TITLE
Fetch assets using Storage.get to get url with auth creds where needed.

### DIFF
--- a/cypress/integration/archive_media_views.spec.js
+++ b/cypress/integration/archive_media_views.spec.js
@@ -1,9 +1,8 @@
 describe('Archive static img view', () => {
   it('shows correct img tag', () => {
     cy.visit('/archive/m58xyh90');
-    cy.get('#content-wrapper > div > div.item-image-section > div.row > div > img')
+    cy.get('img.item-img')
       .eq(0)
-      .should('have.class', 'item-img')
       .should('be.visible');
   });
 });

--- a/src/components/CollectionTopContent.js
+++ b/src/components/CollectionTopContent.js
@@ -1,13 +1,15 @@
 import React, { Component } from "react";
 import { addNewlineInDesc } from "../lib/MetadataRenderer";
 
+import { getFile } from "../lib/fetchTools";
 import "../css/CollectionsShowPage.scss";
 
 class CollectionTopContent extends Component {
   constructor(props) {
     super(props);
     this.state = {
-      descriptionTruncated: true
+      descriptionTruncated: true,
+      collectionThumbnail: ""
     };
   }
 
@@ -67,6 +69,18 @@ class CollectionTopContent extends Component {
     }
   }
 
+  componentDidUpdate(prevProps) {
+    if (this.props.collectionImg !== prevProps.collectionImg) {
+      getFile(this.props.collectionImg, "image", this, "collectionThumbnail");
+    }
+  }
+
+  componentDidMount() {
+    if (this.props.collectionImg) {
+      getFile(this.props.collectionImg, "image", this, "collectionThumbnail");
+    }
+  }
+
   render() {
     return (
       <div
@@ -75,7 +89,7 @@ class CollectionTopContent extends Component {
         aria-labelledby="collection-page-title"
       >
         <div className="collection-img-col col-sm-4">
-          <img src={this.props.collectionImg} alt="" />
+          <img src={this.state.collectionThumbnail} alt="" />
         </div>
         <div className="collection-details-col col-sm-8">
           <h1 className="collection-title" id="collection-page-title">

--- a/src/components/MediaElement.js
+++ b/src/components/MediaElement.js
@@ -3,6 +3,7 @@ import flvjs from "flv.js";
 import hlsjs from "hls.js";
 import "mediaelement";
 
+import { getFile } from "../lib/fetchTools";
 import "mediaelement/build/mediaelementplayer.min.css";
 import "mediaelement/build/mediaelement-flash-video.swf";
 
@@ -10,7 +11,8 @@ export default class MediaElement extends Component {
   constructor(props) {
     super(props);
     this.state = {
-      player: null
+      player: null,
+      audioImg: ""
     };
   }
 
@@ -23,6 +25,10 @@ export default class MediaElement extends Component {
   }
 
   componentDidMount() {
+    if (this.props.poster) {
+      getFile(this.props.poster, "image", this, "audioImg");
+    }
+
     const { MediaElementPlayer } = global;
     if (!MediaElementPlayer) {
       return;
@@ -51,7 +57,7 @@ export default class MediaElement extends Component {
       <div className="audio-img-wrapper">
         <img
           className="audio-img"
-          src={this.props.poster}
+          src={this.state.audioImg}
           alt={this.props.title}
         />
       </div>

--- a/src/components/PodcastMediaElement.js
+++ b/src/components/PodcastMediaElement.js
@@ -30,12 +30,11 @@ export default class PodcastMediaElement extends Component {
     const sources = JSON.parse(this.props.sources);
     let audioResponse = null;
     if (sources[0].src) {
-      const audioUrl = sources[0].src.split("/").pop();
+      const audioUrl = sources[0].src;
       audioResponse = await asyncGetFile(audioUrl, "audio", this, "audioSrc");
     }
     if (audioResponse.success && this.props.poster) {
-      const imgUrl = this.props.poster.split("/").pop();
-      await asyncGetFile(imgUrl, "image", this, "audioImg");
+      await asyncGetFile(this.props.poster, "image", this, "audioImg");
     }
   }
 

--- a/src/components/RelatedItems.js
+++ b/src/components/RelatedItems.js
@@ -7,6 +7,7 @@ import Slider from "react-slick";
 import "slick-carousel/slick/slick.css";
 import "slick-carousel/slick/slick-theme.css";
 
+import Thumbnail from "./Thumbnail.js";
 import "../css/RelatedItems.scss";
 
 class RelatedItems extends Component {
@@ -67,15 +68,15 @@ class RelatedItems extends Component {
 
   render() {
     if (this.state.items != null) {
-      const featuredItems = this.state.items.map(item => {
+      const featuredItems = this.state.items.map((item, idx) => {
         return (
           <div key={item.custom_key}>
             <NavLink to={`/archive/${arkLinkFormatted(item.custom_key)}`}>
               <div className="card">
-                <img
-                  className="card-img-top"
-                  src={item.thumbnail_path}
-                  alt={item.title}
+                <Thumbnail
+                  item={item}
+                  className={"card-img-top"}
+                  altText={item.title}
                 />
                 <div className="card-body">
                   <h4 className="card-title crop-text-4">{item.title}</h4>

--- a/src/components/Thumbnail.js
+++ b/src/components/Thumbnail.js
@@ -24,8 +24,9 @@ class Thumbnail extends Component {
   }
 
   componentDidMount() {
-    if (this.props.item.thumbnail_path) {
-      getFile(this.props.item.thumbnail_path, "image", this, "thumbnailImg");
+    const imgUrl = this.props.imgURL || this.props.item.thumbnail_path;
+    if (imgUrl) {
+      getFile(imgUrl, "image", this, "thumbnailImg");
     }
   }
 

--- a/src/pages/archives/ArchivePage.js
+++ b/src/pages/archives/ArchivePage.js
@@ -20,6 +20,7 @@ import {
 import { searchArchives } from "../../graphql/queries";
 import RelatedItems from "../../components/RelatedItems";
 import Citation from "../../components/Citation";
+import Thumbnail from "../../components/Thumbnail";
 import MtlElement from "../../components/MtlElement";
 import X3DElement from "../../components/X3DElement";
 
@@ -148,7 +149,12 @@ class ArchivePage extends Component {
       display = <MiradorViewer item={item} site={this.props.site} />;
     } else if (this.isImgURL(item.manifest_url)) {
       display = (
-        <img className="item-img" src={item.manifest_url} alt={item.title} />
+        <Thumbnail
+          className="item-img"
+          item={item}
+          imgURL={item.manifest_url}
+          altText={item.title}
+        />
       );
     } else if (this.isAudioURL(item.manifest_url)) {
       const track = this.buildTrack(item.manifest_url, item.thumbnail_path);


### PR DESCRIPTION
**Fetch assets using Storage.get to get url with auth creds where needed.**
* * *

**JIRA Ticket**: (https://webapps.es.vt.edu/jira/browse/LIBTD-2447) (:star:)

* Other Relevant Links (Meeting note, project page, related pull requests, etc.)

# What does this Pull Request do? (:star:)
Fetch assets using Storage.get to get url with auth creds where needed.

# What's the changes? (:star:)
* Check if url requires auth creds.
* If so, use Storage.get to get url with creds
* If not, just return the url as is

# How should this be tested?
* Visit the pages of our various sites (default, iawa, podcasts) and check if images, html files, and audio files are loading correctly

# Additional Notes:
* LIBTD-2447

# Interested parties
@yinlinchen 

(:star:) Required fields
