### PR TITLE
Adds collapsible sections

### DIFF
--- a/src/components/CollectionMetadataSection.js
+++ b/src/components/CollectionMetadataSection.js
@@ -118,7 +118,11 @@ class CollectionMetadataSection extends Component {
             aria-labelledby="collection-details-section-header"
           >
             <h2
-              className="details-section-header"
+              className={
+                this.props.viewOption === "listView"
+                  ? "d-none"
+                  : "details-section-header"
+              }
               id="collection-details-section-header"
             >
               {this.props.metadataTitle}

--- a/src/components/SocialButtons.js
+++ b/src/components/SocialButtons.js
@@ -59,7 +59,9 @@ class SocialButtons extends Component {
       this.props.buttons.socialMedia.length ? (
       <div className="social-buttons-section">
         <div className="line"></div>
-        <h3>Share</h3>
+        <h3 className={this.props.viewOption === "listView" ? "d-none" : ""}>
+          Share
+        </h3>
         {this.getButtons()}
       </div>
     ) : (

--- a/src/css/CollectionsShowPage.scss
+++ b/src/css/CollectionsShowPage.scss
@@ -223,6 +223,23 @@ span.creator:after {
   font-size: 1.3125rem;
 }
 
+.mid-content-row div.accordion.ui .title {
+  font-family: "gineso-condensed", sans-serif;
+  font-size: 1.3125rem;
+}
+
+.mid-content-row div.accordion.ui {
+  background-color: var(--light-gray);
+}
+
+.mid-content-row div.accordion.ui div.details-section {
+  padding: 0px 20px 20px 20px;
+}
+
+.mid-content-row div.accordion.ui div.details-section-content-grid {
+  margin-top: 0px;
+}
+
 .mid-content-row .details-section-content-grid {
   margin-top: 20px;
 }

--- a/src/css/SocialButtons.scss
+++ b/src/css/SocialButtons.scss
@@ -1,7 +1,13 @@
 .social-buttons-wrapper-box {
   background-color: var(--light-gray);
-  padding: 10px 20px;
   margin-bottom: 30px;
+}
+
+div.social-buttons-wrapper-box
+  div.accordion.ui
+  div.content
+  .social-buttons-section {
+  padding: 0px 20px 20px 20px;
 }
 
 .social-buttons-wrapper-line .line {

--- a/src/pages/collections/CollectionsListView.js
+++ b/src/pages/collections/CollectionsListView.js
@@ -2,30 +2,88 @@ import React, { Component } from "react";
 import CollectionMetadataSection from "../../components/CollectionMetadataSection";
 import CollectionItemsLoader from "./CollectionItemsLoader";
 import SocialButtons from "../../components/SocialButtons";
+import { Accordion, Icon } from "semantic-ui-react";
 
 class CollectionsListView extends Component {
+  constructor() {
+    super();
+    this.state = {
+      isSocialActive: true,
+      isMetadataActive: true
+    };
+  }
+
+  setValues = () => {
+    if (window.innerWidth < 992) {
+      this.setState({
+        isSocialActive: false,
+        isMetadataActive: false
+      });
+    }
+  };
+
+  componentDidMount() {
+    this.setValues();
+    window.addEventListener("resize", this.setValues);
+  }
+
   render() {
     return (
       <div className="mid-content-row list-view row">
         <div className="col-12 col-lg-4 mb-5">
           <div className="social-buttons-wrapper-box">
-            <SocialButtons
-              buttons={JSON.parse(this.props.site.siteOptions)}
-              url={window.location.href}
-              title={this.props.title}
-              media={this.props.media}
-            />
+            <Accordion>
+              <Accordion.Title
+                active={this.state.isSocialActive}
+                index={0}
+                onClick={() => {
+                  this.setState(prevState => ({
+                    isSocialActive: !prevState.isSocialActive
+                  }));
+                }}
+              >
+                <Icon name="dropdown" />
+                Share
+              </Accordion.Title>
+              <Accordion.Content active={this.state.isSocialActive}>
+                <SocialButtons
+                  buttons={JSON.parse(this.props.site.siteOptions)}
+                  url={window.location.href}
+                  title={this.props.title}
+                  media={this.props.media}
+                  viewOption={this.props.viewOption}
+                />
+              </Accordion.Content>
+            </Accordion>
           </div>
-          <CollectionMetadataSection
-            key="collection-metadata-section"
-            site={this.props.site}
-            languages={this.props.languages}
-            collection={this.props.collection}
-            metadataTitle={this.props.metadataTitle}
-            subCollectionDescription={this.props.subCollectionDescription}
-            collectionCustomKey={this.props.collectionCustomKey}
-            sectionsSizes={["col-12", "col-12"]}
-          />
+          <Accordion>
+            <Accordion.Title
+              active={this.state.isMetadataActive}
+              index={0}
+              onClick={() => {
+                this.setState(prevState => ({
+                  isMetadataActive: !prevState.isMetadataActive
+                }));
+              }}
+              id="collection-details-section-header"
+            >
+              <Icon name="dropdown" />
+              {this.props.metadataTitle}
+            </Accordion.Title>
+            <Accordion.Content active={this.state.isMetadataActive}>
+              <CollectionMetadataSection
+                key="collection-metadata-section"
+                site={this.props.site}
+                languages={this.props.languages}
+                collection={this.props.collection}
+                metadataTitle={this.props.metadataTitle}
+                subCollectionDescription={this.props.subCollectionDescription}
+                collectionCustomKey={this.props.collectionCustomKey}
+                sectionsSizes={["col-12", "col-12"]}
+                viewOption={this.props.viewOption}
+              />
+            </Accordion.Content>
+          </Accordion>
         </div>
         <CollectionItemsLoader
           key="collection-items-section"
@@ -33,7 +91,7 @@ class CollectionsListView extends Component {
           collection={this.props.collection}
           updateCollectionArchives={this.props.updateCollectionArchives}
           sectionSize="col-12 col-lg-8"
-          view={this.props.view}
+          view={this.props.viewOption}
           site={this.props.site}
         />
       </div>

--- a/src/pages/collections/CollectionsShowPage.js
+++ b/src/pages/collections/CollectionsShowPage.js
@@ -358,7 +358,7 @@ class CollectionsShowPage extends Component {
               updateCollectionArchives={this.updateCollectionArchives.bind(
                 this
               )}
-              view={viewOption}
+              viewOption={viewOption}
               title={this.state.title}
               media={this.state.thumbnail_path}
             />


### PR DESCRIPTION
**JIRA Ticket**: (link) (:star:)

* Other Relevant Links (Meeting note, project page, related pull requests, etc.)
* https://webapps.es.vt.edu/jira/browse/LIBTD-2557

# What does this Pull Request do? (:star:)
Adds collapsible sections for social media sharing and collection details UI elements in the list view for collection pages. When the user's screen is full sized, these sections will automatically load as opened, and for smaller screen sizes these sections will automatically load as closed. This saves space in the mobile site and makes it easier to get the collection items. Collection pages that don't use the list view are not changed.

# What's the changes? (:star:)
Adds an accordion element to the collectionListView component and changes necessary CSS.

# How should this be tested?
Go to the collection page for any podcast. The elements should be open at full screen and closed for smaller screens. Collection pages for all other digital libraries should not be affected.

# Additional Notes:
Branch in LIBTD-2557

# Interested parties
@yinlinchen 

(:star:) Required fields
