### PR TITLE
LIBTD-2441: Correctly display item numbers under a collection show pa…

### DIFF
--- a/cypress/integration/admin_homepage_sponsors_config.spec.js
+++ b/cypress/integration/admin_homepage_sponsors_config.spec.js
@@ -37,9 +37,9 @@ describe("Update sponsors fields and revert", function () {
             .click();
         cy.get("#s0_link")
             .clear()
-            .type("https://www.lib.vt.edu");
+            .type("https://lib.vt.edu/");
         cy.contains("Update Config").click();
-        cy.contains("URL: https://www.lib.vt.edu").should("be.visible");
+        cy.contains("URL: https://lib.vt.edu/").should("be.visible");
     });
 
     it("Reverses update", () => {

--- a/src/components/Header.js
+++ b/src/components/Header.js
@@ -26,7 +26,7 @@ class Header extends Component {
           <div className="row vt-one-headerRow">
             <div className="col header-col">
               <div id="vt_logo" className="vt-logo">
-                <a href="https://www.lib.vt.edu/" className="vt-logo-link">
+                <a href="https://lib.vt.edu/" className="vt-logo-link">
                   <img
                     alt=""
                     className="vt-logo-image"
@@ -107,7 +107,7 @@ class Header extends Component {
                     <li className="vt-currentSiteTitle">
                       <a
                         className="vt-currentSiteTitle-link"
-                        href="https://www.lib.vt.edu/"
+                        href="https://lib.vt.edu/"
                         tabIndex="-1"
                       >
                         University Libraries

--- a/src/pages/collections/CollectionItemsLoader.js
+++ b/src/pages/collections/CollectionItemsLoader.js
@@ -153,8 +153,8 @@ class CollectionItemsLoader extends Component {
           </div>
         </div>
       );
-    } else if (this.state.total === 0) {
-      return <div></div>;
+    } else if (this.state.items !== null) {
+      return <div>Items in Collection ({this.state.items.length})</div>;
     } else {
       return <div>Loading...</div>;
     }


### PR DESCRIPTION
…ge when a collection has no item

**JIRA Ticket**: (https://webapps.es.vt.edu/jira/browse/LIBTD-2441) (:star:)

# What does this Pull Request do? (:star:)
This PR corrects the display for the number of items under an empty collection. It should display number 0 instead of the misleading message "loading."

# What's the changes? (:star:)

* Changes the number of items in an empty collection to display 0 items instead of "Loading"

# How should this be tested?

* Go to one of the empty collections in SWVA repo 
* Check if the number of items displayed as 0
![Items in collection](https://user-images.githubusercontent.com/8228221/118524893-a1faf080-b70c-11eb-8654-3079b68374b7.png)

# Interested parties
Tag (@yinlinchen ) interested parties

(:star:) Required fields

