### PR TITLE
adds rssLink to collectionOptions field in dynamoDb for podcasts

### DIFF
--- a/src/components/CollectionTopContent.js
+++ b/src/components/CollectionTopContent.js
@@ -276,6 +276,27 @@ class CollectionTopContent extends Component {
     }
   }
 
+  async getWebFeed() {
+    if (this.props.siteId === "podcasts") {
+      let webFeed = null;
+      if (
+        this.props.collectionOptions &&
+        this.props.collectionOptions.webFeed
+      ) {
+        webFeed = this.props.collectionOptions.webFeed;
+      } else {
+        webFeed = `https://${
+          Storage._config.AWSS3.bucket
+        }.s3.amazonaws.com/public/sitecontent/text/${process.env.REACT_APP_REP_TYPE.toLowerCase()}/rss/${
+          this.props.customKey
+        }.rss`;
+      }
+      if (webFeed) {
+        getFile(webFeed, "text", this, "rss");
+      }
+    }
+  }
+
   componentDidUpdate(prevProps) {
     if (this.props.collectionImg !== prevProps.collectionImg) {
       getFile(this.props.collectionImg, "image", this, "collectionThumbnail");
@@ -286,15 +307,7 @@ class CollectionTopContent extends Component {
     if (this.props.collectionImg) {
       getFile(this.props.collectionImg, "image", this, "collectionThumbnail");
     }
-
-    if (this.props.siteId === "podcasts") {
-      let rss_link = `https://${
-        Storage._config.AWSS3.bucket
-      }.s3.amazonaws.com/public/sitecontent/text/${process.env.REACT_APP_REP_TYPE.toLowerCase()}/rss/${
-        this.props.customKey
-      }.rss`;
-      getFile(rss_link, "text", this, "rss");
-    }
+    this.getWebFeed();
   }
 
   render() {

--- a/src/pages/admin/ArchiveCollectionEdit/CollectionForm.js
+++ b/src/pages/admin/ArchiveCollectionEdit/CollectionForm.js
@@ -205,15 +205,6 @@ const CollectionForm = React.memo(props => {
       collection.ownerinfo = JSON.stringify(collection.ownerinfo);
     }
 
-    const options = collection.collectionOptions || {};
-    for (const i in collectionOptions) {
-      const key = collectionOptions[i];
-      options[key] = collection[key];
-      collection.collectionOptions = JSON.stringify(options);
-
-      delete collection[key];
-    }
-
     if (newCollection) {
       const id = uuidv4();
       const noid = await mintNOID();
@@ -225,6 +216,31 @@ const CollectionForm = React.memo(props => {
       collection.heirarchy_path = [id.toString()];
       collection.custom_key = customKey;
       collection.collection_category = siteContext.site.groups[0];
+    }
+    let webFeed = null;
+    if (siteContext.site.siteId === "podcasts") {
+      const custom_key = newCollection
+        ? collection.custom_key
+        : fullCollection.custom_key;
+      const rssDirectory = `https://${Storage._config.AWSS3.bucket}.s3.${
+        Storage._config.AWSS3.region
+      }.amazonaws.com/public/sitecontent/text/${process.env.REACT_APP_REP_TYPE.toLowerCase()}/rss`;
+      webFeed = `${rssDirectory}/${custom_key.replace("ark:/53696/", "")}.rss`;
+    }
+
+    let options = collection.collectionOptions || {};
+    if (typeof options === "string") {
+      options = JSON.parse(options);
+    }
+    if (webFeed) {
+      options.webFeed = webFeed;
+    }
+    for (const i in collectionOptions) {
+      const key = collectionOptions[i];
+      options[key] = collection[key];
+      collection.collectionOptions = JSON.stringify(options);
+
+      delete collection[key];
     }
 
     const collectionInfo = {


### PR DESCRIPTION
**adds rssLink to collectionOptions field in dynamoDb for podcasts.**
* * *

**JIRA Ticket**: (https://webapps.es.vt.edu/jira/browse/LIBTD-2571) (:star:)

* Other Relevant Links (Meeting note, project page, related pull requests, etc.)

# What does this Pull Request do? (:star:)
adds rssLink to collectionOptions field in dynamoDb for podcasts and uses that when rendering links on the collection show page

# What's the changes? (:star:)
* Generates link to rss feed document in s3 when collection is created
* Saves link in `collectionsOptions` object field in Dynamo record
* Uses value saved in collection record for rendering "RSS Feed" link in collection show page

# How should this be tested?
* Create a podcast collection
* Create a podcast episode in the newly created collection (RSS feed document is not generated until at least one episode is created)
* Visit collection show page and check that "RSS Feed" link is present

# Additional Notes:
* branch: `LIBTD-2571`

# Interested parties
@yinlinchen 

(:star:) Required fields
