### PR TITLE
Add active classes to menu items on SiteAdmin page

### DIFF
--- a/src/pages/admin/SiteAdmin.js
+++ b/src/pages/admin/SiteAdmin.js
@@ -210,7 +210,11 @@ class SiteAdmin extends Component {
                 Browse Collections Page
               </Link>
             </li>
-            <li>
+            <li
+              className={
+                this.state.form === "displayedAttributes" ? "admin-active" : ""
+              }
+            >
               <Link
                 onClick={() => this.setForm("displayedAttributes")}
                 to={"/siteAdmin"}
@@ -218,7 +222,11 @@ class SiteAdmin extends Component {
                 Displayed Attributes
               </Link>
             </li>
-            <li>
+            <li
+              className={
+                this.state.form === "mediaSection" ? "admin-active" : ""
+              }
+            >
               <Link
                 onClick={() => this.setForm("mediaSection")}
                 to={"/siteAdmin"}
@@ -226,7 +234,11 @@ class SiteAdmin extends Component {
                 Homepage media section
               </Link>
             </li>
-            <li>
+            <li
+              className={
+                this.state.form === "updateArchive" ? "admin-active" : ""
+              }
+            >
               <Link
                 onClick={() => this.setForm("updateArchive")}
                 to={"/siteAdmin"}


### PR DESCRIPTION
**Add active classes to menu items on SiteAdmin page.**
* * *

**JIRA Ticket**: (https://webapps.es.vt.edu/jira/browse/LIBTD-2478) (:star:)

* Other Relevant Links (Meeting note, project page, related pull requests, etc.)

# What does this Pull Request do? (:star:)
Add active classes to menu items on SiteAdmin page.

# What's the changes? (:star:)
* Checks which form has been selected
* Add "active" class to the menu item that matches them selected form

# How should this be tested?
* Go to `/siteAdmin` page
* Click on several menu items and make sure that they stay highlighted when not hovering over them.

# Additional Notes:
* branch: `LIBTD-2478`

# Interested parties
@yinlinchen 

(:star:) Required fields
