### PR TITLE
Fixes podcast feed buttons

### DIFF
--- a/src/components/CollectionTopContent.js
+++ b/src/components/CollectionTopContent.js
@@ -186,7 +186,7 @@ class CollectionTopContent extends Component {
               __html: this.createRssHtml(
                 link,
                 "border-square",
-                "https://static.lib.vt.edu/vtdlp/images/radiopublic-white.png",
+                "https://static.lib.vt.edu/vtdlp/images/pocketcasts.png",
                 "Listen on Pocket Casts"
               )
             }}

--- a/src/css/CollectionsShowPage.scss
+++ b/src/css/CollectionsShowPage.scss
@@ -118,9 +118,10 @@ span.creator:after {
   margin-right: 10px;
 }
 
-.feed-links li.badge-outline {
+.feed-links .badge-outline {
   border: 1px solid var(--dark-gray);
   border-radius: 10px;
+  padding: 2px;
 }
 
 .feed-links a {


### PR DESCRIPTION
# What does this Pull Request do? (:star:)
Fixes classes that weren't being applied to RSS badges. Corrects image for pocket casts.

# What's the changes? (:star:)
-Image file src
-class style

# How should this be tested?
On the collection page for MFAngle, the border activated on hover should match the shape of the badge. Pocket casts badge should now appear.

# Interested parties
@yinlinchen 

(:star:) Required fields
