### PR TITLE
Fix display of featured items

### DIFF
--- a/src/css/FeaturedItems.scss
+++ b/src/css/FeaturedItems.scss
@@ -16,7 +16,7 @@
 
 .featured-items-wrapper .card-img-top {
   width: 100%;
-  height: 12rem;
+  height: 192px;
   object-fit: cover;
 }
 

--- a/src/css/RelatedItems.scss
+++ b/src/css/RelatedItems.scss
@@ -15,7 +15,7 @@
 
 .related-items-wrapper .card-img-top {
   width: 100%;
-  height: 12rem;
+  height: 192px;
   object-fit: cover;
 }
 

--- a/src/pages/home/FeaturedItem.js
+++ b/src/pages/home/FeaturedItem.js
@@ -24,6 +24,9 @@ class FeaturedItem extends Component {
           role="group"
           aria-roledescription="slide"
           aria-label={`${this.props.position} of ${this.props.length}`}
+          style={
+            this.props.tile.active ? { display: "block" } : { display: "none" }
+          }
         >
           <a href={this.props.tile.link}>
             <div className="card">

--- a/src/pages/home/FeaturedItems.js
+++ b/src/pages/home/FeaturedItems.js
@@ -11,15 +11,26 @@ class FeaturedItems extends Component {
       endIndex: 4,
       multiplier: 4
     };
-    this.handleClick = this.handleClick.bind(this);
   }
 
-  handleClick(start, end) {
+  handleClick = group => {
+    let start = (group - 1) * this.state.multiplier;
+    let end = start + this.state.multiplier;
     this.setState({
       startIndex: start,
       endIndex: end
     });
-  }
+  };
+
+  displayItems = items => {
+    items.forEach(item => (item.active = false));
+    let end =
+      this.state.endIndex < items.length ? this.state.endIndex : items.length;
+    for (let i = this.state.startIndex; i < end; i++) {
+      items[i].active = true;
+    }
+    return items;
+  };
 
   setValues = () => {
     if (window.innerWidth >= 768) {
@@ -50,38 +61,32 @@ class FeaturedItems extends Component {
 
   render() {
     if (this.props.featuredItems && this.props.featuredItems.length > 0) {
-      const tiles = this.props.featuredItems
-        .slice(this.state.startIndex, this.state.endIndex)
-        .map((item, index) => {
-          return (
-            <FeaturedItem
-              key={index}
-              tile={item}
-              position={this.state.startIndex + index + 1}
-              length={this.props.featuredItems.length}
-            />
-          );
-        });
+      let items = this.displayItems([...this.props.featuredItems]);
+      const tiles = items.map((item, index) => {
+        return (
+          <FeaturedItem
+            key={item.src}
+            tile={item}
+            position={this.state.startIndex + index + 1}
+            length={this.props.featuredItems.length}
+          />
+        );
+      });
 
       const Controls = () => {
         let controls = [];
         let count = Math.ceil(
           this.props.featuredItems.length / this.state.multiplier
         );
-        for (let i = count; i > 0; i--) {
+        for (let i = 1; i <= count; i++) {
           controls.push(
             <button
               key={i}
-              aria-label={`Slide group ${count - i + 1}`}
-              onClick={() =>
-                this.handleClick(
-                  (count - i) * this.state.multiplier,
-                  (count - i) * this.state.multiplier + this.state.multiplier
-                )
-              }
+              aria-label={`Slide group ${i}`}
+              onClick={() => this.handleClick(i)}
               type="button"
               aria-disabled={
-                this.state.startIndex === (count - i) * this.state.multiplier
+                this.state.startIndex === (i - 1) * this.state.multiplier
                   ? true
                   : false
               }
@@ -89,7 +94,7 @@ class FeaturedItems extends Component {
             >
               <span
                 className={
-                  this.state.startIndex === (count - i) * this.state.multiplier
+                  this.state.startIndex === (i - 1) * this.state.multiplier
                     ? "dot dot-active"
                     : "dot"
                 }


### PR DESCRIPTION
**JIRA Ticket**: (link) (:star:)
https://webapps.es.vt.edu/jira/browse/LIBTD-2391

# What does this Pull Request do? (:star:)
Fixes display issue with featured items. After clicking on a panel with less than 4 items, the next panel would not show all the items that it was supposed to (i.e. on Demo site, click on dot for last panel, then click on dot for either of the other two panels and only one item would show eventhough those panels should show 4 items)

# What's the changes? (:star:)
Changes the featured items component to display items based on adding an "active" property to items rather than by slicing the array.
FeaturedItems.scss & RelatedItems.scss - unrelated fixe for scaling when user changes browser settings to enlarge text.
FeaturedItem.js - adds conditional style
FeaturedItems.js - simplifies some code and adds function to add/update "active" property.

# How should this be tested?
In the demo site, the same items should be displayed each time the corresponding dot is clicked, no matter what order they are clicked in. Also this should be true at different screen sizes.

# Additional Notes:
Branch is LIBTD-2391

# Interested parties
@yinlinchen 

(:star:) Required fields
