### PR TITLE
Allows embargos to be attached to Collections

### DIFF
--- a/src/components/FormFields.js
+++ b/src/components/FormFields.js
@@ -73,7 +73,7 @@ const textAreaInput = options => {
 };
 
 const dateInput = options => {
-  const { outerClass, innerClass, label, id, name, onChange } = options;
+  const { outerClass, innerClass, label, id, name, value, onChange } = options;
   return (
     <div className={outerClass} key={id || name}>
       <label htmlFor={id || name}>{label}</label>
@@ -82,7 +82,8 @@ const dateInput = options => {
           type="date"
           id={id || name}
           name={name}
-          onChange={onChange}
+          value={value}
+          onChange={event => onChange(event, id)}
         ></input>
       </div>
     </div>

--- a/src/css/adminForms.scss
+++ b/src/css/adminForms.scss
@@ -123,3 +123,8 @@ div.checkbox-inline {
 select.form-control:not([size]):not([multiple]) {
   height: unset;
 }
+
+p.errorMsg {
+  color: var(--hokieOrange);
+  font-size: 1.1em;
+}

--- a/src/lib/EmbargoTools.js
+++ b/src/lib/EmbargoTools.js
@@ -1,0 +1,43 @@
+import { API, graphqlOperation } from "aws-amplify";
+import * as queries from "../graphql/queries";
+import * as mutations from "../graphql/mutations";
+
+export const validEmbargo = item => {
+  return !!item["embargo_start_date"] || !!item["embargo_end_date"];
+};
+
+export const loadEmbargo = async (itemResponse, setEmbargo) => {
+  if (itemResponse && itemResponse.id) {
+    try {
+      const response = await API.graphql(
+        graphqlOperation(queries.getEmbargo, { id: itemResponse.id })
+      );
+      if (response.data.getEmbargo) {
+        setEmbargo(response.data.getEmbargo);
+        return response.data.getEmbargo;
+      }
+    } catch (error) {
+      console.error("Error fetching embargo", error);
+    }
+  }
+};
+
+export const createEmbargoRecord = async (item, fullItem, embargo, type) => {
+  let embargoMutation = mutations.createEmbargo;
+  if (embargo) {
+    embargoMutation = mutations.updateEmbargo;
+  }
+  const embargoObj = {
+    id: item.id || fullItem.id,
+    identifier: item.identifier || fullItem.identifier,
+    start_date: item.embargo_start_date,
+    end_date: item.embargo_end_date,
+    note: item.embargo_note,
+    record_type: type
+  };
+  await API.graphql({
+    query: embargoMutation,
+    variables: { input: embargoObj },
+    authMode: "AMAZON_COGNITO_USER_POOLS"
+  });
+};


### PR DESCRIPTION
**Allows embargos to be attached to Collections.**
* * *

**JIRA Ticket**: (https://webapps.es.vt.edu/jira/browse/LIBTD-2577) (:star:)

* Other Relevant Links (Meeting note, project page, related pull requests, etc.)

# What does this Pull Request do? (:star:)
Allows embargos to be attached to Collections

# What's the changes? (:star:)
* Adds form fields for embargo info to Collection form
* Creates or updates embargo record if at least one embargo date field is filled in
* Shows message indicating that embargo was NOT created if neither date field filled in (but still creates/updates collection record)
* Displays embargo info on collection admin "View" page

# How should this be tested?
* Create a new Collection or edit an existing collection
* Fill out at least one of the embargo date fields
* Fill out the embargo note field
* After submitting changes the embargo details should be displayed on the resulting admin "view" page

# Additional Notes:
* branch: `LIBTD-2577`

# Interested parties
@yinlinchen 

(:star:) Required fields
