### PR TITLE
clear out values for homepage media section in admin. Only render med…

### DIFF
--- a/cypress/integration/admin_media_section_config.spec.js
+++ b/cypress/integration/admin_media_section_config.spec.js
@@ -1,5 +1,9 @@
 const USERNAME = "devtest";
 const PASSWORD = Cypress.env("password");
+let linkText;
+let mediaEmbedText;
+let titleText;
+let textText;
 
 describe("Displays and updates media section configurations", () => {
   beforeEach(() => {
@@ -36,10 +40,27 @@ describe("Displays and updates media section configurations", () => {
       cy.get("input[value='view']")
         .parent()
         .click();
-      cy.get("span.link-value", { timeout: 2000 }).should("not.be.empty").should("be.visible");
-      cy.get("span.media-embed-value").should("not.be.empty").should("be.visible");
-      cy.get("span.title-value").should("not.be.empty").should("be.visible");
-      cy.get("span.text-value").should("not.be.empty").should("be.visible");
+      
+      cy.get('span.link-value', { timeout: 2000 }).should(($link) => {
+        linkText = $link.text()
+        expect($link).to.not.be.empty
+        expect($link).to.be.visible
+      });
+      cy.get('span.media-embed-value', { timeout: 2000 }).should(($mediaEmbed) => {
+        mediaEmbedText = $mediaEmbed.text()
+        expect($mediaEmbed).to.not.be.empty
+        expect($mediaEmbed).to.be.visible
+      });
+      cy.get('span.title-value', { timeout: 2000 }).should(($title) => {
+        titleText = $title.text()
+        expect($title).to.not.be.empty
+        expect($title).to.be.visible
+      });
+      cy.get('span.text-value', { timeout: 2000 }).should(($text) => {
+        textText = $text.text()
+        expect($text).to.not.be.empty
+        expect($text).to.be.visible
+      });
     });
   });
     
@@ -69,6 +90,44 @@ describe("Displays and updates media section configurations", () => {
         .type(title);
       cy.get("button.submit").contains("Update Config").click();
       cy.contains(title, { timeout: 2000 }).should("be.visible");
+    });
+  });
+
+  describe("Doesn't render media section if no values present", () => {
+    it("Clears values and doesn't render section", () => {
+      cy.get("input[value='edit']").parent().click();
+      cy.get("#clear-values").click();
+      cy.get("button.submit").contains("Update Config").click();
+
+      cy.visit("/");
+      cy.get("div.media-section-wrapper", { timeout: 2000 }).should('not.exist');
+      cy.visit("/siteAdmin");
+    });
+  });
+
+  describe("Renders media section if values present", () => {
+    it("Adds values back and renders section", () => {
+      cy.get("input[value='edit']")
+        .parent()
+        .click();
+      cy.get("input[name='link']", { timeout: 2000 })
+        .clear()
+        .type(linkText);
+      cy.get("textarea[name='mediaEmbed']", { timeout: 2000 })
+        .clear()
+        .type(mediaEmbedText);
+      cy.get("input[name='title']", { timeout: 2000 })
+        .clear()
+        .type(titleText);
+      cy.get("input[name='text']", { timeout: 2000 })
+        .clear()
+        .type(textText);
+      cy.get("button.submit").contains("Update Config").click();
+
+
+      cy.visit("/");
+      cy.get("div.media-section-wrapper", { timeout: 2000 }).should("be.visible");
+      cy.visit("/siteAdmin");
     });
   });
 

--- a/src/css/adminForms.scss
+++ b/src/css/adminForms.scss
@@ -108,3 +108,9 @@ div.checkbox-inline {
     margin-top: 6px;
   }
 }
+
+#clear-values {
+  text-align: right;
+  color: var(--hokieMaroon);
+  cursor: pointer;
+}

--- a/src/pages/admin/MediaSectionForm.js
+++ b/src/pages/admin/MediaSectionForm.js
@@ -103,11 +103,18 @@ class MediaSectionForm extends Component {
     this.setState({ viewState: value });
   };
 
+  clearValues = event => {
+    event.preventDefault();
+    this.setState({
+      formState: initialFormState
+    });
+  };
+
   editForm = () => {
     return (
       <div>
         <h2>{`Edit Homepage Media Section Top with SiteId: ${process.env.REACT_APP_REP_TYPE.toLowerCase()}`}</h2>
-        <Form>
+        <Form id="homepage-media-form">
           <section className="homepage-media-section">
             <h3>Homepage Media Section</h3>
             <Form.Input
@@ -139,6 +146,9 @@ class MediaSectionForm extends Component {
               onChange={this.updateInputValue}
             />
           </section>
+          <div id="clear-values" onClick={this.clearValues}>
+            Clear values
+          </div>
           <button className="submit" onClick={this.handleSubmit}>
             Update Config
           </button>

--- a/src/pages/home/MultimediaSection.js
+++ b/src/pages/home/MultimediaSection.js
@@ -3,8 +3,17 @@ import React, { Component } from "react";
 import "../../css/MultimediaSection.scss";
 
 class MultimediaSection extends Component {
+  hasMediaSection() {
+    return !!(
+      this.props.mediaSection.link &&
+      this.props.mediaSection.mediaEmbed &&
+      this.props.mediaSection.title &&
+      this.props.mediaSection.text
+    );
+  }
+
   render() {
-    if (this.props.mediaSection) {
+    if (this.hasMediaSection()) {
       return (
         <div
           className="row media-section-wrapper"


### PR DESCRIPTION
**Provide link to delete media section attributes. Only render media section if attributes are present**
* * *

**JIRA Ticket**: (https://webapps.es.vt.edu/jira/browse/LIBTD-2514) (:star:)

* Other Relevant Links (Meeting note, project page, related pull requests, etc.)

# What does this Pull Request do? (:star:)
Provide link to delete media section attributes. Only render media section if attributes are present

# What's the changes? (:star:)
* Provide link to delete media section attributes. 
* Only render media section if attributes are present

# How should this be tested?
* Visit "Homepage Media Section" on /siteAdmin page. 
* In the Edit form check the "Clear All Values" link and then click Submit button
* Visit the homepage and check that the Media section does NOT render
* Visit "Homepage Media Section" on /siteAdmin page again.
* Add the values back into the form and Submit
* Visit the homepage again and check that the Media section does render.

# Additional Notes:
* branch: `LIBTD-2514`

# Interested parties
@yinlinchen 

(:star:) Required fields
