### PR TITLE
Switch item and metadata sections for collections

### DIFF
--- a/src/components/CollectionMetadataSection.js
+++ b/src/components/CollectionMetadataSection.js
@@ -1,0 +1,168 @@
+import React, { Component } from "react";
+import SubCollectionsLoader from "../pages/collections/SubCollectionsLoader";
+import { RenderItemsDetailed, addNewlineInDesc } from "../lib/MetadataRenderer";
+
+import "../css/CollectionsShowPage.scss";
+
+const TRUNCATION_LENGTH = 600;
+
+class CollectionMetadataSection extends Component {
+  constructor(props) {
+    super(props);
+    this.state = {
+      collection: null,
+      collectionCustomKey: "",
+      languages: null,
+      descriptionTruncated: true,
+      subDescriptionTruncated: true,
+      description: "",
+      title: "",
+      thumbnail_path: "",
+      creator: "",
+      updatedAt: "",
+      titleList: []
+    };
+    this.onMoreLessClick = this.onMoreLessClick.bind(this);
+  }
+
+  updateSubCollections(component, collection, subCollections) {
+    collection.subCollection_total =
+      subCollections != null ? subCollections.length : 0;
+    component.setCollectionState(collection);
+  }
+
+  setCollectionState(collection) {
+    this.setState({
+      collection: collection
+    });
+  }
+
+  subCollectionDescription() {
+    let descriptionSection = <></>;
+    let descriptionText = this.props.collection.description;
+
+    if (descriptionText && this.state.subDescriptionTruncated) {
+      descriptionText = descriptionText.substr(0, TRUNCATION_LENGTH);
+    }
+    if (this.props.collection.parent_collection && descriptionText) {
+      descriptionSection = (
+        <div className="collection-detail-description">
+          <div className="collection-detail-key">Description</div>
+          <div
+            className={`collection-detail-value description ${
+              this.state.subDescriptionTruncated ? "trunc" : "full"
+            }`}
+          >
+            {addNewlineInDesc(descriptionText)}
+            {this.moreLessButtons(descriptionText, "metadata")}
+          </div>
+        </div>
+      );
+    }
+    return descriptionSection;
+  }
+
+  moreLessButtons(text, section) {
+    let moreLess = <></>;
+    if (text && text.length >= TRUNCATION_LENGTH) {
+      moreLess = (
+        <span>
+          <button
+            onClick={e => this.onMoreLessClick(section, e)}
+            className="more"
+            type="button"
+            aria-controls="collection-description"
+            aria-expanded="false"
+          >
+            . . .[more]
+          </button>
+          <button
+            onClick={e => this.onMoreLessClick(section, e)}
+            className="less"
+            type="button"
+            aria-controls="collection-description"
+            aria-expanded="true"
+          >
+            . . .[less]
+          </button>
+        </span>
+      );
+    }
+    return moreLess;
+  }
+
+  onMoreLessClick(section, e) {
+    e.preventDefault();
+    let key = "descriptionTruncated";
+    if (section === "metadata") {
+      key = "subDescriptionTruncated";
+    }
+    let truncated = true;
+    if (this.state[key]) {
+      truncated = false;
+    }
+    let stateObj = {};
+    stateObj[key] = truncated;
+    this.setState(stateObj, function() {
+      this.render();
+    });
+  }
+
+  render() {
+    if (this.props.languages && this.props.collection) {
+      return (
+        <div className="container">
+          <div className="mid-content-row row">
+            <div
+              className="col-12 col-lg-8 details-section"
+              role="region"
+              aria-labelledby="collection-details-section-header"
+            >
+              <h2
+                className="details-section-header"
+                id="collection-details-section-header"
+              >
+                {this.props.metadataTitle}
+              </h2>
+
+              <div className="details-section-content-grid">
+                {this.props.subCollectionDescription}
+                <table aria-label="Collection Metadata">
+                  <tbody>
+                    <RenderItemsDetailed
+                      keyArray={
+                        JSON.parse(this.props.site.displayedAttributes)[
+                          "collection"
+                        ]
+                      }
+                      item={this.props.collection}
+                      languages={this.props.languages}
+                      collectionCustomKey={this.props.collectionCustomKey}
+                      type="table"
+                      site={this.props.site}
+                    />
+                  </tbody>
+                </table>
+              </div>
+            </div>
+            <div
+              className="col-12 col-lg-4 subcollections-section"
+              role="region"
+              aria-labelledby="collection-subcollections-section"
+            >
+              <SubCollectionsLoader
+                parent={this}
+                collection={this.props.collection}
+                updateSubCollections={this.updateSubCollections}
+              />
+            </div>
+          </div>
+        </div>
+      );
+    } else {
+      return null;
+    }
+  }
+}
+
+export default CollectionMetadataSection;

--- a/src/pages/collections/CollectionsShowPage.js
+++ b/src/pages/collections/CollectionsShowPage.js
@@ -2,14 +2,11 @@ import React, { Component } from "react";
 import { API, graphqlOperation } from "aws-amplify";
 import { searchCollections } from "../../graphql/queries";
 import SiteTitle from "../../components/SiteTitle";
-import SubCollectionsLoader from "./SubCollectionsLoader";
+import CollectionMetadataSection from "../../components/CollectionMetadataSection";
 import CollectionItemsLoader from "./CollectionItemsLoader";
 import Breadcrumbs from "../../components/Breadcrumbs";
 import CollectionTopContent from "../../components/CollectionTopContent";
-import {
-  RenderItemsDetailed,
-  addNewlineInDesc
-} from "../../lib/MetadataRenderer";
+import { addNewlineInDesc } from "../../lib/MetadataRenderer";
 import {
   fetchLanguages,
   getTopLevelParentForCollection
@@ -215,6 +212,44 @@ class CollectionsShowPage extends Component {
     return title;
   }
 
+  collectionMainContent() {
+    const items = (
+      <CollectionItemsLoader
+        key="collection-items-section"
+        parent={this}
+        collection={this.state.collection}
+        updateCollectionArchives={this.updateCollectionArchives.bind(this)}
+      />
+    );
+    const metadata = (
+      <CollectionMetadataSection
+        key="collection-metadata-section"
+        site={this.props.site}
+        languages={this.state.languages}
+        collection={this.state.collection}
+        metadataTitle={this.metadataTitle()}
+        subCollectionDescription={this.subCollectionDescription()}
+        collectionCustomKey={this.state.collectionCustomKey}
+      />
+    );
+
+    const blocks = [];
+    const options = JSON.parse(this.props.site.siteOptions);
+    if (options && options.collectionPageSettings) {
+      if (parseInt(options.collectionPageSettings.itemsPosition) === 0) {
+        blocks.push(items);
+        blocks.push(metadata);
+      } else {
+        blocks.push(metadata);
+        blocks.push(items);
+      }
+    } else {
+      blocks.push(metadata);
+      blocks.push(items);
+    }
+    return <div>{blocks}</div>;
+  }
+
   componentDidUpdate(prevProps) {
     if (this.props !== prevProps) {
       this.getCollection(this.props.customKey);
@@ -252,60 +287,7 @@ class CollectionsShowPage extends Component {
             TRUNCATION_LENGTH={TRUNCATION_LENGTH}
             creator={this.state.creator}
           />
-
-          <div className="container">
-            <div className="mid-content-row row">
-              <div
-                className="col-12 col-lg-8 details-section"
-                role="region"
-                aria-labelledby="collection-details-section-header"
-              >
-                <h2
-                  className="details-section-header"
-                  id="collection-details-section-header"
-                >
-                  {this.metadataTitle()}
-                </h2>
-
-                <div className="details-section-content-grid">
-                  {this.subCollectionDescription()}
-                  <table aria-label="Collection Metadata">
-                    <tbody>
-                      <RenderItemsDetailed
-                        keyArray={
-                          JSON.parse(this.props.site.displayedAttributes)[
-                            "collection"
-                          ]
-                        }
-                        item={this.state.collection}
-                        languages={this.state.languages}
-                        collectionCustomKey={this.state.collectionCustomKey}
-                        type="table"
-                        site={this.props.site}
-                      />
-                    </tbody>
-                  </table>
-                </div>
-              </div>
-              <div
-                className="col-12 col-lg-4 subcollections-section"
-                role="region"
-                aria-labelledby="collection-subcollections-section"
-              >
-                <SubCollectionsLoader
-                  parent={this}
-                  collection={this.state.collection}
-                  updateSubCollections={this.updateSubCollections}
-                />
-              </div>
-            </div>
-          </div>
-
-          <CollectionItemsLoader
-            parent={this}
-            collection={this.state.collection}
-            updateCollectionArchives={this.updateCollectionArchives.bind(this)}
-          />
+          {this.collectionMainContent()}
         </div>
       );
     } else {


### PR DESCRIPTION
**Switch item and metadata sections for collections.**
* * *

**JIRA Ticket**: (https://webapps.es.vt.edu/jira/browse/LIBTD-2541) (:star:)

* Other Relevant Links (Meeting note, project page, related pull requests, etc.)

# What does this Pull Request do? (:star:)
Switch item and metadata sections for collections

# What's the changes? (:star:)
A in-depth description of the changes made by this PR. Technical details and possible side effects.
* Move metadata block into it's own component
* Switch the order of the items block and the metadata block

# How should this be tested?
* Launch the podcast site
* Visit one of the collection pages and check to see that the items block renders before (above) the metadata block

# Additional Notes:
Any additional information that you think would be helpful when reviewing this PR.
* branch: `LIBTD-2541`

# Interested parties
@yinlinchen 

(:star:) Required fields
