### PR TITLE
Adjust fetchTools so that assetBasePath and lang fields can be removed from Site model

### DIFF
--- a/src/lib/fetchTools.js
+++ b/src/lib/fetchTools.js
@@ -117,7 +117,7 @@ export const mintNOID = async () => {
   return retVal;
 };
 
-export const fetchAvailableDisplayedAttributes = async site => {
+export const fetchAvailableDisplayedAttributes = async () => {
   let data = null;
   const keyName = `availableAttributes`;
   try {
@@ -129,8 +129,14 @@ export const fetchAvailableDisplayedAttributes = async site => {
     console.log(`fetching ${keyName}`);
     let response = null;
     try {
-      const htmlLink = `${site.lang}/${keyName}.json`;
-      response = await fetch(htmlLink);
+      const prefix = "public/data/";
+      Storage.configure({
+        customPrefix: {
+          public: prefix
+        }
+      });
+      const attributesLink = await Storage.get(`${keyName}.json`);
+      response = await fetch(attributesLink);
       data = await response.json();
     } catch (error) {
       console.error(`Error fetching ${keyName}`);
@@ -145,17 +151,24 @@ export const fetchAvailableDisplayedAttributes = async site => {
 
 export const fetchLanguages = async (component, site, key, callback) => {
   let data = null;
+  const keyName = `language_codes_by_${key}`;
   try {
-    data = JSON.parse(sessionStorage.getItem(`lang_by_${key}`));
+    data = JSON.parse(sessionStorage.getItem(keyName));
   } catch (error) {
-    console.log(`lang_by_${key} not in sessionStorage`);
+    console.log(`${keyName} not in sessionStorage`);
   }
   if (data === null) {
-    console.log(`fetching by lang_by_${key}`);
+    console.log(`fetching by ${key}`);
     let response = null;
     try {
-      const htmlLink = `${site.lang}/language_codes_by_${key}.json`;
-      response = await fetch(htmlLink);
+      const prefix = "public/data/";
+      Storage.configure({
+        customPrefix: {
+          public: prefix
+        }
+      });
+      const langLink = await Storage.get(`${keyName}.json`);
+      response = await fetch(langLink);
       data = await response.json();
     } catch (error) {
       console.error(`Error fetching languages`);
@@ -163,7 +176,7 @@ export const fetchLanguages = async (component, site, key, callback) => {
     }
   }
   if (data !== null) {
-    sessionStorage.setItem(`lang_by_${key}`, JSON.stringify(data));
+    sessionStorage.setItem(keyName, JSON.stringify(data));
     component.setState({ languages: data }, function() {
       if (typeof component.loadItems === "function") {
         component.loadItems();

--- a/src/lib/fetchTools.js
+++ b/src/lib/fetchTools.js
@@ -117,6 +117,18 @@ export const mintNOID = async () => {
   return retVal;
 };
 
+const fetchGlobalData = async (prefix, filename) => {
+  Storage.configure({
+    customPrefix: {
+      public: prefix
+    }
+  });
+  const authLink = await Storage.get(filename);
+  const response = await fetch(authLink);
+  const data = await response.json();
+  return data;
+};
+
 export const fetchAvailableDisplayedAttributes = async () => {
   let data = null;
   const keyName = `availableAttributes`;
@@ -127,17 +139,8 @@ export const fetchAvailableDisplayedAttributes = async () => {
   }
   if (data === null) {
     console.log(`fetching ${keyName}`);
-    let response = null;
     try {
-      const prefix = "public/data/";
-      Storage.configure({
-        customPrefix: {
-          public: prefix
-        }
-      });
-      const attributesLink = await Storage.get(`${keyName}.json`);
-      response = await fetch(attributesLink);
-      data = await response.json();
+      data = await fetchGlobalData("public/data/", `${keyName}.json`);
     } catch (error) {
       console.error(`Error fetching ${keyName}`);
       console.error(error);
@@ -159,17 +162,8 @@ export const fetchLanguages = async (component, site, key, callback) => {
   }
   if (data === null) {
     console.log(`fetching by ${key}`);
-    let response = null;
     try {
-      const prefix = "public/data/";
-      Storage.configure({
-        customPrefix: {
-          public: prefix
-        }
-      });
-      const langLink = await Storage.get(`${keyName}.json`);
-      response = await fetch(langLink);
-      data = await response.json();
+      data = await fetchGlobalData("public/data/", `${keyName}.json`);
     } catch (error) {
       console.error(`Error fetching languages`);
       console.error(error);

--- a/src/pages/search/SearchLoader.js
+++ b/src/pages/search/SearchLoader.js
@@ -185,15 +185,13 @@ class SearchLoader extends Component {
   }
 
   componentDidUpdate(prevProps) {
-    if (this.props !== prevProps) {
+    if (this.props.location !== prevProps.location) {
       fetchLanguages(this, this.props.site, "name", this.loadItems);
-      this.loadItems();
     }
   }
 
   componentDidMount() {
     fetchLanguages(this, this.props.site, "name", this.loadItems);
-    this.loadItems();
   }
 
   render() {


### PR DESCRIPTION
**Adjust fetchTools so that assetBasePath and lang fields can be removed from Site model.**
* * *

**JIRA Ticket**: (https://webapps.es.vt.edu/jira/browse/LIBTD-2442) (:star:)

* Other Relevant Links (Meeting note, project page, related pull requests, etc.)

# What does this Pull Request do? (:star:)
Adjust fetchTools so that assetBasePath and lang fields can be removed from Site model

# What's the changes? (:star:)
* moves availableAttributes.json and language_codes_by_(name/abbr).json into bucket configured for site Storage
* Uses `Storage.get` to fetch files instead of using `lang` field

# How should this be tested?
* visit "/siteAdmin" and click on "Displayed Attributes"
* check to make sure that attributes are loading
* visit "/search"
* check that Language filter is still working

# Additional Notes:
* branch: `LIBTD-2442`

# Interested parties
@yinlinchen 

(:star:) Required fields
