### PR TITLE
Add transcripts to existing podcasts

### DIFF
--- a/src/components/FileUploadField.js
+++ b/src/components/FileUploadField.js
@@ -120,7 +120,7 @@ class FileUploadField extends Component {
             evt
           );
         }
-        this.props.setSrc(evt);
+        this.props.setSrc(evt, this.props.fileType, this.props.field);
       });
 
       const eventInfo = {

--- a/src/css/ArchivePage.scss
+++ b/src/css/ArchivePage.scss
@@ -129,4 +129,5 @@ div.obj-wrapper {
   width: 100%;
   border: solid 1px var(--dark-gray);
   height: 300px;
+  background-color: white;
 }

--- a/src/css/podcastMediaElement.scss
+++ b/src/css/podcastMediaElement.scss
@@ -9,10 +9,6 @@
 }
 
 @media (min-width: 768px) {
-  .media-element-container {
-    flex-wrap: nowrap;
-  }
-
   .media-element-container div.audio-img-wrapper {
     max-width: 33%;
     margin-bottom: 0;


### PR DESCRIPTION
**JIRA Ticket**: (link) (:star:)
https://webapps.es.vt.edu/jira/browse/LIBTD-2579

# What does this Pull Request do? (:star:)
Updates the archive form to allow transcripts to be added to existing audio and video files.

# What's the changes? (:star:)
ArchiveForm.js - If the file is an audio or video file then the audioTranscript field is added to the editable fields. The field allows a file upload like the thumbnail field and those functions have been updated to work for both upload fields. When the form is submitted, the audioTranscript value is stored in archiveOptions.

# How should this be tested?
Go to update item form in admin site and input any podcast identifier. Upload an html transcript. Then go to that item in the DLP and you should be able to display the transcript.

# Additional Notes:
Branch is LIBTD-2579

# Interested parties
@yinlinchen 

(:star:) Required fields
