### PR TITLE
LIBTD-2444: Add an item link on the view tab of the siteAdmin 'Update…

### DIFF
--- a/cypress/integration/admin_archive_edit.spec.js
+++ b/cypress/integration/admin_archive_edit.spec.js
@@ -1,7 +1,7 @@
 const USERNAME = "devtest";
 const PASSWORD = Cypress.env('password');
 
-describe("Update archive metadata and change it back", function() {
+describe("Update item metadata and change it back", function() {
   beforeEach(() => {
     cy.visit("/siteAdmin");
     cy.get("amplify-authenticator")
@@ -26,18 +26,18 @@ describe("Update archive metadata and change it back", function() {
 
       cy.get("#content-wrapper > div > div > ul", { timeout: 2000 })
       .find(":nth-child(9) > a")
-      .contains("Update Archive")
+      .contains("Update Item")
       .click()
     cy.url().should("include", "/siteAdmin")
 
-    cy.get('input')
+    cy.get("input")
       .clear()
-      .type('Ms1990_025_Per_Ph_B001_F001_003_demo');
+      .type("Ms1990_025_Per_Ph_B001_F001_003_demo");
     cy.contains("Confirm").click();
     cy.get("input[value='view']")
     .parent()
-    .find('input')
-    .should('be.checked')
+    .find("input")
+    .should("be.checked")
     cy.contains("Rights holder: Special Collections, University Libraries, Virginia Tech").should("be.visible");
   })
  
@@ -46,7 +46,7 @@ describe("Update archive metadata and change it back", function() {
     cy.get("div[class='required field']")
       .first()
       .find("input").clear().type("  ");
-    cy.contains("Update Archive Metadata").click();
+    cy.contains("Update Item Metadata").click();
     cy.contains("Please fill in the required field!").should('be.visible');
   })
 
@@ -54,15 +54,17 @@ describe("Update archive metadata and change it back", function() {
     cy.get("input[value='edit']").parent().click();
     cy.get("input[name='title']")
       .clear().type("New Title");
-    cy.contains("Update Archive Metadata").click();
+    cy.contains("Update Item Metadata").click();
     cy.contains("Title: New Title").should('be.visible');
+    cy.contains("View Item")
+      .should('have.attr', 'href').and("include", "/archive/3h85z50c")
   })
 
   it("Change single-valued metadata back", () => {
     cy.get("input[value='edit']").parent().click();
     cy.get("input[name='title']")
       .clear().type("Unidentified building site, c. 1979. Photographs (Ms1990-025)");
-    cy.contains("Update Archive Metadata").click();
+    cy.contains("Update Item Metadata").click();
     cy.contains("Title: Unidentified building site, c. 1979. Photographs (Ms1990-025)").should('be.visible');
   })
 
@@ -70,7 +72,7 @@ describe("Update archive metadata and change it back", function() {
     cy.get("input[value='edit']").parent().click();
     cy.get("input[name='description']")
       .clear();
-    cy.contains("Update Archive Metadata").click();
+    cy.contains("Update Item Metadata").click();
     cy.contains("Description: ").should('not.exist');
   })
 
@@ -78,7 +80,7 @@ describe("Update archive metadata and change it back", function() {
     cy.get("input[value='edit']").parent().click();
     cy.get("input[name='description']")
       .clear().type("Two photographs of an unidentified industrial building site.");
-      cy.contains("Update Archive Metadata").click();
+      cy.contains("Update Item Metadata").click();
       cy.contains("Description: Two photographs of an unidentified industrial building site.").should('be.visible');
   })
 
@@ -88,7 +90,7 @@ describe("Update archive metadata and change it back", function() {
       .parent()
       .siblings(".deleteValue")
       .click();
-    cy.contains("Update Archive Metadata").click();
+    cy.contains("Update Item Metadata").click();
     cy.contains("Ms1990-025, Box 1, Folder 1").should('not.exist');
   })
 
@@ -101,7 +103,7 @@ describe("Update archive metadata and change it back", function() {
     cy.get("input[name='belongs_to_1']").should("have.value", "new belongs_to")
       .clear()
       .type("Ms1990-025, Box 1, Folder 1");
-    cy.contains("Update Archive Metadata").click();
+    cy.contains("Update Item Metadata").click();
     cy.contains("Ms1990-025, Box 1, Folder 1").should('be.visible');
   })
 

--- a/src/pages/admin/ArchiveCollectionEdit/ArchiveForm.js
+++ b/src/pages/admin/ArchiveCollectionEdit/ArchiveForm.js
@@ -34,6 +34,7 @@ const singleFields = [
   "rights_holder",
   "rights_statement",
   "title",
+  "custom_key",
   "thumbnail_path"
 ];
 
@@ -90,7 +91,11 @@ const ArchiveForm = React.memo(props => {
   const editableAttributes = () => {
     const displayedAttributes = JSON.parse(
       siteContext.site.displayedAttributes
-    )["archive"].filter(attribute => editableFields.includes(attribute.field));
+    )["archive"].filter(
+      attribute =>
+        attribute.field !== "custom_key" &&
+        editableFields.includes(attribute.field)
+    );
     displayedAttributes.unshift(
       {
         field: "title",
@@ -255,16 +260,26 @@ const ArchiveForm = React.memo(props => {
   let archiveDisplay = null;
   if (archive) {
     if (viewState === "view") {
-      archiveDisplay = editableAttributes().map((attribute, index) => {
-        return (
-          <ViewMetadata
-            key={`view_${index}`}
-            attribute={attribute}
-            isMulti={multiFields.includes(attribute.field)}
-            values={archive[attribute.field]}
-          />
-        );
-      });
+      archiveDisplay = [
+        <a
+          key="view_custom_key"
+          href={`/archive/${archive.custom_key.split("/").pop()}`}
+        >
+          View Item
+        </a>
+      ];
+      archiveDisplay.push(
+        editableAttributes().map((attribute, index) => {
+          return (
+            <ViewMetadata
+              key={`view_${attribute.field}`}
+              attribute={attribute}
+              isMulti={multiFields.includes(attribute.field)}
+              values={archive[attribute.field]}
+            />
+          );
+        })
+      );
     } else {
       let errorMsg = null;
       if (!validForm) {
@@ -279,7 +294,7 @@ const ArchiveForm = React.memo(props => {
             return formElement(attribute, index);
           })}
           <Form.Button onClick={submitArchiveHandler}>
-            Update Archive Metadata
+            Update Item Metadata
           </Form.Button>
         </Form>
       );

--- a/src/pages/admin/SiteAdmin.js
+++ b/src/pages/admin/SiteAdmin.js
@@ -243,7 +243,7 @@ class SiteAdmin extends Component {
                 onClick={() => this.setForm("updateArchive")}
                 to={"/siteAdmin"}
               >
-                Update Archive
+                Update Item
               </Link>
             </li>
             <li


### PR DESCRIPTION
… Item' page to enable direct access to the updated item page

**JIRA Ticket**: (https://webapps.es.vt.edu/jira/browse/LIBTD-2444) (:star:)

# What does this Pull Request do? (:star:)
This PR adds an item link on the view tab at the siteAdmin 'Update Item' configuration page so that after editing the item, the editor can go directly to the item page to see the updated item metadata.

# What's the changes? (:star:)

* Adds a link to the item display page on the view tab
* Changes the "Update Archive" to "Update Item" to be consistent with the vocabularies

# How should this be tested?

* Go to the "siteAdmin" page, click on "Update Item"
* Update some metadata for an item, then click on "Update Item Metadata" at the bottom
* At the landing view tab, click on the "View Item" link at the top to see changes reflected on the item display page.

# Interested parties
Tag (@yinlinchen) interested parties

(:star:) Required fields
