### PR TITLE
LIBTD-2475: use groupsField argument, item_category in Archive and co…

### DIFF
--- a/src/pages/admin/SiteAdmin.js
+++ b/src/pages/admin/SiteAdmin.js
@@ -36,16 +36,8 @@ class SiteAdmin extends Component {
         data.signInUserSession.accessToken.payload["cognito:groups"];
       this.setState({ groups: groups });
       this.setState({ userEmail: data.attributes.email });
-      let adminGroup = "";
-      const repo_type = process.env.REACT_APP_REP_TYPE.toLowerCase();
-      if (repo_type === "default") {
-        adminGroup = "demoSiteAdmin";
-      } else if (repo_type === "podcasts") {
-        adminGroup = "podcastSiteAdmin";
-      } else {
-        adminGroup = `${repo_type}SiteAdmin`;
-      }
-      if (groups && groups.indexOf(adminGroup) !== -1) {
+      const repo_type = process.env.REACT_APP_REP_TYPE;
+      if (groups && groups.indexOf(repo_type) !== -1) {
         this.setAuthorized(true);
       } else {
         this.setAuthorized(false);


### PR DESCRIPTION
…llection_category in Collection to set up dynamic group GraphQL authorization rules

**JIRA Ticket**: (https://webapps.es.vt.edu/jira/browse/LIBTD-2475) (:star:)

# What does this Pull Request do? (:star:)
This PR utilizes the existing fields, i.e., 'item_category' in Archive and 'collection_category' in Collection GraphQL types as groupsField argument to set up dynamic group authorization rules.

# What's the changes? (:star:)

* Check the cognito group directly against REACT_APP_REP_TYPE instead of manually created groups

# How should this be tested?

* Add users to the corresponding group according to the repository type to test out the authorization permissions.
* First check if the user is allowed to access the siteAdmin pages
* Then check if the user can successfully perform edit actions on site configurations as well as archive/collection records
* Check if user can be prohibited to perform CRUD actions when he/she does not belong to the proper group(s)


# Interested parties
Tag (@yinlinchen) interested parties

(:star:) Required fields
