### PR TITLE
Add key to collection metadata section to fix console warning

### DIFF
--- a/src/pages/collections/CollectionsShowPage.js
+++ b/src/pages/collections/CollectionsShowPage.js
@@ -224,7 +224,7 @@ class CollectionsShowPage extends Component {
       />
     );
     const metadata = (
-      <div className="mid-content-row row">
+      <div className="mid-content-row row" key="collection-metadata-row">
         <CollectionMetadataSection
           key="collection-metadata-section"
           site={this.props.site}


### PR DESCRIPTION
**Add key to collection metadata section to fix console warning.**
* * *

**JIRA Ticket**: (link) (:star:)

* Other Relevant Links (Meeting note, project page, related pull requests, etc.)

# What does this Pull Request do? (:star:)
Add key to collection metadata section to fix console warning

# What's the changes? (:star:)
Add key to collection metadata section to fix console warning

# How should this be tested?
* Visit any collection show page and open the browser dev console
* Check that there are no warnings for missing keys. `Warning: Each child in a list should have a unique "key" prop.`

# Additional Notes:
* branch: `fix_collection_key`

# Interested parties
@yinlinchen 

(:star:) Required fields
