### PR TITLE
Customizations for sponsors section

### DIFF
--- a/src/App.js
+++ b/src/App.js
@@ -58,6 +58,12 @@ class App extends Component {
         homepage.staticImage.titleSize
       );
     }
+    if (homepage.sponsorsColor) {
+      document.documentElement.style.setProperty(
+        "--sponsorsColor",
+        homepage.sponsorsColor.replace(/["]+/g, "")
+      );
+    }
   }
 
   setPaginationClick(event) {

--- a/src/css/SiteSponsors.scss
+++ b/src/css/SiteSponsors.scss
@@ -1,6 +1,16 @@
 .home-sponsors-section {
-  background-color: var(--dark-gray);
+  background-color: var(--sponsorsColor);
   padding-bottom: 10px;
+}
+
+.sponsors-solid {
+  border: 0px;
+  background-color: var(--sponsorsColor);
+}
+
+.sponsors-divider {
+  background-color: #ffffff;
+  border-top: solid 5px var(--sponsorsColor);
 }
 
 .home-sponsors-wrapper {

--- a/src/css/colors.scss
+++ b/src/css/colors.scss
@@ -10,4 +10,5 @@
   --themeHighlightColor: #861f41;
 
   --titleFontSize: 40px;
+  --sponsorsColor: "#75787b";
 }

--- a/src/pages/HomePage.js
+++ b/src/pages/HomePage.js
@@ -25,6 +25,7 @@ class HomePage extends Component {
     let staticImage = null;
     let mediaSection = null;
     let sponsors = null;
+    let sponsorsStyle = null;
     let collectionHighlights = null;
     try {
       const homePageInfo = JSON.parse(this.props.site.homePage);
@@ -33,6 +34,7 @@ class HomePage extends Component {
       staticImage = homePageInfo["staticImage"];
       mediaSection = homePageInfo["mediaSection"];
       sponsors = homePageInfo["sponsors"];
+      sponsorsStyle = homePageInfo["sponsorsStyle"];
       collectionHighlights = homePageInfo["collectionHighlights"];
     } catch (error) {
       console.error("Error setting config property");
@@ -64,7 +66,7 @@ class HomePage extends Component {
           </div>
           <FeaturedItems featuredItems={featuredItems} />
           <MultimediaSection mediaSection={mediaSection} />
-          <SiteSponsors sponsors={sponsors} />
+          <SiteSponsors sponsors={sponsors} style={sponsorsStyle} />
           <CollectionHighlights collectionHighlights={collectionHighlights} />
         </div>
       </>

--- a/src/pages/admin/HomepageForm.js
+++ b/src/pages/admin/HomepageForm.js
@@ -19,6 +19,8 @@ const initialFormState = {
   staticImageTitleSize: "",
   staticImageTextStyle: "",
   sponsors: [],
+  sponsorsColor: "",
+  sponsorsStyle: "",
   featuredItems: [],
   collectionHighlights: []
 };
@@ -92,6 +94,8 @@ class HomepageForm extends Component {
           staticImageTitleSize: homepage.staticImage.titleSize || "40px",
           staticImageTextStyle: homepage.staticImage.textStyle || "uppercase",
           sponsors: homepage.sponsors || [],
+          sponsorsColor: homepage.sponsorsColor || "#75787b",
+          sponsorsStyle: homepage.sponsorsStyle || "solid",
           featuredItems: homepage.featuredItems || [],
           collectionHighlights: homepage.collectionHighlights || []
         };
@@ -145,6 +149,8 @@ class HomepageForm extends Component {
     homePage.staticImage.titleSize = this.state.formState.staticImageTitleSize;
     homePage.staticImage.textStyle = this.state.formState.staticImageTextStyle;
     homePage.sponsors = this.state.formState.sponsors;
+    homePage.sponsorsColor = this.state.formState.sponsorsColor;
+    homePage.sponsorsStyle = this.state.formState.sponsorsStyle;
     homePage.featuredItems = this.state.formState.featuredItems;
     homePage.collectionHighlights = this.state.formState.collectionHighlights;
     const initialHomePage = JSON.parse(this.props.site.homePage);
@@ -273,6 +279,44 @@ class HomepageForm extends Component {
           removeItem={this.removeItem}
           site={this.props.site}
         />
+        <Form>
+          <section>
+            <h3>Style Sponsors Section</h3>
+            <div className="form-group">
+              <label htmlFor="sponsorsColor">Background Color</label>
+              <select
+                className="form-control"
+                id="sponsorsColor"
+                name="sponsorsColor"
+                value={this.state.formState.sponsorsColor}
+                placeholder="Choose a color"
+                onChange={this.updateInputValue}
+              >
+                <option value="#861f41">Maroon</option>
+                <option value="#E87722">Orange</option>
+                <option value="#FFFFFF">White</option>
+                <option value="#75787B">Gray</option>
+                <option value="#D7D2CB">Light Gray</option>
+                <option value="#508590">Teal</option>
+                <option value="#CE0058">Pink</option>
+              </select>
+            </div>
+            <div className="form-group">
+              <label htmlFor="sponsorsStyle">Background Style</label>
+              <select
+                className="form-control"
+                id="sponsorsStyle"
+                name="sponsorsStyle"
+                value={this.state.formState.sponsorsStyle}
+                placeholder="Choose a style"
+                onChange={this.updateInputValue}
+              >
+                <option value="solid">Solid Background</option>
+                <option value="divider">Divider Line</option>
+              </select>
+            </div>
+          </section>
+        </Form>
         <CollectionHighlightsForm
           highlightsList={this.state.formState.collectionHighlights}
           updateItemValue={this.updateItemValue}
@@ -326,6 +370,14 @@ class HomepageForm extends Component {
             <h3>Featured Items</h3>
             <FeaturedItems itemList={this.state.formState.featuredItems} />
             <h3>Sponsors</h3>
+            <p>
+              <span className="key">Background Color:</span>{" "}
+              {this.state.formState.sponsorsColor}
+            </p>
+            <p>
+              <span className="key">Background Style:</span>{" "}
+              {this.state.formState.sponsorsStyle}
+            </p>
             <Sponsors sponsorsList={this.state.formState.sponsors} />
             <h3>Collection Highlights</h3>
             <CollectionHighlights

--- a/src/pages/home/SiteSponsors.js
+++ b/src/pages/home/SiteSponsors.js
@@ -31,7 +31,11 @@ class SiteSponsors extends Component {
     ) {
       return (
         <div
-          className="container home-sponsors-section"
+          className={
+            this.props.style
+              ? `container home-sponsors-section sponsors-${this.props.style}`
+              : "container home-sponsors-section"
+          }
           role="region"
           aria-label="Sponsors"
         >


### PR DESCRIPTION
**JIRA Ticket**: (link) (:star:)
https://webapps.es.vt.edu/jira/browse/LIBTD-2538

* Other Relevant Links (Meeting note, project page, related pull requests, etc.)
https://apps.es.vt.edu/confluence/display/LIBTD/2021-10-29+Meeting+notes 

# What does this Pull Request do? (:star:)
Adds customization options for the sponsors section on the homepage. Allows users to change the background color or the section, and choose whether the section will have a solid color background, or just a divider line in the color of their choosing.

# What's the changes? (:star:)
-App.js - adds function to set css variable for background color
-siteSponsors.scss - adds needed css/classes
-colors.scss - adds css variable
-HomePage.js - adds style props
-HomePageForm.js - adds form to set sponsors section background color and style
-siteSponsors.js - adds conditional for class name

# How should this be tested?
In the admin site, choose a color and style for the sponsor section. The changes should be reflected on the homepage.

# Additional Notes:
branch is LIBTD-2538

# Interested parties
@yinlinchen 

(:star:) Required fields
