### PR TITLE
Add ability to attach embargo to Archive records

### DIFF
--- a/cypress/integration/admin_archive_edit.spec.js
+++ b/cypress/integration/admin_archive_edit.spec.js
@@ -55,7 +55,7 @@ describe("admin_archive_edit: Update item metadata and change it back", function
     cy.get("textarea[name='title']")
       .clear().type("New Title");
     cy.contains("Update Item Metadata").click();
-    cy.contains("Title: New Title").should('be.visible');
+    cy.contains("Title: New Title", { timeout: 5000 }).should('be.visible');
     cy.contains("View Item")
       .should('have.attr', 'href').and("include", "/archive/3h85z50c")
   })

--- a/cypress/integration/admin_page_title_config.spec.js
+++ b/cypress/integration/admin_page_title_config.spec.js
@@ -29,7 +29,7 @@ describe("admin_page_title_config: Update Site title and change it back", functi
     cy.get("input[value='editSite']").parent().click();
     cy.get("input[name='siteTitle']", { timeout: 2000 }).clear().type("DEMO1");
     cy.contains("Update Site").click();
-    cy.contains("Site Title: DEMO1", { timeout: 2000 }).should('be.visible');
+    cy.contains("Site Title: DEMO1").should('be.visible');
   })
 
   it("Change title back", () => {

--- a/cypress/integration/podcast_deposit.spec.js
+++ b/cypress/integration/podcast_deposit.spec.js
@@ -57,7 +57,7 @@ describe("podcast_deposit: Creates Podcast Archive record", () => {
           .should("include", "uploaded successfully");
   
         cy.get("button.submit").contains("Submit Podcast Episode").click();
-        cy.get("#title_value", { timeout: 2 * 1000 })
+        cy.get("#title_value", { timeout: 5 * 1000 })
           .invoke("text")
           .should("include", title);
 

--- a/cypress/integration/related_items.spec.js
+++ b/cypress/integration/related_items.spec.js
@@ -6,22 +6,25 @@ describe("related_items: Related items on archives page", () => {
     })
 
     it("Carousel populates when more than ten items in the item's subcollection", () => {
-        cy.visit("http://localhost:3000/archive/pf59ds4d", { timeout: 2000 });
+        cy.visit("http://localhost:3000/archive/pf59ds4d", { timeout: 5000 });
         cy.get(".slick-slide").should("have.class", "slick-active");
     })
 
     it("Carousel populates when less than 10 items in the item's subcollection, and more than 10 items in the parent's subcollections", () => {
-        cy.visit("http://localhost:3000/archive/p0636w4x", { timeout: 2000 });
+        cy.visit("http://localhost:3000/archive/p0636w4x", { timeout: 5000 });
+        cy.wait(5000);
         cy.get(".slick-slide").should("have.class", "slick-active");
     });
 
     it("Carousel populates when less than 10 items in the item's subcollection, and less than 10 items in the parent's subcollections", () => {
-        cy.visit("http://localhost:3000/archive/ft77nv3b", { timeout: 2000 });
+        cy.visit("http://localhost:3000/archive/ft77nv3b", { timeout: 5000 });
+        cy.wait(5000);
         cy.get(".slick-slide").should("have.class", "slick-active");
     })
 
     it("Carousel populates when less than 10 items in the entire collection", () => {
-        cy.visit("http://localhost:3000/archive/m58xyh90", { timeout: 2000 });
+        cy.visit("http://localhost:3000/archive/m58xyh90", { timeout: 5000 });
+        cy.wait(5000);
         cy.get(".slick-slide").should("have.class", "slick-active");
     });
 

--- a/src/lib/EmbargoTools.js
+++ b/src/lib/EmbargoTools.js
@@ -41,3 +41,9 @@ export const createEmbargoRecord = async (item, fullItem, embargo, type) => {
     authMode: "AMAZON_COGNITO_USER_POOLS"
   });
 };
+
+export const toTitleCase = str => {
+  return str.replace(/\w\S*/g, function(txt) {
+    return txt.charAt(0).toUpperCase() + txt.substr(1).toLowerCase();
+  });
+};

--- a/src/pages/admin/ArchiveCollectionEdit/CollectionForm.js
+++ b/src/pages/admin/ArchiveCollectionEdit/CollectionForm.js
@@ -8,7 +8,8 @@ import { getCollectionByIdentifier, mintNOID } from "../../../lib/fetchTools";
 import {
   validEmbargo,
   loadEmbargo,
-  createEmbargoRecord
+  createEmbargoRecord,
+  toTitleCase
 } from "../../../lib/EmbargoTools";
 import { addedDiff, updatedDiff } from "deep-object-diff";
 import * as mutations from "../../../graphql/mutations";
@@ -74,7 +75,6 @@ const CollectionForm = React.memo(props => {
   const siteContext = useContext(SiteContext);
 
   useEffect(() => {
-    console.log("useEffect");
     if (siteContext.site.siteId === "podcasts") {
       multiFields.push("podcast_links");
       if (editableFields.indexOf("podcast_links") === -1) {
@@ -456,12 +456,6 @@ const CollectionForm = React.memo(props => {
     const fileUrl = getFileUrl(event.target.name, event.target.value);
     event.target.value = fileUrl;
     changeValueHandler(event, "thumbnail_path");
-  };
-
-  const toTitleCase = str => {
-    return str.replace(/\w\S*/g, function(txt) {
-      return txt.charAt(0).toUpperCase() + txt.substr(1).toLowerCase();
-    });
   };
 
   const formElement = (attribute, index) => {


### PR DESCRIPTION
**Add ability to attach embargo to Archive records.**
* * *

**JIRA Ticket**: (https://webapps.es.vt.edu/jira/browse/LIBTD-2577) (:star:)

* Other Relevant Links (Meeting note, project page, related pull requests, etc.)

# What does this Pull Request do? (:star:)
Add ability to attach embargo to Archive records

# What's the changes? (:star:)
* Adds embargo fields to Archive edit form
* Adds embargo info to admin Archive view

# How should this be tested?
* Visit "Update Item" tab of /siteAdmin page
* Add or edit embargo info in edit form. At least one date must be added.
* Check that the embargo record has been created and that it's displayed in view

# Additional Notes:
* branch: `LIBTD-2577_archives`

# Interested parties
@yinlinchen 

(:star:) Required fields
