### PR TITLE
Remove Brackets and Commas from Email Display in About Pages

### DIFF
--- a/src/components/ContactSection.js
+++ b/src/components/ContactSection.js
@@ -21,8 +21,8 @@ class ContactSection extends Component {
             {contactList.map((contact, index) => (
               <div key={index}>
                 <p className="contact-title">
-                  {contact.title} [
-                  <a href={`mailto:${contact.email}`}>{contact.email}</a>],{" "}
+                  {contact.title} &nbsp;
+                  <a href={`mailto:${contact.email}`}>{contact.email}</a> {" "}
                   {contact.group}
                 </p>
                 <div className="contact-address">


### PR DESCRIPTION
**JIRA Ticket**: (https://webapps.es.vt.edu/jira/browse/LIBTD-2499) (:star:)

# What does this Pull Request do? (:star:)
Remove Brackets and Commas from Email Display in About Pages

# What's the changes? (:star:)
<img width="1011" alt="Screen Shot 2021-06-29 at 8 14 59 AM" src="https://user-images.githubusercontent.com/7999195/123795850-72fe9f80-d8b2-11eb-8812-bb78a874ef08.png">

# How should this be tested?
1. Pull & Run
2. See About page and check the change, should like screenshot above

(:star:) Required fields
