### PR TITLE
Removed code to hide title of library

### DIFF
--- a/cypress/integration/admin_homepage_top_config.spec.js
+++ b/cypress/integration/admin_homepage_top_config.spec.js
@@ -45,20 +45,6 @@ describe("Update Homepage fields and revert", function() {
     cy.contains("Heading: Welcome").should('be.visible');
   })
 
-  it("Update Show title", () => {
-    cy.get("input[value='edit']").parent().click();
-    cy.get("input[name='staticImageShowTitle']").uncheck();
-    cy.contains("Update Config").click();
-    cy.contains("Show title: false").should('be.visible');
-  })
-
-  it("Change Show title back", () => {
-    cy.get("input[value='edit']").parent().click();
-    cy.get("input[name='staticImageShowTitle']").check();
-    cy.contains("Update Config").click();
-    cy.contains("Show title: true").should('be.visible');
-  })
-
   it("displays successful upload", () => {
     cy.get("input[value='edit']").parent().click();
     const imgPath = "sitecontent/cover_image1.jpg";

--- a/src/css/FeaturedStaticImage.scss
+++ b/src/css/FeaturedStaticImage.scss
@@ -12,10 +12,3 @@
   max-height: 450px;
   object-fit: cover;
 }
-
-.home-wrapper-no-text .home-static-image-wrapper img {
-  width: 100%;
-  margin: 0px;
-  max-height: 450px;
-  object-fit: cover;
-}

--- a/src/css/HomePage.scss
+++ b/src/css/HomePage.scss
@@ -26,10 +26,6 @@
   text-shadow: -2px 3px 5px #000000b5;
 }
 
-.home-wrapper-no-text #home-site-title-wrapper {
-  display: none;
-}
-
 .home-statement-wrapper {
   width: 100%;
   padding-top: 40px;
@@ -59,11 +55,6 @@
   width: 100%;
   padding: 0 10px 0 10px;
   transform: translate(0, -23px);
-}
-
-.home-wrapper-no-text .home-search-wrapper {
-  width: 100%;
-  padding-top: 40px;
 }
 
 .home-nav-links {
@@ -123,11 +114,6 @@
 
   .home-wrapper .home-search-wrapper {
     padding: 0 40px 0 40px;
-  }
-
-  .home-wrapper-no-text .home-search-wrapper {
-    padding: 0 40px 0 40px;
-    transform: translate(0, -23px);
   }
 }
 

--- a/src/css/adminForms.scss
+++ b/src/css/adminForms.scss
@@ -46,9 +46,6 @@ div.view-section ul li span.entry {
 .key {
   font-weight: bold;
 }
-input.showTitleCheckbox {
-  margin: 4px 0 0 5px;
-}
 button.submit {
   font-size: 18px;
 }

--- a/src/pages/HomePage.js
+++ b/src/pages/HomePage.js
@@ -32,11 +32,7 @@ class HomePage extends Component {
     return (
       <>
         <SiteTitle siteTitle={this.props.site.siteTitle} pageTitle="Home" />
-        <div
-          className={
-            staticImage.showTitle ? "home-wrapper" : "home-wrapper-no-text"
-          }
-        >
+        <div className="home-wrapper">
           <div className="home-featured-image-wrapper">
             <FeaturedStaticImage staticImage={staticImage} />
             <div id="home-site-title-wrapper">

--- a/src/pages/admin/HomepageForm.js
+++ b/src/pages/admin/HomepageForm.js
@@ -13,7 +13,6 @@ import * as sanitizeHtml from "sanitize-html";
 const initialFormState = {
   staticImageSrc: "",
   staticImageAltText: "",
-  staticImageShowTitle: false,
   homeStatementHeading: "",
   homeStatement: "",
   sponsors: [],
@@ -83,7 +82,6 @@ class HomepageForm extends Component {
         siteInfo = {
           staticImageSrc: homepage.staticImage.src || "",
           staticImageAltText: homepage.staticImage.altText || "",
-          staticImageShowTitle: homepage.staticImage.showTitle || false,
           homeStatementHeading: homepage.homeStatement.heading || "",
           homeStatement: homepage.homeStatement.statement,
           sponsors: homepage.sponsors || [],
@@ -136,7 +134,6 @@ class HomepageForm extends Component {
     );
     homePage.staticImage.src = this.state.formState.staticImageSrc;
     homePage.staticImage.altText = this.state.formState.staticImageAltText;
-    homePage.staticImage.showTitle = this.state.formState.staticImageShowTitle;
     homePage.sponsors = this.state.formState.sponsors;
     homePage.featuredItems = this.state.formState.featuredItems;
     homePage.collectionHighlights = this.state.formState.collectionHighlights;
@@ -208,16 +205,6 @@ class HomepageForm extends Component {
               placeholder="Enter Alt Text"
               onChange={this.updateInputValue}
             />
-            <label>
-              Show title:
-              <input
-                className="showTitleCheckbox"
-                name="staticImageShowTitle"
-                type="checkbox"
-                checked={this.state.formState.staticImageShowTitle}
-                onChange={this.updateInputValue}
-              />
-            </label>
           </section>
         </Form>
         <FeaturedItemsForm
@@ -251,16 +238,6 @@ class HomepageForm extends Component {
     );
   };
 
-  showTitleFormatted() {
-    let title = "false";
-    try {
-      title = this.state.formState.staticImageShowTitle.toString();
-    } catch (error) {
-      console.error(error);
-    }
-    return title;
-  }
-
   view = () => {
     if (this.props.site && this.state.formState) {
       return (
@@ -283,10 +260,6 @@ class HomepageForm extends Component {
             <p>
               <span className="key">Alt text:</span>{" "}
               {this.state.formState.staticImageAltText}
-            </p>
-            <p>
-              <span className="key">Show title:</span>{" "}
-              {this.showTitleFormatted()}
             </p>
             <h3>Featured Items</h3>
             <FeaturedItems itemList={this.state.formState.featuredItems} />


### PR DESCRIPTION
**JIRA Ticket**: (link) (:star:)
https://webapps.es.vt.edu/jira/browse/LIBTD-2431

* Other Relevant Links (Meeting note, project page, related pull requests, etc.)

# What does this Pull Request do? (:star:)
Removes the option from the admin site to hide the title of the digital library so that the cover image can have branded text included within the image. Also removes the code in the site which triggered the alternate layout and the cypress test for this feature. Due to accessibility concerns, this is not a good feature to support.

# What's the changes? (:star:)

-cypress/integration/admin_homepage_top_config.spec.js -  just removes the test for changing the site to hide the title.
-FeaturedStaticImage.scss -  removes CSS for alternate layout
-HomePage.scss -  removes CSS for alternate layout
-adminForms.scss - removes CSS for the checkbox that was in the admin site
-HomePage.js -  removes conditional which looked for this value
-HomepageForm.js - removes the code which allowed this option in the admin site

# How should this be tested?
The Homepage config form should still work as before, just without this option. The Podcast library will no longer hide the title of the library over the cover image (cover image has been updated to gray background until they figure out another image to use, as per stakeholder request.)

# Additional Notes:
branch is LIBTD-2431

# Interested parties
@yinlinchen 

(:star:) Required fields
