### PR TITLE
Navigation bar

### DIFF
--- a/cypress/integration/additional_pages.spec.js
+++ b/cypress/integration/additional_pages.spec.js
@@ -14,10 +14,7 @@ describe('Site nav menu', () => {
 describe('About link', () => {
   it('links to correct About page', () => {
     cy.visit('/');
-    cy.get('#vt_nav > div.linkWrapper > button')
-      .click();
-    cy.get('#vt_main_nav > li:nth-child(4) .link-wrapper a', { timeout: 2000 })
-      .should('be.visible')
+    cy.get('nav.top-navbar > ul > li:nth-child(4) > a')
       .click();
     cy.get('#content-wrapper > div > div.col-12.about-heading > h1', { timeout: 2000 })
       .invoke('text')

--- a/src/App.js
+++ b/src/App.js
@@ -4,6 +4,7 @@ import ScrollToTop from "./lib/ScrollToTop";
 import RouteListener from "./lib/RouteListener";
 import AnalyticsConfig from "./components/AnalyticsConfig";
 import Header from "./components/Header";
+import NavBar from "./components/NavBar";
 import Footer from "./components/Footer";
 import { buildRoutes } from "./lib/CustomPageRoutes";
 import HomePage from "./pages/HomePage";
@@ -70,6 +71,9 @@ class App extends Component {
             path={this.state.path}
           />
           <main style={{ minHeight: "500px", padding: "1em 1em 0 1em" }}>
+            <div className="container p-0">
+              <NavBar site={this.state.site} />
+            </div>
             <div id="content-wrapper" className="container p-0">
               <Switch>
                 {customRoutes}

--- a/src/components/Header.js
+++ b/src/components/Header.js
@@ -14,13 +14,12 @@ class Header extends Component {
       <div id="vt_theme_one" className="vt-home norightcol home-page">
         <header className="header">
           <nav aria-label="Skip Links">
-            <ul className="vt-skip-nav">
-              <li className="vt-skip-navItem">
-                <a className="vt-skip-navLink" href="#vt_main">
-                  Skip to main content
-                </a>
-              </li>
-            </ul>
+            <a
+              className="sr-only sr-only-focusable skipLink"
+              href="#content-wrapper"
+            >
+              Skip to main content
+            </a>
           </nav>
 
           <div className="row vt-one-headerRow">
@@ -114,8 +113,9 @@ class Header extends Component {
                       </a>
                     </li>
                   </ol>
-
-                  <SiteNavigationLinks site={this.props.site} />
+                  <div className="menu-links">
+                    <SiteNavigationLinks site={this.props.site} />
+                  </div>
                 </div>
               </nav>
             </div>

--- a/src/components/NavBar.js
+++ b/src/components/NavBar.js
@@ -1,0 +1,120 @@
+import React, { Component } from "react";
+import { NavLink } from "react-router-dom";
+
+class NavBar extends Component {
+  buildListItems() {
+    let listItems = [];
+    let sitePageItems = JSON.parse(this.props.site.sitePages);
+
+    const sitePages = {};
+    Object.keys(sitePageItems)
+      .sort()
+      .forEach(function(key) {
+        sitePages[key] = sitePageItems[key];
+      });
+
+    for (const [key, page] of Object.entries(sitePages)) {
+      listItems.push(this.topLevelItem(key, page));
+    }
+    return listItems;
+  }
+
+  topLevelItem(key, page) {
+    const hasChildClass = page.children ? "nav-item dropdown" : "nav-item";
+    const link = page.children ? (
+      <>
+        <NavLink className="nav-link inline" to={page.local_url}>
+          {page.text.toUpperCase()}
+        </NavLink>
+        <a
+          id="navbarDropdownMenuLink"
+          href="/about"
+          role="button"
+          data-toggle="dropdown"
+          aria-haspopup="true"
+          aria-expanded="false"
+          aria-label={`${page.text} menu`}
+        >
+          <i class="fa fa-chevron-down" aria-hidden="true"></i>
+        </a>
+      </>
+    ) : (
+      <NavLink className="nav-link" to={page.local_url}>
+        {page.text.toUpperCase()}
+      </NavLink>
+    );
+    const listItem = (
+      <li key={page.text} className={hasChildClass}>
+        {link}
+        {this.childList(page)}
+      </li>
+    );
+    return listItem;
+  }
+
+  childList(page) {
+    let childList = <></>;
+    if (page.children) {
+      const ulID = `${page.text.toLowerCase()}_submenu`;
+      const ariaLabel = `${page.text} Submenu`;
+      childList = (
+        <div className="dropdown-menu" id={ulID} aria-label={ariaLabel}>
+          {this.childItems(page)}
+        </div>
+      );
+    }
+    return childList;
+  }
+
+  childItems(parentPage) {
+    const parentKey = parentPage.text;
+    let childItems = [];
+    for (const [childKey, page] of Object.entries(parentPage.children)) {
+      const liKey = `${parentKey}.${childKey}`;
+      const item = (
+        <NavLink
+          className="dropdown-item"
+          key={liKey}
+          to={page.local_url}
+          tabIndex="-1"
+        >
+          {page.text}
+        </NavLink>
+      );
+      childItems.push(item);
+    }
+    return childItems;
+  }
+
+  render() {
+    const additionalListItems = this.buildListItems();
+    return (
+      <nav
+        className="navbar navbar-expand-md top-navbar bg-light"
+        role="navigation"
+        aria-label="Pages in Site"
+      >
+        <ul className="navbar-nav">
+          <li className="nav-item">
+            <NavLink className="nav-link" to="/">
+              HOME
+            </NavLink>
+          </li>
+          <li className="nav-item">
+            <NavLink className="nav-link" to="/collections">
+              BROWSE COLLECTIONS
+            </NavLink>
+          </li>
+          <li className="nav-item">
+            <NavLink className="nav-link" to="/search">
+              SEARCH
+            </NavLink>
+          </li>
+          {additionalListItems}
+        </ul>
+      </nav>
+    );
+  }
+}
+
+export default NavBar;

--- a/src/css/index.scss
+++ b/src/css/index.scss
@@ -19,6 +19,72 @@ code {
   line-height: 1.25rem;
 }
 
+a.skipLink:focus {
+  outline-color: #75787b;
+  outline-offset: 3px;
+  outline-style: dashed;
+  outline-width: 2px;
+}
+
 #vt_offcanvas_nav .vt-parent-org {
   margin-bottom: 0;
+}
+
+.menu-links {
+  display: block;
+}
+
+nav.navbar.navbar-expand-md.top-navbar {
+  display: none;
+  font-family: Acherus, sans-serif;
+  font-style: italic;
+  color: #212529;
+  font-weight: 500;
+  margin-bottom: 36px;
+}
+
+nav.navbar.navbar-expand-md.top-navbar ul.navbar-nav {
+  width: 100%;
+  display: flex;
+  justify-content: space-evenly;
+}
+
+nav.navbar.navbar-expand-md.top-navbar ul.navbar-nav a {
+  color: var(--darker-gray);
+}
+
+nav.navbar.navbar-expand-md.top-navbar ul.navbar-nav a:hover {
+  color: var(--hokieMaroon);
+}
+nav.navbar.navbar-expand-md.top-navbar ul.navbar-nav a:focus {
+  outline: none;
+}
+nav.navbar.navbar-expand-md.top-navbar ul.navbar-nav a:focus-visible {
+  color: var(--hokieMaroon);
+  outline-color: var(--hokieMaroon);
+  outline-offset: 3px;
+  outline-style: dashed;
+  outline-width: 2px;
+}
+
+nav.navbar.navbar-expand-md.top-navbar ul.navbar-nav a:active {
+  color: var(--hokieMaroon);
+  outline: hidden;
+}
+
+a.nav-link.inline {
+  display: inline-block;
+}
+
+li.nav-item.dropdown:hover div.dropdown-menu {
+  display: block;
+}
+
+@media (min-width: 992px) {
+  .menu-links {
+    display: none;
+  }
+  nav.navbar.navbar-expand-md.top-navbar {
+    display: flex;
+  }
 }


### PR DESCRIPTION
**JIRA Ticket**: (link) (:star:)
https://webapps.es.vt.edu/jira/browse/LIBTD-2503

* Other Relevant Links (Meeting note, project page, related pull requests, etc.)
Mockup: https://xd.adobe.com/view/4668a190-e56d-4bee-8689-e66e56da63ec-133b/.

# What does this Pull Request do? (:star:)
Creates a navigation bar at the top of site pages for screen sizes over 992 px. At smaller screen sizes the hamburger menu will contain the navigation links. As per the Communications team, the button for the hamburger menu must be present at all screen sizes because it is part of the VT branding. The navigation bar is fully accessible. A submenu of links will appear on hover. The parent link is clickable. For keyboard users, the focus will move to the down arrow which opens the submenu on enter. The submenu allows in-menu navigation by arrow keys and esc closes menu then restores focus to down arrow. Also includes a fix for the skip link.

# What's the changes? (:star:)
App.js - adds navbar component to page layout
Header.js - fixes skip link
NavBar.js - creates navbar (essentially a modified version of SiteNavigationLink.js)
index.scss - style for the new navbar and skip link

# How should this be tested?
For SWVA and the federated site, sub menu of links should appear in navbar when screen is >992px. Smaller screen sizes would show the navigation links in the hamburger menu, as usual. For IAWA and other libraries without sub-pages in their navigation, the primary navigation links will show in the navbar in a single line. Focus outline is present when navigating by keyboard.

# Additional Notes:
Branch is LIBTD-2503

# Interested parties
@yinlinchen 

(:star:) Required fields
