### PR TITLE
Add thumbnail upload to Archive edit form

### DIFF
--- a/src/components/FileUploadField.js
+++ b/src/components/FileUploadField.js
@@ -169,12 +169,15 @@ class FileUploadField extends Component {
   render() {
     return (
       <div className="fileUploadField">
+        <div>
+          <span className="key">{this.props.label}</span>
+        </div>
         {this.props.value && (
           <div>
-            <span className="key">Src:</span> {this.props.value}
+            <span>Current file:</span>{" "}
+            <span className="wrap-content">{this.props.value}</span>
           </div>
         )}
-        <label>{this.props.label}</label>
         <input
           type="file"
           id={this.props.input_id || ""}

--- a/src/css/adminForms.scss
+++ b/src/css/adminForms.scss
@@ -98,3 +98,7 @@ span.required {
   font-weight: 700;
   text-transform: none;
 }
+
+.wrap-content {
+  overflow-wrap: anywhere;
+}

--- a/src/pages/admin/ArchiveCollectionEdit/CollectionForm.js
+++ b/src/pages/admin/ArchiveCollectionEdit/CollectionForm.js
@@ -301,7 +301,7 @@ const CollectionForm = React.memo(props => {
           key={`thumbnail_path_upload_${index}`}
           value={collection["thumbnail_path"]}
           site={siteContext.site}
-          label="Upload thumbnail image"
+          label="Thumbnail image"
           input_id={`thumbnail_path_upload_${index}`}
           name={`thumbnail_path_upload_${index}`}
           placeholder="Enter thumbnail source"

--- a/src/pages/admin/ArchiveCollectionEdit/ViewMetadata.js
+++ b/src/pages/admin/ArchiveCollectionEdit/ViewMetadata.js
@@ -17,7 +17,7 @@ const viewMetadata = React.memo(props => {
   return (
     <div className="view-seciton">
       {props.values && <span className="key">{props.attribute.label}: </span>}
-      {displayValues}
+      <span className="wrap-content">{displayValues}</span>
     </div>
   );
 });


### PR DESCRIPTION
**Add thumbnail upload to Archive edit form.**
* * *

**JIRA Ticket**: (https://webapps.es.vt.edu/jira/browse/LIBTD-2457) (:star:)

* Other Relevant Links (Meeting note, project page, related pull requests, etc.)

# What does this Pull Request do? (:star:)
Add thumbnail upload to Archive edit form.

# What's the changes? (:star:)
* Adds `<FileUploadField />` component for thumbnail_path field

# How should this be tested?
* visit "/siteAdmin" and click "Update Archive"
* Note the value in the "Thumbnail image" field so that you can change back to the original later
* Click "Edit" radio button and upload a new file using the "Thumbnail Image" field
* Submit the form and check that the record was successfully updated.
* (change the image back to what it was previously)

# Additional Notes:
* branch: `LIBTD-2457`

# Interested parties
@yinlinchen 

(:star:) Required fields
