### PR TITLE
Set collection_category automatically, don't allow user modification.

### DIFF
--- a/src/pages/admin/ArchiveCollectionEdit/CollectionForm.js
+++ b/src/pages/admin/ArchiveCollectionEdit/CollectionForm.js
@@ -24,7 +24,6 @@ const multiFields = [
 const singleFields = [
   "bibliographic_citation",
   "circa",
-  "collection_category",
   "description",
   "display_date",
   "end_date",
@@ -115,7 +114,7 @@ const CollectionForm = React.memo(props => {
   }, [identifier, newCollection]);
 
   const isRequiredField = attribute => {
-    const requiredFields = ["title", "collection_category", "visibility"];
+    const requiredFields = ["title", "visibility"];
     return requiredFields.includes(attribute);
   };
 
@@ -159,6 +158,7 @@ const CollectionForm = React.memo(props => {
       collection.identifier = id.toString();
       collection.heirarchy_path = [id.toString()];
       collection.custom_key = customKey;
+      collection.collection_category = siteContext.site.groups[0];
     }
 
     setValidForm(true);


### PR DESCRIPTION
**Set collection_category automatically, don't allow user modification.**
* * *

**JIRA Ticket**: (https://webapps.es.vt.edu/jira/browse/LIBTD-2482) (:star:)

* Other Relevant Links (Meeting note, project page, related pull requests, etc.)

# What does this Pull Request do? (:star:)
Set collection_category automatically, don't allow user modification.

# What's the changes? (:star:)
* Removes `collection_category` form input field.
* Sets `collection_category` automatically using Site object if collection is new. (Should already be set if modifying an existing collection)

# How should this be tested?
* Go to `/siteAdmin` and click "New / Update Collection"
* Create a new collection
* Check to make sure that the collection_category field is set correctly, according to the site you're logged in to

# Additional Notes:
* branch: `LIBTD-2482`

# Interested parties
@yinlinchen 

(:star:) Required fields
