### PR TITLE
Fixed placement of modal for VT branding

### DIFF
--- a/public/js/one.js
+++ b/public/js/one.js
@@ -197,15 +197,19 @@ function navToggle() {
 		}
 
 		$(document).scrollTop(0);
-		$( "main, footer, .vt-page-path" ).animate({
-			"left" : "-=320px"
-	  },200);
+		$( "main, footer" ).animate({
+			"left" : "-=320px",
+	 	 },200);
+	 	$( ".vt-page-path" ).animate({
+		"left" : "-=320px",
+		"margin-right" : "0"
+  		},200);
 		$(".vt-nav-toggle").attr("aria-expanded", "true");
 		$(".vt-nav-toggle .menu-open").addClass("d-none");
 		$(".vt-nav-toggle .menu-close").removeClass("d-none");
 		$(".vt-universal-access, .vt-access-dialog-wrapper").addClass("menuOpen");
 		$(".vt-nav-toggle, #vt_offcanvas_nav, #vt_nav").addClass("open");
-		$("html").addClass("vt-bodyNoScroll");
+		$("body").addClass("vt-bodyNoScroll");
 		$('.vt-page-path > .gateway, .vt-page-path > .vt-subnav, main > div[class*="-content"], main > .row, footer > .row').attr("aria-hidden", "true");
 		$("#vt_offcanvas_nav").attr("aria-hidden", "false");
 		$("#vt_offcanvas_nav").show();
@@ -227,11 +231,17 @@ function navToggle() {
 		$(".vt-universal-access, .vt-access-dialog-wrapper").removeClass("menuOpen");
 		$("#vt_offcanvas_nav, .vt-nav-toggle, #vt_nav").removeClass("open");
 		$("#vt_offcanvas_nav").attr("aria-hidden", "true");
-		$( "main, footer, .vt-page-path" ).animate({
+		$( "main, footer" ).animate({
 			"left" : "+=320px"
 	  }, 200, function() {
 	    $("#vt_offcanvas_nav").hide();
 	  });
+	  $( ".vt-page-path" ).animate({
+		"left" : "+=320px",
+		"margin-right" : "-15px"
+  	  }, 200, function() {
+		$("#vt_offcanvas_nav").hide();
+  	  });
 		$(".vt-body-modal, .vt-footer-modal, .vt-pageContext-modal").remove();
 		$(".has-submenu .link-wrapper").removeClass("active");
 		disableBodyScroll(false);

--- a/src/css/adminForms.scss
+++ b/src/css/adminForms.scss
@@ -1,4 +1,4 @@
-section {
+form section {
   margin: 20px 0;
   padding: 10px;
   border: 1px solid black;

--- a/src/css/index.scss
+++ b/src/css/index.scss
@@ -20,3 +20,7 @@ code {
   text-align: center;
   line-height: 1.25rem;
 }
+
+#vt_offcanvas_nav .vt-parent-org {
+  margin-bottom: 0;
+}


### PR DESCRIPTION
**JIRA Ticket**: (link) (:star:)
https://webapps.es.vt.edu/jira/browse/LIBTD-2504

# What does this Pull Request do? (:star:)
As noted in feedback from SWVA stakeholders, when the menu button is clicked and the navigation menu is expanded, the modal that covers the rest of the page content was not in the correct place.

# What's the changes? (:star:)
The problem was that overflow:hidden was not being recognized on the html element by React. This style is now applied to body element successfully. So scrolling is disabled when the modal is active and without the scrollbar the modal placement is correct. I also corrected some small style conflicts that were impacting the modal/nav menu appearance.

# How should this be tested?
Menu button should expand nav menu and modal to the left should appear with no gaps around it. The screen should not be scrollable.

# Additional Notes:
Branch is LIBTD-2504

# Interested parties
@yinlinchen 

(:star:) Required fields
