### PR TITLE
Add feed links to collection page

### DIFF
--- a/cypress/integration/admin_collection_edit.spec.js
+++ b/cypress/integration/admin_collection_edit.spec.js
@@ -43,10 +43,10 @@ describe("admin_collection_edit: Update collection metadata and change it back",
 
   it("Update single-valued metadata", () => {
     cy.get("input[value='edit']").parent().click();
-    cy.get("textarea[name='title']")
-      .clear().type("New Title");
+    cy.get("textarea[name='title']").invoke('val', '');
+    cy.get("textarea[name='title']").type("New Title");
     cy.contains("Update Collection Metadata").click();
-    cy.contains("Title: New Title").should('be.visible');
+    cy.contains("New Title").should('be.visible');
   })
 
   it("Change single-valued metadata back", () => {

--- a/src/components/CollectionTopContent.js
+++ b/src/components/CollectionTopContent.js
@@ -62,7 +62,7 @@ class CollectionTopContent extends Component {
     });
   }
 
-  createRss(key, rssUrl, className, imageUrl, alt) {
+  createRssHtml(key, rssUrl, className, imageUrl, alt) {
     const rssLinks = `<li key="${key}">
           <a href="${rssUrl}" target="_blank" rel="noopener noreferrer" className="${className}">
             <img
@@ -82,7 +82,7 @@ class CollectionTopContent extends Component {
         return (
           <div
             dangerouslySetInnerHTML={{
-              __html: this.createRss(
+              __html: this.createRssHtml(
                 "amazon",
                 l,
                 "border-square",
@@ -96,7 +96,7 @@ class CollectionTopContent extends Component {
         return (
           <div
             dangerouslySetInnerHTML={{
-              __html: this.createRss(
+              __html: this.createRssHtml(
                 "apple",
                 l,
                 "border-square",
@@ -110,7 +110,7 @@ class CollectionTopContent extends Component {
         return (
           <div
             dangerouslySetInnerHTML={{
-              __html: this.createRss(
+              __html: this.createRssHtml(
                 "google",
                 l,
                 "border-curved",
@@ -124,7 +124,7 @@ class CollectionTopContent extends Component {
         return (
           <div
             dangerouslySetInnerHTML={{
-              __html: this.createRss(
+              __html: this.createRssHtml(
                 "spotify",
                 l,
                 "badge-outline",
@@ -138,7 +138,7 @@ class CollectionTopContent extends Component {
         return (
           <div
             dangerouslySetInnerHTML={{
-              __html: this.createRss(
+              __html: this.createRssHtml(
                 "stitcher",
                 l,
                 "border-square",
@@ -152,7 +152,7 @@ class CollectionTopContent extends Component {
         return (
           <div
             dangerouslySetInnerHTML={{
-              __html: this.createRss(
+              __html: this.createRssHtml(
                 "breaker",
                 l,
                 "badge-outline",
@@ -166,7 +166,7 @@ class CollectionTopContent extends Component {
         return (
           <div
             dangerouslySetInnerHTML={{
-              __html: this.createRss(
+              __html: this.createRssHtml(
                 "radio_public",
                 l,
                 "border-square",
@@ -180,7 +180,7 @@ class CollectionTopContent extends Component {
         return (
           <div
             dangerouslySetInnerHTML={{
-              __html: this.createRss(
+              __html: this.createRssHtml(
                 "pocket_casts",
                 l,
                 "border-square",
@@ -194,7 +194,7 @@ class CollectionTopContent extends Component {
         return (
           <div
             dangerouslySetInnerHTML={{
-              __html: this.createRss(
+              __html: this.createRssHtml(
                 "tunein",
                 l,
                 "border-square",
@@ -208,7 +208,7 @@ class CollectionTopContent extends Component {
         return (
           <div
             dangerouslySetInnerHTML={{
-              __html: this.createRss(
+              __html: this.createRssHtml(
                 "podchaser",
                 l,
                 "border-square",
@@ -220,35 +220,31 @@ class CollectionTopContent extends Component {
         );
       } else if (l.indexOf("podbean.com") >= 0) {
         return (
-          <li key="podbean">
-            <a
-              href={l}
-              target="_blank"
-              rel="noopener noreferrer"
-              className="border-square"
-            >
-              <img
-                src="https://static.lib.vt.edu/vtdlp/images/podbean.png"
-                alt="Listen on Podbean"
-              />
-            </a>
-          </li>
+          <div
+            dangerouslySetInnerHTML={{
+              __html: this.createRssHtml(
+                "podbean",
+                l,
+                "border-square",
+                "https://static.lib.vt.edu/vtdlp/images/podbean.png",
+                "Listen on Podbean"
+              )
+            }}
+          />
         );
       } else if (l.indexOf("castbox.fm") >= 0) {
         return (
-          <li key="castbox">
-            <a
-              href={l}
-              target="_blank"
-              rel="noopener noreferrer"
-              className="border-square"
-            >
-              <img
-                src="https://static.lib.vt.edu/vtdlp/images/Castbox.svg"
-                alt="Listen on Castbox"
-              />
-            </a>
-          </li>
+          <div
+            dangerouslySetInnerHTML={{
+              __html: this.createRssHtml(
+                "castbox",
+                l,
+                "border-square",
+                "https://static.lib.vt.edu/vtdlp/images/Castbox.svg",
+                "Listen on Castbox"
+              )
+            }}
+          />
         );
       } else {
         console.log(`Error: ${l}`);

--- a/src/components/CollectionTopContent.js
+++ b/src/components/CollectionTopContent.js
@@ -62,169 +62,161 @@ class CollectionTopContent extends Component {
     });
   }
 
+  createRss(key, rssUrl, className, imageUrl, alt) {
+    const rssLinks = `<li key="${key}">
+          <a href="${rssUrl}" target="_blank" rel="noopener noreferrer" className="${className}">
+            <img
+              src="${imageUrl}"
+              alt="${alt}"
+            />
+          </a>
+        </li>`;
+
+    return rssLinks;
+  }
+
   getFeeds = () => {
     let links = this.props.collectionOptions.podcast_links.map(link => {
       let l = link.toLowerCase();
       if (l.indexOf("amazon.com") >= 0) {
         return (
-          <li key="amazon">
-            <a
-              href={l}
-              target="_blank"
-              rel="noopener noreferrer"
-              className="border-square"
-            >
-              <img
-                src="https://static.lib.vt.edu/vtdlp/images/Amazon.png"
-                alt="Listen on Amazon Music"
-              />
-            </a>
-          </li>
+          <div
+            dangerouslySetInnerHTML={{
+              __html: this.createRss(
+                "amazon",
+                l,
+                "border-square",
+                "https://static.lib.vt.edu/vtdlp/images/Amazon.png",
+                "Listen on Amazon Music"
+              )
+            }}
+          />
         );
       } else if (l.indexOf("apple.com") >= 0) {
         return (
-          <li key="apple">
-            <a
-              href={l}
-              target="_blank"
-              rel="noopener noreferrer"
-              className="border-square"
-            >
-              <img
-                src="https://static.lib.vt.edu/vtdlp/images/Apple.svg"
-                alt="Listen on Apple Music"
-              />
-            </a>
-          </li>
+          <div
+            dangerouslySetInnerHTML={{
+              __html: this.createRss(
+                "apple",
+                l,
+                "border-square",
+                "https://static.lib.vt.edu/vtdlp/images/Apple.svg",
+                "Listen on Apple Music"
+              )
+            }}
+          />
         );
       } else if (l.indexOf("goo.gl") >= 0) {
         return (
-          <li key="google">
-            <a
-              href={l}
-              target="_blank"
-              rel="noopener noreferrer"
-              className="border-curved"
-            >
-              <img
-                src="https://static.lib.vt.edu/vtdlp/images/Google.svg"
-                alt="Listen on Google Podcasts"
-              />
-            </a>
-          </li>
+          <div
+            dangerouslySetInnerHTML={{
+              __html: this.createRss(
+                "google",
+                l,
+                "border-curved",
+                "https://static.lib.vt.edu/vtdlp/images/Google.svg",
+                "Listen on Google Podcasts"
+              )
+            }}
+          />
         );
       } else if (l.indexOf("spotify.com") >= 0) {
         return (
-          <li key="spotify" className="badge-outline">
-            <a
-              href={l}
-              target="_blank"
-              rel="noopener noreferrer"
-              className="border-curved"
-            >
-              <img
-                className="p-1"
-                src="https://static.lib.vt.edu/vtdlp/images/Spotify.png"
-                alt="Listen on Spotify"
-              />
-            </a>
-          </li>
+          <div
+            dangerouslySetInnerHTML={{
+              __html: this.createRss(
+                "spotify",
+                l,
+                "badge-outline",
+                "https://static.lib.vt.edu/vtdlp/images/Spotify.png",
+                "Listen on Spotify"
+              )
+            }}
+          />
         );
       } else if (l.indexOf("stitcher.com") >= 0) {
         return (
-          <li key="stitcher">
-            <a
-              href={l}
-              target="_blank"
-              rel="noopener noreferrer"
-              className="border-square"
-            >
-              <img
-                src="https://static.lib.vt.edu/vtdlp/images/Stitcher.png"
-                alt="Listen on Stitcher"
-              />
-            </a>
-          </li>
+          <div
+            dangerouslySetInnerHTML={{
+              __html: this.createRss(
+                "stitcher",
+                l,
+                "border-square",
+                "https://static.lib.vt.edu/vtdlp/images/Stitcher.png",
+                "Listen on Stitcher"
+              )
+            }}
+          />
         );
       } else if (l.indexOf("breaker.audio") >= 0) {
         return (
-          <li key="breaker" className="badge-outline">
-            <a
-              href={l}
-              target="_blank"
-              rel="noopener noreferrer"
-              className="border-curved"
-            >
-              <img
-                src="https://static.lib.vt.edu/vtdlp/images/breaker--white.svg"
-                alt="Listen on Breaker"
-              />
-            </a>
-          </li>
+          <div
+            dangerouslySetInnerHTML={{
+              __html: this.createRss(
+                "breaker",
+                l,
+                "badge-outline",
+                "https://static.lib.vt.edu/vtdlp/images/breaker--white.svg",
+                "Listen on Breaker"
+              )
+            }}
+          />
         );
       } else if (l.indexOf("radiopublic.com") >= 0) {
         return (
-          <li key="radio_public">
-            <a
-              href={l}
-              target="_blank"
-              rel="noopener noreferrer"
-              className="border-square"
-            >
-              <img
-                src="https://static.lib.vt.edu/vtdlp/images/radiopublic-white.png"
-                alt="Listen on Radio Public"
-              />
-            </a>
-          </li>
+          <div
+            dangerouslySetInnerHTML={{
+              __html: this.createRss(
+                "radio_public",
+                l,
+                "border-square",
+                "https://static.lib.vt.edu/vtdlp/images/radiopublic-white.png",
+                "Listen on Radio Public"
+              )
+            }}
+          />
         );
       } else if (l.indexOf("pocketcasts.com") >= 0) {
         return (
-          <li key="pocket_casts">
-            <a
-              href={l}
-              target="_blank"
-              rel="noopener noreferrer"
-              className="border-square"
-            >
-              <img
-                src="https://static.lib.vt.edu/vtdlp/images/pocketcasts.png"
-                alt="Listen on Pocket Casts"
-              />
-            </a>
-          </li>
+          <div
+            dangerouslySetInnerHTML={{
+              __html: this.createRss(
+                "pocket_casts",
+                l,
+                "border-square",
+                "https://static.lib.vt.edu/vtdlp/images/radiopublic-white.png",
+                "Listen on Pocket Casts"
+              )
+            }}
+          />
         );
       } else if (l.indexOf("tunein.com") >= 0) {
         return (
-          <li key="tunein">
-            <a
-              href={l}
-              target="_blank"
-              rel="noopener noreferrer"
-              className="border-square"
-            >
-              <img
-                src="https://static.lib.vt.edu/vtdlp/images/tunein.png"
-                alt="Listen on Tune In"
-              />
-            </a>
-          </li>
+          <div
+            dangerouslySetInnerHTML={{
+              __html: this.createRss(
+                "tunein",
+                l,
+                "border-square",
+                "https://static.lib.vt.edu/vtdlp/images/tunein.png",
+                "Listen on Tune In"
+              )
+            }}
+          />
         );
       } else if (l.indexOf("podchaser.com") >= 0) {
         return (
-          <li key="podchaser">
-            <a
-              href={l}
-              target="_blank"
-              rel="noopener noreferrer"
-              className="border-square"
-            >
-              <img
-                src="https://static.lib.vt.edu/vtdlp/images/podchaser.png"
-                alt="Listen on Podchaser"
-              />
-            </a>
-          </li>
+          <div
+            dangerouslySetInnerHTML={{
+              __html: this.createRss(
+                "podchaser",
+                l,
+                "border-square",
+                "https://static.lib.vt.edu/vtdlp/images/podchaser.png",
+                "Listen on Pod Chaser"
+              )
+            }}
+          />
         );
       } else if (l.indexOf("podbean.com") >= 0) {
         return (

--- a/src/components/CollectionTopContent.js
+++ b/src/components/CollectionTopContent.js
@@ -1,6 +1,6 @@
 import React, { Component } from "react";
 import { addNewlineInDesc } from "../lib/MetadataRenderer";
-
+import { Storage } from "aws-amplify";
 import { getFile } from "../lib/fetchTools";
 import "../css/CollectionsShowPage.scss";
 
@@ -9,7 +9,8 @@ class CollectionTopContent extends Component {
     super(props);
     this.state = {
       descriptionTruncated: true,
-      collectionThumbnail: ""
+      collectionThumbnail: "",
+      rss: ""
     };
   }
 
@@ -61,6 +62,224 @@ class CollectionTopContent extends Component {
     });
   }
 
+  getFeeds = () => {
+    let links = this.props.collectionOptions.podcast_links.map(link => {
+      let l = link.toLowerCase();
+      if (l.indexOf("amazon.com") >= 0) {
+        return (
+          <li key="amazon">
+            <a
+              href={l}
+              target="_blank"
+              rel="noopener noreferrer"
+              className="border-square"
+            >
+              <img
+                src="https://static.lib.vt.edu/vtdlp/images/Amazon.png"
+                alt="Listen on Amazon Music"
+              />
+            </a>
+          </li>
+        );
+      } else if (l.indexOf("apple.com") >= 0) {
+        return (
+          <li key="apple">
+            <a
+              href={l}
+              target="_blank"
+              rel="noopener noreferrer"
+              className="border-square"
+            >
+              <img
+                src="https://static.lib.vt.edu/vtdlp/images/Apple.svg"
+                alt="Listen on Apple Music"
+              />
+            </a>
+          </li>
+        );
+      } else if (l.indexOf("goo.gl") >= 0) {
+        return (
+          <li key="google">
+            <a
+              href={l}
+              target="_blank"
+              rel="noopener noreferrer"
+              className="border-curved"
+            >
+              <img
+                src="https://static.lib.vt.edu/vtdlp/images/Google.svg"
+                alt="Listen on Google Podcasts"
+              />
+            </a>
+          </li>
+        );
+      } else if (l.indexOf("spotify.com") >= 0) {
+        return (
+          <li key="spotify" className="badge-outline">
+            <a
+              href={l}
+              target="_blank"
+              rel="noopener noreferrer"
+              className="border-curved"
+            >
+              <img
+                className="p-1"
+                src="https://static.lib.vt.edu/vtdlp/images/Spotify.png"
+                alt="Listen on Spotify"
+              />
+            </a>
+          </li>
+        );
+      } else if (l.indexOf("stitcher.com") >= 0) {
+        return (
+          <li key="stitcher">
+            <a
+              href={l}
+              target="_blank"
+              rel="noopener noreferrer"
+              className="border-square"
+            >
+              <img
+                src="https://static.lib.vt.edu/vtdlp/images/Stitcher.png"
+                alt="Listen on Stitcher"
+              />
+            </a>
+          </li>
+        );
+      } else if (l.indexOf("breaker.audio") >= 0) {
+        return (
+          <li key="breaker" className="badge-outline">
+            <a
+              href={l}
+              target="_blank"
+              rel="noopener noreferrer"
+              className="border-curved"
+            >
+              <img
+                src="https://static.lib.vt.edu/vtdlp/images/breaker--white.svg"
+                alt="Listen on Breaker"
+              />
+            </a>
+          </li>
+        );
+      } else if (l.indexOf("radiopublic.com") >= 0) {
+        return (
+          <li key="radio_public">
+            <a
+              href={l}
+              target="_blank"
+              rel="noopener noreferrer"
+              className="border-square"
+            >
+              <img
+                src="https://static.lib.vt.edu/vtdlp/images/radiopublic-white.png"
+                alt="Listen on Radio Public"
+              />
+            </a>
+          </li>
+        );
+      } else if (l.indexOf("pocketcasts.com") >= 0) {
+        return (
+          <li key="pocket_casts">
+            <a
+              href={l}
+              target="_blank"
+              rel="noopener noreferrer"
+              className="border-square"
+            >
+              <img
+                src="https://static.lib.vt.edu/vtdlp/images/pocketcasts.png"
+                alt="Listen on Pocket Casts"
+              />
+            </a>
+          </li>
+        );
+      } else if (l.indexOf("tunein.com") >= 0) {
+        return (
+          <li key="tunein">
+            <a
+              href={l}
+              target="_blank"
+              rel="noopener noreferrer"
+              className="border-square"
+            >
+              <img
+                src="https://static.lib.vt.edu/vtdlp/images/tunein.png"
+                alt="Listen on Tune In"
+              />
+            </a>
+          </li>
+        );
+      } else if (l.indexOf("podchaser.com") >= 0) {
+        return (
+          <li key="podchaser">
+            <a
+              href={l}
+              target="_blank"
+              rel="noopener noreferrer"
+              className="border-square"
+            >
+              <img
+                src="https://static.lib.vt.edu/vtdlp/images/podchaser.png"
+                alt="Listen on Podchaser"
+              />
+            </a>
+          </li>
+        );
+      } else if (l.indexOf("podbean.com") >= 0) {
+        return (
+          <li key="podbean">
+            <a
+              href={l}
+              target="_blank"
+              rel="noopener noreferrer"
+              className="border-square"
+            >
+              <img
+                src="https://static.lib.vt.edu/vtdlp/images/podbean.png"
+                alt="Listen on Podbean"
+              />
+            </a>
+          </li>
+        );
+      } else if (l.indexOf("castbox.fm") >= 0) {
+        return (
+          <li key="castbox">
+            <a
+              href={l}
+              target="_blank"
+              rel="noopener noreferrer"
+              className="border-square"
+            >
+              <img
+                src="https://static.lib.vt.edu/vtdlp/images/Castbox.svg"
+                alt="Listen on Castbox"
+              />
+            </a>
+          </li>
+        );
+      } else {
+        console.log(`Error: ${l}`);
+        return <></>;
+      }
+    });
+
+    return links;
+  };
+
+  getRSS = () => {
+    if (this.state.rss) {
+      return (
+        <li key="rss" className="custom-badge">
+          <a href={this.state.rss} target="_blank" rel="noopener noreferrer">
+            <i className="fas fa-rss"></i>
+            RSS Link
+          </a>
+        </li>
+      );
+    }
+  };
+
   creatorDates(creator) {
     if (creator) {
       return <span className="creator">Created by: {creator}</span>;
@@ -79,6 +298,15 @@ class CollectionTopContent extends Component {
     if (this.props.collectionImg) {
       getFile(this.props.collectionImg, "image", this, "collectionThumbnail");
     }
+
+    if (this.props.siteId === "podcasts") {
+      let rss_link = `https://${
+        Storage._config.AWSS3.bucket
+      }.s3.amazonaws.com/public/sitecontent/text/${process.env.REACT_APP_REP_TYPE.toLowerCase()}/rss/${
+        this.props.customKey
+      }.rss`;
+      getFile(rss_link, "text", this, "rss");
+    }
   }
 
   render() {
@@ -91,7 +319,7 @@ class CollectionTopContent extends Component {
         <div className="collection-img-col col-sm-4">
           <img src={this.state.collectionThumbnail} alt="" />
         </div>
-        <div className="collection-details-col col-sm-8">
+        <div className="collection-details-col col-md-8">
           <h1 className="collection-title" id="collection-page-title">
             {this.props.collectionTitle}
           </h1>
@@ -113,6 +341,20 @@ class CollectionTopContent extends Component {
               {this.moreLessButtons(this.props.description)}
             </div>
           </div>
+          {this.props.siteId === "podcasts" ? (
+            <ul className="feed-links">
+              {this.props.collectionOptions &&
+              this.props.collectionOptions.podcast_links &&
+              this.props.collectionOptions.podcast_links.length ? (
+                this.getFeeds()
+              ) : (
+                <></>
+              )}
+              {this.getRSS()}
+            </ul>
+          ) : (
+            <></>
+          )}
         </div>
       </div>
     );

--- a/src/components/PodcastMediaElement.js
+++ b/src/components/PodcastMediaElement.js
@@ -2,7 +2,7 @@ import React, { Component } from "react";
 import flvjs from "flv.js";
 import hlsjs from "hls.js";
 import "mediaelement";
-
+import { FontAwesomeIcon } from "@fortawesome/react-fontawesome";
 import "mediaelement/build/mediaelementplayer.min.css";
 import "mediaelement/build/mediaelement-flash-video.swf";
 import { asyncGetFile } from "../lib/fetchTools";
@@ -88,8 +88,15 @@ export default class PodcastMediaElement extends Component {
   transcriptButton() {
     if (this.props.transcript) {
       return (
-        <button type="button" className="transcript-button">
-          <i class="fas fa-file-alt" aria-label="Transcript"></i>
+        <button
+          type="button"
+          className="transcript-button"
+          aria-label="Transcript"
+        >
+          <span className="fa-layers fa-fw fa-3x">
+            <FontAwesomeIcon icon="circle" color="var(--themeHighlightColor)" />
+            <FontAwesomeIcon icon="file" inverse transform="shrink-7" />
+          </span>
         </button>
       );
     }
@@ -148,7 +155,13 @@ export default class PodcastMediaElement extends Component {
               download
               aria-label="Download episode"
             >
-              <i className="fa fa-download"></i>
+              <span className="fa-layers fa-fw fa-3x">
+                <FontAwesomeIcon
+                  icon="circle"
+                  color="var(--themeHighlightColor)"
+                />
+                <FontAwesomeIcon icon="download" inverse transform="shrink-7" />
+              </span>
             </a>
           </div>
         </div>

--- a/src/css/CollectionsShowPage.scss
+++ b/src/css/CollectionsShowPage.scss
@@ -11,7 +11,7 @@ div.nav-row {
   display: none;
 }
 
-@media only screen and (min-width: 576px) {
+@media only screen and (min-width: 768px) {
   .top-content-row .collection-img-col {
     display: block;
     height: 300px;
@@ -73,8 +73,95 @@ span.creator:after {
   display: none;
 }
 
+.feed-links {
+  display: flex;
+  flex-wrap: wrap;
+  list-style: none;
+  margin-top: 15px;
+  margin-bottom: 0px;
+}
+
+@media only screen and (min-width: 992px) {
+  .feed-links {
+    border-bottom: 1px solid rgb(117, 120, 123);
+    padding-bottom: 40px;
+  }
+}
+
+.feed-links li {
+  margin: 0 10px 10px 0;
+  height: 40px;
+  display: flex;
+}
+
+.feed-links li.custom-badge {
+  border: 1px solid var(--dark-gray);
+  border-radius: 10px;
+}
+
+.feed-links img {
+  height: 100%;
+  width: auto;
+}
+
+.feed-links .custom-badge img {
+  margin-right: 10px;
+}
+
+.feed-links .custom-badge .fa-rss {
+  margin-right: 10px;
+}
+
+.feed-links li.badge-outline {
+  border: 1px solid var(--dark-gray);
+  border-radius: 10px;
+}
+
+.feed-links a {
+  height: 100%;
+  width: 100%;
+}
+
+.feed-links a.border-square {
+  border-radius: 6px;
+}
+
+.feed-links a.border-curved {
+  border-radius: 10px;
+}
+
+.feed-links a:hover,
+.feed-link a:active,
+.feed-links a:focus {
+  box-shadow: 0px 0px 3px 1px rgba(0, 0, 0, 0.4);
+}
+
+.feed-links .custom-badge a {
+  font-family: "gineso-condensed", sans-serif;
+  font-size: 1.125rem;
+  font-weight: 500;
+  padding: 5px 10px;
+  text-transform: uppercase;
+  text-decoration: none;
+  display: flex;
+  align-items: center;
+  border-radius: 6px;
+}
+
+.feed-links .custom-badge a,
+.feed-links .custom-badge a:visited {
+  color: var(--hokieMaroon);
+}
+
+.feed-links .custom-badge a:hover,
+.feed-links .custom-badge a:focus,
+.feed-links .custom-badge a:active {
+  text-decoration: none;
+}
+
 .mid-content-row.row {
-  margin: 40px 0px;
+  margin-top: 40px;
+  margin-bottom: 40px;
   padding: 20px 10px;
   background-color: var(--light-gray);
 }
@@ -267,5 +354,9 @@ div.collection-item .item-image img {
     width: 150px;
     height: 108px;
     object-fit: cover;
+  }
+
+  .collection-items-list-wrapper .collection-items-list div.collection-details {
+    width: calc(100% - 182px);
   }
 }

--- a/src/css/podcastMediaElement.scss
+++ b/src/css/podcastMediaElement.scss
@@ -28,17 +28,11 @@
   width: 100%;
   display: flex;
   flex-wrap: wrap;
-  align-items: center;
+  align-items: flex-end;
 }
 
 .media-player {
   width: 100%;
-}
-
-@media (min-width: 576px) {
-  .media-player {
-    width: calc(100% - 130px);
-  }
 }
 
 @media (min-width: 768px) {
@@ -58,28 +52,14 @@
 @media (min-width: 576px) {
   .media-buttons {
     margin-top: 0px;
-    width: 110px;
-    text-align: left;
-    line-height: 1px;
   }
-}
-
-.download-link {
-  color: white !important;
-  font-size: 1.4em;
-  background-color: var(--themeHighlightColor);
-  padding: 5px 10px 5px 10px;
-  border-radius: 25px;
 }
 
 .transcript-button {
   border: none;
   background-color: var(--light-gray);
-  font-size: 2.3em;
-  color: var(--themeHighlightColor);
   margin-right: 10px;
-  padding: 0px 10px 0px 10px;
-  vertical-align: middle;
+  padding: 0px;
 }
 
 div.feed-button-wrapper {

--- a/src/lib/MetadataRenderer.js
+++ b/src/lib/MetadataRenderer.js
@@ -153,7 +153,11 @@ function textFormat(item, attr, languages, collectionCustomKey, site) {
       `<a href="${redirect}/${item.custom_key}">${redirect}/${item.custom_key}</a>`
     );
   } else if (attr === "description") {
-    return <MoreLink category={category} item={item} />;
+    if (item["description"].length <= 120) {
+      return item["description"];
+    } else {
+      return <MoreLink category={category} item={item} />;
+    }
   } else if (attr === "display_date" || attr === "start_date") {
     return dateFormatted(item);
   } else if (attr === "size") {

--- a/src/pages/admin/ArchiveCollectionEdit/CollectionForm.js
+++ b/src/pages/admin/ArchiveCollectionEdit/CollectionForm.js
@@ -129,12 +129,14 @@ const CollectionForm = React.memo(props => {
       setCollection(newCollection);
       setCollectionId(null);
     }
-
-    if (identifier && !newCollection) {
-      loadItem();
-    } else if (newCollection) {
-      setNewCollection();
+    async function init() {
+      if (identifier && !newCollection) {
+        await loadItem();
+      } else if (newCollection) {
+        setNewCollection();
+      }
     }
+    init();
   }, [identifier, newCollection, siteContext.site.siteId, viewState]);
 
   const isRequiredField = attribute => {
@@ -226,9 +228,6 @@ const CollectionForm = React.memo(props => {
       collection.collection_category = siteContext.site.groups[0];
     }
 
-    setValidForm(true);
-    setViewState("view");
-
     const collectionInfo = {
       id: collectionId,
       ...collection
@@ -307,6 +306,9 @@ const CollectionForm = React.memo(props => {
     };
 
     siteContext.updateSite(eventInfo);
+
+    setValidForm(true);
+    setViewState("view");
   };
 
   const changeValueHandler = (event, field, valueIdx) => {

--- a/src/pages/admin/ArchiveCollectionEdit/CollectionForm.js
+++ b/src/pages/admin/ArchiveCollectionEdit/CollectionForm.js
@@ -86,7 +86,7 @@ const CollectionForm = React.memo(props => {
 
         const inOptions = key => {
           let retVal = null;
-          if (item.collectionOptions[key] !== null) {
+          if (item.collectionOptions && item.collectionOptions[key] !== null) {
             const options = JSON.parse(item.collectionOptions);
             retVal = options[key];
           }

--- a/src/pages/admin/ArchiveCollectionEdit/CollectionForm.js
+++ b/src/pages/admin/ArchiveCollectionEdit/CollectionForm.js
@@ -205,7 +205,6 @@ const CollectionForm = React.memo(props => {
       collection.ownerinfo = JSON.stringify(collection.ownerinfo);
     }
 
-    // Options
     const options = collection.collectionOptions || {};
     for (const i in collectionOptions) {
       const key = collectionOptions[i];

--- a/src/pages/collections/CollectionsShowPage.js
+++ b/src/pages/collections/CollectionsShowPage.js
@@ -340,6 +340,11 @@ class CollectionsShowPage extends Component {
             description={this.state.description}
             TRUNCATION_LENGTH={TRUNCATION_LENGTH}
             creator={this.state.creator}
+            customKey={this.props.customKey}
+            collectionOptions={JSON.parse(
+              this.state.collection.collectionOptions
+            )}
+            siteId={this.props.site.siteId}
           />
           {viewOption === "listView" ? (
             <CollectionsListView


### PR DESCRIPTION
**JIRA Ticket**: (link) (:star:)
https://webapps.es.vt.edu/jira/browse/LIBTD-2548 

* Other Relevant Links (Meeting note, project page, related pull requests, etc.)

# What does this Pull Request do? (:star:)
It adds form fields title podcast_link to the New/Update Collection area of the admin site. Users can enter links to podcast shows on various aggregators. The badge for that show will automatically populate on the collection's page in the DLP. The component supports 12 aggregators currently used by the stakeholder: Apple, Google, Spotify, Amazon, Stitcher, Breaker, Radio Public, Pocket Casts, TuneIn, Podchaser, Podbean, and Castbox.

# What's the changes? (:star:)
-src/components/CollectionTopContent.js - adds all the logic needed to generate the correct badge from podcast_links and a link to the RSS feed.
-PodcastMediaElement.js - includes unrelated fix for the download and transcript button styles on podcast item pages
-CollectionsShowPage.scss - all the css for the feed links.
-podcastMediaElement.scss - updates css for unrelated fix for download and transcript buttons
-MetadataRenderer.js - unrelated fix to only show the "...more" link if description is longer than 120 characters.
-ArchiveCollectionEdit/CollectionForm.js - updates the form to allow entering and display of podcast links.

# How should this be tested?
In the podcast admin site, edit a show such as mfangle, then enter a podcast link, such as https://amaazon.com. The link will show automatically on the mfangle collection page. The link can be deleted. The RSS link will always show on podcast collection pages. No feed links or rss link will show on collection pages for other libraries.

# Additional Notes:
branch is LIBTD-2548

# Interested parties
@yinlinchen 

(:star:) Required fields
