### PR TITLE
Allows podcast collection items to be sorted asc or desc

### DIFF
--- a/src/components/SortOrderDropdown.js
+++ b/src/components/SortOrderDropdown.js
@@ -4,10 +4,6 @@ import { Dropdown } from "semantic-ui-react";
 import "semantic-ui-css/semantic.min.css";
 
 class SortOrderDropdown extends Component {
-  constructor(props) {
-    super(props);
-  }
-
   setSortOrder = (event, result) => {
     if (typeof this.props.setSortOrder === "function") {
       this.props.setSortOrder(event, result);

--- a/src/components/SortOrderDropdown.js
+++ b/src/components/SortOrderDropdown.js
@@ -1,0 +1,45 @@
+import React, { Component } from "react";
+import { Dropdown } from "semantic-ui-react";
+
+import "semantic-ui-css/semantic.min.css";
+
+class SortOrderDropdown extends Component {
+  constructor(props) {
+    super(props);
+  }
+
+  setSortOrder = (event, result) => {
+    if (typeof this.props.setSortOrder === "function") {
+      this.props.setSortOrder(event, result);
+    }
+  };
+
+  render() {
+    const options = [
+      {
+        key: "asc",
+        text: "Oldest to Newest",
+        value: "asc"
+      },
+      {
+        key: "desc",
+        text: "Newest to Oldest",
+        value: "desc"
+      }
+    ];
+    const placeholder = "Sort order";
+    return (
+      <Dropdown
+        placeholder={placeholder}
+        compact
+        selection
+        options={options}
+        onChange={this.setSortOrder}
+        aria-label="Sort order dropdown"
+        aria-haspopup="listbox"
+      />
+    );
+  }
+}
+
+export default SortOrderDropdown;

--- a/src/pages/collections/CollectionsShowPage.js
+++ b/src/pages/collections/CollectionsShowPage.js
@@ -221,6 +221,7 @@ class CollectionsShowPage extends Component {
         collection={this.state.collection}
         updateCollectionArchives={this.updateCollectionArchives.bind(this)}
         sectionSize="no-size"
+        site={this.props.site}
       />
     );
     const metadata = (


### PR DESCRIPTION
**Allows podcast collection items to be sorted asc or desc.**
* * *

**JIRA Ticket**: (https://webapps.es.vt.edu/jira/browse/LIBTD-2567) (:star:)

* Other Relevant Links (Meeting note, project page, related pull requests, etc.)

# What does this Pull Request do? (:star:)
Allows podcast collection items to be sorted asc or desc.

# What's the changes? (:star:)
* Add dropdown component to control sort order
* On change set sort order state in parent component
* Run query for items using sort_order state variable

# How should this be tested?
* Visit a Podcast site collection page
* Make sure that the "Sort Order" dropdown is visible
* Toggle the values in the dropdown and check that the order of items changes accordingly

# Additional Notes:
* branch: `LIBTD-2567`

# Interested parties
@yinlinchen 

(:star:) Required fields
