### PR TITLE
Change to matchPhrasePrefix

### DIFF
--- a/cypress/integration/search_bar.spec.js
+++ b/cypress/integration/search_bar.spec.js
@@ -42,11 +42,11 @@ describe('Search by description by hitting enter key', () => {
       .should('eq', 'http://localhost:3000/search?field=description&q=certificate&view=Gallery');
     cy.get('#content > div.navbar > div.view-info > div.pagination-section > div.pagination-text')
       .invoke('text')
-      .should('equal', 'Search Results: 1 - 3 of 3');
+      .should('equal', 'Search Results: 1 - 4 of 4');
 
     cy.get('#content > div.search-results-section > div.row')
       .children()
-      .should('have.length', 3);
+      .should('have.length', 4);
 
     cy.get('#content > div.search-results-section > div.row > :nth-child(1) > div.card > a > div.card-body > p')
       .invoke('text')

--- a/src/lib/fetchTools.js
+++ b/src/lib/fetchTools.js
@@ -221,7 +221,7 @@ export const fetchSearchResults = async (
       let parent_collection_id = await getCollectionIDByTitle(filter[key]);
       filters["heirarchy_path"] = { eq: parent_collection_id };
     } else if (key === "title" || key === "description") {
-      filters[key] = { matchPhrase: filter[key] };
+      filters[key] = { matchPhrasePrefix: filter[key] };
     } else if (Array.isArray(filter[key])) {
       if (key === "date") {
         filter[key].forEach(function(value) {


### PR DESCRIPTION
**JIRA Ticket**: (https://webapps.es.vt.edu/jira/browse/LIBTD-2470) (:star:)

# What does this Pull Request do? (:star:)
Change to matchPhrasePrefix, so user don't need to exactly query. e.g.  both `record` or `records` works. It is only for the `Title` in the search bar, as reported by the stakeholder.

<img width="1646" alt="Screen Shot 2021-06-03 at 9 31 20 AM" src="https://user-images.githubusercontent.com/7999195/120701722-37beab80-c481-11eb-95f4-1cc18ca727c2.png">


# How should this be tested?
1. See the amplify preview link below and do the search.

# Interested parties
Tag (@tingtingjh ) interested parties

(:star:) Required fields
