### PR TITLE
Add rich schema function and show in the about page

### DIFF
--- a/cypress/integration/richSchemaTools.spec.js
+++ b/cypress/integration/richSchemaTools.spec.js
@@ -1,0 +1,11 @@
+import { buildHeaderSchema } from '../../src/lib/richSchemaTools';
+
+describe("buildHeaderSchema: Create rich schema", () => {
+  it('rich schema', () => {
+    const contnt = buildHeaderSchema("Article", "AboutPage", "localhost", "title"); 
+    expect(contnt).to.include('"@type": "Article"');
+    expect(contnt).to.include('mainEntityOfPage": {\n        "@type": "AboutPage"');
+    expect(contnt).to.include('"@id": "localhost"');
+    expect(contnt).to.include('"headline": "title"');
+  });
+});

--- a/src/lib/richSchemaTools.js
+++ b/src/lib/richSchemaTools.js
@@ -1,0 +1,12 @@
+export function buildHeaderSchema(parenttype, type, id, title) {
+  const scriptContent = `{ 
+      "@context": "https://schema.org",
+      "@type": "${parenttype}",
+      "mainEntityOfPage": {
+        "@type": "${type}",
+        "@id": "${id}"
+      },
+      "headline": "${title}"
+    }`;
+  return scriptContent;
+}

--- a/src/pages/AboutPage.js
+++ b/src/pages/AboutPage.js
@@ -1,7 +1,9 @@
 import React, { Component } from "react";
+import { Helmet } from "react-helmet";
 import SiteTitle from "../components/SiteTitle";
 import ContactSection from "../components/ContactSection";
 import { getFile } from "../lib/fetchTools";
+import { buildHeaderSchema } from "../lib/richSchemaTools";
 
 import "../css/AboutPage.scss";
 
@@ -20,11 +22,27 @@ class AboutPage extends Component {
   }
 
   render() {
+    const title = "About ".concat(this.props.site.siteTitle);
+
     return (
       <div className="row about-page-wrapper">
         <div className="col-12 about-heading">
           <SiteTitle siteTitle={this.props.site.siteTitle} pageTitle="About" />
-          <h1 id="about-heading">About {this.props.site.siteTitle}</h1>
+          <h1 id="about-heading">{title}</h1>
+          <Helmet
+            script={[
+              { type: "text/javascript" },
+              {
+                type: "application/ld+json",
+                innerHTML: buildHeaderSchema(
+                  "Article",
+                  "AboutPage",
+                  window.location.href,
+                  title
+                )
+              }
+            ]}
+          ></Helmet>
         </div>
         <div className="col-md-8" role="region" aria-labelledby="about-heading">
           <div


### PR DESCRIPTION
**JIRA Ticket**: ([link](https://webapps.es.vt.edu/jira/browse/LIBTD-2560)) (:star:)

# What does this Pull Request do? (:star:)
1. A new function `buildHeaderSchema` in `richSchemaTools.js` to create JSON-LD using schema.org. 
2. Make About page to have this rich schema that supports rich results. 

# How should this be tested?
1. See preview in amplify console
2. Use the link generated by amplify and test if it is working on the Google rich results test tool: https://search.google.com/test/rich-results
3. A test case for `buildHeaderSchema` is included in the Cypress

# Interested parties
Tag (@waingram @whunter ) interested parties

(:star:) Required fields
