### PR TITLE
Styles for additional pages

### DIFF
--- a/src/css/AdditionalPages.scss
+++ b/src/css/AdditionalPages.scss
@@ -1,0 +1,41 @@
+.additional-pages-wrapper {
+  font-family: "Acherus", sans-serif;
+}
+
+.additional-pages-wrapper h1,
+.additional-pages-wrapper h2,
+.additional-pages-wrapper h3,
+.additional-pages-wrapper h4,
+.additional-pages-wrapper h5,
+.additional-pages-wrapper h6 {
+  font-family: "gineso-condensed", sans-serif;
+}
+
+.additional-pages-wrapper a,
+.additional-pages-wrapper a:visited {
+  color: var(--hokieOrange);
+}
+.additional-pages-wrapper a:hover,
+.additional-pages-wrapper a:focus,
+.additional-pages-wrapper a:active {
+  color: var(---hokieOrangeHover);
+}
+
+.additional-pages-wrapper table {
+  width: 100%;
+  margin-bottom: 1rem;
+  color: #212529;
+  font-family: "Acherus", sans-serif;
+}
+
+.additional-pages-wrapper table th,
+.additional-pages-wrapper table td {
+  font-family: "Acherus", sans-serif;
+  padding: 0.75rem;
+  border-top: 1px solid #dee2e6;
+  vertical-align: top;
+}
+
+.additional-pages-wrapper table caption {
+  caption-side: top;
+}

--- a/src/css/index.scss
+++ b/src/css/index.scss
@@ -1,8 +1,6 @@
 body {
   margin: 0;
-  font-family: -apple-system, BlinkMacSystemFont, "Segoe UI", "Roboto", "Oxygen",
-    "Ubuntu", "Cantarell", "Fira Sans", "Droid Sans", "Helvetica Neue",
-    sans-serif;
+  font-family: "Acherus", sans-serif;
   -webkit-font-smoothing: antialiased;
   -moz-osx-font-smoothing: grayscale;
 }

--- a/src/pages/AdditionalPages.js
+++ b/src/pages/AdditionalPages.js
@@ -1,6 +1,8 @@
 import React, { Component } from "react";
 import { getFile } from "../lib/fetchTools";
 
+import "../css/AdditionalPages.scss";
+
 class AdditionalPages extends Component {
   constructor(props) {
     super(props);
@@ -19,7 +21,12 @@ class AdditionalPages extends Component {
   }
 
   render() {
-    return <div dangerouslySetInnerHTML={{ __html: this.state.copy }}></div>;
+    return (
+      <div
+        className="additional-pages-wrapper"
+        dangerouslySetInnerHTML={{ __html: this.state.copy }}
+      ></div>
+    );
   }
 }
 


### PR DESCRIPTION
**JIRA Ticket**: (link) (:star:)
https://webapps.es.vt.edu/jira/browse/LIBTD-2466
https://webapps.es.vt.edu/jira/browse/LIBTD-2467

* Other Relevant Links (Meeting note, project page, related pull requests, etc.)
Wen's feedback - https://docs.google.com/presentation/d/151ilRgro82BQAZxXF3pSZNU6nQB7s0fpPMnrpgn2a3I/edit?usp=sharing

# What does this Pull Request do? (:star:)
Adds some based styles for fonts, links and tables to the additional pages included in digital libraries.

# What's the changes? (:star:)
-CSS file for the styles
-Changes base font style to branded font for the site overall
-Adds class to component which generates these pages.

# How should this be tested?
-SWVA additional pages should now look similar to the rest of the DLP. The tables should have improved spacing.

# Additional Notes:
branch is LIBTD-2466

# Interested parties
@yinlinchen 

(:star:) Required fields
