### PR TITLE
List view for podcast collections

### DIFF
--- a/src/components/CollectionMetadataSection.js
+++ b/src/components/CollectionMetadataSection.js
@@ -111,53 +111,51 @@ class CollectionMetadataSection extends Component {
   render() {
     if (this.props.languages && this.props.collection) {
       return (
-        <div className="container">
-          <div className="mid-content-row row">
-            <div
-              className="col-12 col-lg-8 details-section"
-              role="region"
-              aria-labelledby="collection-details-section-header"
+        <>
+          <div
+            className={`${this.props.sectionsSizes[0]} details-section`}
+            role="region"
+            aria-labelledby="collection-details-section-header"
+          >
+            <h2
+              className="details-section-header"
+              id="collection-details-section-header"
             >
-              <h2
-                className="details-section-header"
-                id="collection-details-section-header"
-              >
-                {this.props.metadataTitle}
-              </h2>
+              {this.props.metadataTitle}
+            </h2>
 
-              <div className="details-section-content-grid">
-                {this.props.subCollectionDescription}
-                <table aria-label="Collection Metadata">
-                  <tbody>
-                    <RenderItemsDetailed
-                      keyArray={
-                        JSON.parse(this.props.site.displayedAttributes)[
-                          "collection"
-                        ]
-                      }
-                      item={this.props.collection}
-                      languages={this.props.languages}
-                      collectionCustomKey={this.props.collectionCustomKey}
-                      type="table"
-                      site={this.props.site}
-                    />
-                  </tbody>
-                </table>
-              </div>
-            </div>
-            <div
-              className="col-12 col-lg-4 subcollections-section"
-              role="region"
-              aria-labelledby="collection-subcollections-section"
-            >
-              <SubCollectionsLoader
-                parent={this}
-                collection={this.props.collection}
-                updateSubCollections={this.updateSubCollections}
-              />
+            <div className="details-section-content-grid">
+              {this.props.subCollectionDescription}
+              <table aria-label="Collection Metadata">
+                <tbody>
+                  <RenderItemsDetailed
+                    keyArray={
+                      JSON.parse(this.props.site.displayedAttributes)[
+                        "collection"
+                      ]
+                    }
+                    item={this.props.collection}
+                    languages={this.props.languages}
+                    collectionCustomKey={this.props.collectionCustomKey}
+                    type="table"
+                    site={this.props.site}
+                  />
+                </tbody>
+              </table>
             </div>
           </div>
-        </div>
+          <div
+            className={`${this.props.sectionsSizes[1]} subcollections-section`}
+            role="region"
+            aria-labelledby="collection-subcollections-section"
+          >
+            <SubCollectionsLoader
+              parent={this}
+              collection={this.props.collection}
+              updateSubCollections={this.updateSubCollections}
+            />
+          </div>
+        </>
       );
     } else {
       return null;

--- a/src/css/CollectionsShowPage.scss
+++ b/src/css/CollectionsShowPage.scss
@@ -73,10 +73,14 @@ span.creator:after {
   display: none;
 }
 
-.mid-content-row {
-  margin: 40px 0;
+.mid-content-row.row {
+  margin: 40px 0px;
   padding: 20px 10px;
   background-color: var(--light-gray);
+}
+.mid-content-row.list-view {
+  background-color: white;
+  padding: 0px;
 }
 
 .mid-content-row a,
@@ -95,13 +99,23 @@ span.creator:after {
   border-bottom: 1px solid var(--dark-gray);
   border-right: none;
 }
+.mid-content-row.list-view .details-section {
+  background-color: var(--light-gray);
+  padding: 20px;
+}
+
 @media only screen and (min-width: 992px) {
   .mid-content-row {
     padding: 20px;
   }
+
   .mid-content-row .details-section {
     border-right: 1px solid var(--dark-gray);
     border-bottom: none;
+  }
+  .mid-content-row.list-view .details-section {
+    border-bottom: 1px solid var(--dark-gray);
+    border-right: none;
   }
 }
 
@@ -133,6 +147,9 @@ span.creator:after {
 .mid-content-row div.details-section-content-grid {
   margin-bottom: 15px;
 }
+.mid-content-row.list-view div.details-section-content-grid {
+  margin-bottom: 0px;
+}
 
 @media only screen and (min-width: 992px) {
   .mid-content-row .details-section-content-grid {
@@ -159,6 +176,10 @@ span.creator:after {
 .mid-content-row div.subcollections-section {
   padding-left: 20px;
   line-height: 1.2em;
+}
+.mid-content-row.list-view div.subcollections-section {
+  padding: 20px;
+  background-color: var(--light-gray);
 }
 
 div.collection-items-grid {
@@ -215,18 +236,23 @@ div.collection-item .item-image img {
   font-weight: 400;
 }
 
-div.collection-items-list-wrapper {
+.mid-content-row div.collection-items-list-wrapper {
   margin-top: 30px;
+}
+.mid-content-row.list-view div.collection-items-list-wrapper {
+  margin-top: 0px;
 }
 .collection-items-list-wrapper h2.collection-items-header {
   font-family: "gineso-condensed", sans-serif;
   font-size: 1.3125rem;
 }
 
-.collection-items-list-wrapper h3.subcollection-header {
+.collection-items-list-wrapper h2.subcollection-header {
   font-family: "gineso-condensed", sans-serif;
   font-size: 1.25rem;
+  font-weight: 400;
 }
+
 .collection-items-list-wrapper .results-text {
   font-family: "gineso-condensed", sans-serif;
 }
@@ -234,4 +260,12 @@ div.collection-items-list-wrapper {
 .collection-items-list-wrapper .subCollectionList a:visited {
   font-family: "gineso-condensed", sans-serif;
   font-size: 1rem;
+}
+
+@media only screen and (min-width: 768px) {
+  .collection-items-list-wrapper .collection-items-list div.collection-img img {
+    width: 150px;
+    height: 108px;
+    object-fit: cover;
+  }
 }

--- a/src/pages/collections/CollectionItemsList.js
+++ b/src/pages/collections/CollectionItemsList.js
@@ -1,6 +1,7 @@
 import React, { Component } from "react";
 import Thumbnail from "../../components/Thumbnail";
-import { arkLinkFormatted } from "../../lib/MetadataRenderer";
+import { NavLink } from "react-router-dom";
+import { RenderItems, arkLinkFormatted } from "../../lib/MetadataRenderer";
 
 import "../../css/CollectionsShowPage.scss";
 
@@ -10,24 +11,52 @@ class CollectionItemsList extends Component {
     if (this.props.items.length) {
       retVal = (
         <div
-          className="collection-items-grid"
+          className={
+            this.props.view === "listView"
+              ? "collection-items-list"
+              : "collection-items-grid"
+          }
           role="group"
           aria-roledescription="Collection items"
         >
-          {this.props.items.map(item => (
-            <div className="collection-item" key={item.identifier}>
-              <div className="collection-item-wrapper">
-                <a href={`/archive/${arkLinkFormatted(item.custom_key)}`}>
-                  <div className="item-image">
-                    <Thumbnail item={item} category="archive" />
+          {this.props.items.map(item => {
+            if (this.props.view === "listView") {
+              return (
+                <div key={item.identifier} className="collection-entry">
+                  <NavLink to={`/archive/${arkLinkFormatted(item.custom_key)}`}>
+                    <div className="collection-img">
+                      <Thumbnail item={item} category="archive" />
+                    </div>
+                    <div className="collection-details">
+                      <h3>{item.title}</h3>
+                      <RenderItems
+                        keyArray={[
+                          { field: "description", label: "Description" }
+                        ]}
+                        item={item}
+                        site={this.props.site}
+                      />
+                    </div>
+                  </NavLink>
+                </div>
+              );
+            } else {
+              return (
+                <div className="collection-item" key={item.identifier}>
+                  <div className="collection-item-wrapper">
+                    <a href={`/archive/${arkLinkFormatted(item.custom_key)}`}>
+                      <div className="item-image">
+                        <Thumbnail item={item} category="archive" />
+                      </div>
+                      <div className="item-info">
+                        <h3>{item.title}</h3>
+                      </div>
+                    </a>
                   </div>
-                  <div className="item-info">
-                    <h3>{item.title}</h3>
-                  </div>
-                </a>
-              </div>
-            </div>
-          ))}
+                </div>
+              );
+            }
+          })}
         </div>
       );
     } else {

--- a/src/pages/collections/CollectionItemsLoader.js
+++ b/src/pages/collections/CollectionItemsLoader.js
@@ -27,6 +27,9 @@ const GetCollectionItems = `query SearchCollectionItems(
       thumbnail_path
       custom_key
       identifier
+      description
+      tags
+      creator
     }
     total
     nextToken
@@ -120,24 +123,26 @@ class CollectionItemsLoader extends Component {
     if (this.state.items !== null && this.state.total > 0) {
       return (
         <div
-          className="collection-items-list-wrapper"
+          className={`collection-items-list-wrapper ${this.props.sectionSize}`}
           role="region"
           aria-labelledby="collection-items-section-header"
         >
-          <div className="mb-3">
+          <div className="row justify-content-between mb-3">
             <h2
-              className="collection-items-header"
+              className="collection-items-header col-auto"
               id="collection-items-section-header"
             >
               Items in Collection ({this.state.total})
             </h2>
-          </div>
-          <div className="form-group">
-            <ResultsNumberDropdown setLimit={this.setLimit.bind(this)} />
+            <div className="col-auto">
+              <ResultsNumberDropdown setLimit={this.setLimit.bind(this)} />
+            </div>
           </div>
           <CollectionItemsList
             items={this.state.items}
             collection={this.props.collection}
+            view={this.props.view}
+            site={this.props.site}
           />
           <div aria-live="polite">
             <Pagination

--- a/src/pages/collections/CollectionsListView.js
+++ b/src/pages/collections/CollectionsListView.js
@@ -1,0 +1,35 @@
+import React, { Component } from "react";
+import CollectionMetadataSection from "../../components/CollectionMetadataSection";
+import CollectionItemsLoader from "./CollectionItemsLoader";
+
+class CollectionsListView extends Component {
+  render() {
+    return (
+      <div className="mid-content-row list-view row">
+        <div className="col-12 col-lg-4 mb-5">
+          <CollectionMetadataSection
+            key="collection-metadata-section"
+            site={this.props.site}
+            languages={this.props.languages}
+            collection={this.props.collection}
+            metadataTitle={this.props.metadataTitle}
+            subCollectionDescription={this.props.subCollectionDescription}
+            collectionCustomKey={this.props.collectionCustomKey}
+            sectionsSizes={["col-12", "col-12"]}
+          />
+        </div>
+        <CollectionItemsLoader
+          key="collection-items-section"
+          parent={this.props.parent}
+          collection={this.props.collection}
+          updateCollectionArchives={this.props.updateCollectionArchives}
+          sectionSize="col-12 col-lg-8"
+          view={this.props.view}
+          site={this.props.site}
+        />
+      </div>
+    );
+  }
+}
+
+export default CollectionsListView;

--- a/src/pages/collections/CollectionsShowPage.js
+++ b/src/pages/collections/CollectionsShowPage.js
@@ -4,6 +4,7 @@ import { searchCollections } from "../../graphql/queries";
 import SiteTitle from "../../components/SiteTitle";
 import CollectionMetadataSection from "../../components/CollectionMetadataSection";
 import CollectionItemsLoader from "./CollectionItemsLoader";
+import CollectionsListView from "./CollectionsListView";
 import Breadcrumbs from "../../components/Breadcrumbs";
 import CollectionTopContent from "../../components/CollectionTopContent";
 import { addNewlineInDesc } from "../../lib/MetadataRenderer";
@@ -219,18 +220,22 @@ class CollectionsShowPage extends Component {
         parent={this}
         collection={this.state.collection}
         updateCollectionArchives={this.updateCollectionArchives.bind(this)}
+        sectionSize="no-size"
       />
     );
     const metadata = (
-      <CollectionMetadataSection
-        key="collection-metadata-section"
-        site={this.props.site}
-        languages={this.state.languages}
-        collection={this.state.collection}
-        metadataTitle={this.metadataTitle()}
-        subCollectionDescription={this.subCollectionDescription()}
-        collectionCustomKey={this.state.collectionCustomKey}
-      />
+      <div className="mid-content-row row">
+        <CollectionMetadataSection
+          key="collection-metadata-section"
+          site={this.props.site}
+          languages={this.state.languages}
+          collection={this.state.collection}
+          metadataTitle={this.metadataTitle()}
+          subCollectionDescription={this.subCollectionDescription()}
+          collectionCustomKey={this.state.collectionCustomKey}
+          sectionsSizes={["col-12 col-lg-8", "col-12 col-lg-4"]}
+        />
+      </div>
     );
 
     const blocks = [];
@@ -262,6 +267,10 @@ class CollectionsShowPage extends Component {
   }
 
   render() {
+    const options = JSON.parse(this.props.site.siteOptions);
+    const viewOption = options.collectionPageSettings
+      ? options.collectionPageSettings.viewOption
+      : null;
     if (this.state.languages && this.state.collection) {
       return (
         <div>
@@ -287,7 +296,23 @@ class CollectionsShowPage extends Component {
             TRUNCATION_LENGTH={TRUNCATION_LENGTH}
             creator={this.state.creator}
           />
-          {this.collectionMainContent()}
+          {viewOption === "listView" ? (
+            <CollectionsListView
+              site={this.props.site}
+              languages={this.state.languages}
+              collection={this.state.collection}
+              metadataTitle={this.metadataTitle()}
+              subCollectionDescription={this.subCollectionDescription()}
+              collectionCustomKey={this.state.collectionCustomKey}
+              parent={this}
+              updateCollectionArchives={this.updateCollectionArchives.bind(
+                this
+              )}
+              view={viewOption}
+            />
+          ) : (
+            this.collectionMainContent()
+          )}
         </div>
       );
     } else {

--- a/src/pages/collections/SubCollectionsLoader.js
+++ b/src/pages/collections/SubCollectionsLoader.js
@@ -158,12 +158,12 @@ class SubCollectionsLoader extends Component {
       return_value = (
         <div className="collection-items-list-wrapper">
           <div className="mb-3">
-            <h3
+            <h2
               className="subcollection-header"
               id="collection-subcollections-section"
             >
               Collection Organization
-            </h3>
+            </h2>
           </div>
 
           <TreeView


### PR DESCRIPTION
**JIRA Ticket**: (link) (:star:)
https://webapps.es.vt.edu/jira/browse/LIBTD-2547

* Other Relevant Links (Meeting note, project page, related pull requests, etc.)

# What does this Pull Request do? (:star:)
Creates alternate layout for collection pages which displays collection items in a list rather than a grid

# What's the changes? (:star:)
-CollectionMetadataSection.js - adjusts layout in a few ways
-CollectionsShowPage.scss - adds css to style list-view class, plus other adjustments
-CollectionItemsList.js - adds conditional and the code for list options versus default grid option
-CollectionItemsLoader.js - adjusts layout and adds required props
-CollectionsShowPage.js - adjusts layout and adds conditional to trigger collection list view component
-CollectionsListView.js - new component which creates the list view
-SubCollectionsLoader.js - just changes the heading to the proper level

# How should this be tested?
-start the podcasts library and navigate into any collection. The items should appear in the list view. layout should respond appropriately to different screen sizes.
-start any other library. The items should appear in an image grid view as usual.

# Additional Notes:
branch is LIBTD-2547

# Interested parties
Tag (@ mention) interested parties
@yinlinchen 
@whunter 

(:star:) Required fields
