### PR TITLE
Add links back and forth between siteAdmin and podcastDeposit

### DIFF
--- a/src/css/adminForms.scss
+++ b/src/css/adminForms.scss
@@ -114,3 +114,8 @@ div.checkbox-inline {
   color: var(--hokieMaroon);
   cursor: pointer;
 }
+
+.siteAdmin-return-link {
+  display: inline-block;
+  margin: 10px 0 15px 0;
+}

--- a/src/pages/admin/PodcastDeposit.js
+++ b/src/pages/admin/PodcastDeposit.js
@@ -1,6 +1,7 @@
 import React, { Component } from "react";
 import { AmplifySignOut, withAuthenticator } from "@aws-amplify/ui-react";
 import { Form } from "semantic-ui-react";
+import { Link } from "react-router-dom";
 import { updatedDiff } from "deep-object-diff";
 import { API, Auth, Storage } from "aws-amplify";
 import { getPodcastCollections, mintNOID } from "../../lib/fetchTools";
@@ -407,6 +408,9 @@ class PodcastDeposit extends Component {
       content = (
         <div>
           <div className="col-lg-9 col-sm-12 admin-content">
+            <Link className="siteAdmin-return-link" to={"/siteAdmin"}>
+              Return to Site Admin Page
+            </Link>
             <Form>
               <Form.Group inline>
                 <label>Current mode:</label>

--- a/src/pages/admin/SiteAdmin.js
+++ b/src/pages/admin/SiteAdmin.js
@@ -65,26 +65,6 @@ class SiteAdmin extends Component {
     this.setState({ form: form });
   };
 
-  getForm() {
-    const formProps = {
-      site: this.state.site,
-      updateSite: this.updateSiteHandler
-    };
-    const forms = {
-      site: <SiteForm />,
-      contentUpload: <ContentUpload />,
-      sitePages: <SitePagesForm />,
-      homepage: <HomepageForm {...formProps} />,
-      searchPage: <SearchPageForm />,
-      browseCollections: <BrowseCollectionsForm {...formProps} />,
-      displayedAttributes: <DisplayedAttributesForm />,
-      mediaSection: <MediaSectionForm />,
-      updateArchive: <IdentifierForm type="archive" />,
-      collectionForm: <IdentifierForm type="collection" />
-    };
-    return forms[this.state.form];
-  }
-
   getForm = () => {
     const formProps = {
       site: this.state.site,
@@ -258,6 +238,11 @@ class SiteAdmin extends Component {
                 New / Update Collection
               </Link>
             </li>
+            {this.state.site && this.state.site.siteId === "podcasts" && (
+              <li>
+                <Link to={"/podcastDeposit"}>Add Podcast Episode</Link>
+              </li>
+            )}
           </ul>
           <AmplifySignOut />
         </div>


### PR DESCRIPTION
**Add links back and forth between siteAdmin and podcastDeposit.**
* * *

**JIRA Ticket**: (https://webapps.es.vt.edu/jira/browse/LIBTD-2532) (:star:)

* Other Relevant Links (Meeting note, project page, related pull requests, etc.)

# What does this Pull Request do? (:star:)
Add links back and forth between siteAdmin and podcastDeposit.

# How should this be tested?
* Launch podcast site and check that link to `/podcastDeposit` page is present and works
* Launch any other site (IAWA/SWVA) and check that link to `/podcastDeposit` is not present

# Additional Notes:
* branch: `LIBTD-2532`

# Interested parties
@yinlinchen 

(:star:) Required fields
