### PR TITLE
Fetches .srt files and displays transcripts

### DIFF
--- a/src/components/MediaElement.js
+++ b/src/components/MediaElement.js
@@ -2,17 +2,21 @@ import React, { Component } from "react";
 import flvjs from "flv.js";
 import hlsjs from "hls.js";
 import "mediaelement";
-
-import { getFile } from "../lib/fetchTools";
+import { FontAwesomeIcon } from "@fortawesome/react-fontawesome";
 import "mediaelement/build/mediaelementplayer.min.css";
 import "mediaelement/build/mediaelement-flash-video.swf";
+import { asyncGetFile, getFile } from "../lib/fetchTools";
 
 export default class MediaElement extends Component {
   constructor(props) {
     super(props);
     this.state = {
       player: null,
-      audioImg: ""
+      audioImg: null,
+      audioSrc: null,
+      captionSrc: null,
+      transcript: null,
+      isTranscriptActive: false
     };
   }
 
@@ -24,30 +28,64 @@ export default class MediaElement extends Component {
     console.log(media);
   }
 
+  async getAssetFiles() {
+    const sources = JSON.parse(this.props.sources);
+    let audioResponse = null;
+    if (sources[0].src) {
+      const audioUrl = sources[0].src;
+      audioResponse = await asyncGetFile(audioUrl, "audio", this, "audioSrc");
+    }
+    if (audioResponse.success) {
+      const tracks = JSON.parse(this.props.tracks);
+      const captionSrc = tracks[0].src;
+      await asyncGetFile(captionSrc, "audio", this, "captionSrc");
+    }
+    if (audioResponse.success && this.props.poster) {
+      await asyncGetFile(this.props.poster, "image", this, "audioImg");
+    }
+    if (this.props.transcript && this.props.transcript.audioTranscript) {
+      await getFile(
+        this.props.transcript.audioTranscript,
+        "text",
+        this,
+        "transcript"
+      );
+    }
+
+    return audioResponse.success;
+  }
+
+  async loadAssets() {
+    const assetResponse = await this.getAssetFiles();
+    if (assetResponse) {
+      const { MediaElementPlayer } = global;
+      if (!MediaElementPlayer) {
+        return;
+      }
+
+      const options = Object.assign({}, JSON.parse(this.props.options), {
+        pluginPath: "./static/media/",
+        success: (media, node, instance) => this.success(media, node, instance),
+        error: (media, node) => this.error(media, node)
+      });
+
+      window.flvjs = flvjs;
+      window.Hls = hlsjs;
+      this.setState({ player: new MediaElementPlayer(this.props.id, options) });
+    }
+  }
+
   componentDidMount() {
-    if (this.props.poster) {
-      getFile(this.props.poster, "image", this, "audioImg");
-    }
-
-    const { MediaElementPlayer } = global;
-    if (!MediaElementPlayer) {
-      return;
-    }
-
-    const options = Object.assign({}, JSON.parse(this.props.options), {
-      pluginPath: "./static/media/",
-      success: (media, node, instance) => this.success(media, node, instance),
-      error: (media, node) => this.error(media, node)
-    });
-
-    window.flvjs = flvjs;
-    window.Hls = hlsjs;
-    this.setState({ player: new MediaElementPlayer(this.props.id, options) });
+    this.loadAssets();
   }
 
   componentWillUnmount() {
-    if (this.state.player) {
-      this.state.player.remove();
+    if (this.state.player && this.state.player.media) {
+      try {
+        this.state.player.remove();
+      } catch (error) {
+        console.log(error);
+      }
       this.setState({ player: null });
     }
   }
@@ -64,21 +102,50 @@ export default class MediaElement extends Component {
     );
   }
 
+  openTranscript = () => {
+    this.setState(prevState => {
+      return {
+        isTranscriptActive: !prevState.isTranscriptActive
+      };
+    });
+  };
+
+  transcriptButton() {
+    if (this.props.transcript && this.props.transcript.audioTranscript) {
+      return (
+        <button
+          type="button"
+          className="transcript-button"
+          aria-label="Transcript"
+          onClick={this.openTranscript}
+          title="View transcript"
+        >
+          <span className="fa-layers fa-fw fa-3x">
+            <FontAwesomeIcon icon="circle" color="var(--themeHighlightColor)" />
+            <FontAwesomeIcon icon="file" inverse transform="shrink-7" />
+          </span>
+        </button>
+      );
+    }
+  }
+
   render() {
+    if (!this.state.audioSrc || !this.state.audioImg) {
+      return <></>;
+    }
     const props = this.props,
-      sources = JSON.parse(props.sources),
       tracks = JSON.parse(props.tracks),
       sourceTags = [],
       tracksTags = [];
-    for (let i = 0, total = sources.length; i < total; i++) {
-      const source = sources[i];
-      sourceTags.push(`<source src="${source.src}" type="${source.type}">`);
-    }
+    const sources = JSON.parse(this.props.sources);
+    sourceTags.push(
+      `<source src="${this.state.audioSrc}" type="${sources[0].type}">`
+    );
 
     for (let i = 0, total = tracks.length; i < total; i++) {
       const track = tracks[i];
       tracksTags.push(
-        `<track src="${track.src}" kind="${track.kind}" srclang="${
+        `<track src="${this.state.captionSrc}" kind="${track.kind}" srclang="${
           track.lang
         }"${track.label ? ` label=${track.label}` : ""}>`
       );
@@ -97,12 +164,63 @@ export default class MediaElement extends Component {
           ${mediaBody}
         </video>`
           : `<audio id="${props.id}" width="${props.width}" controls>
-          ${mediaBody}
-        </audio>`;
+            ${mediaBody}
+          </audio>`;
     return (
       <div>
         {props.mediaType === "audio" && this.audioImg()}
         <div dangerouslySetInnerHTML={{ __html: mediaHtml }}></div>
+        <div className="media-buttons">
+          {this.transcriptButton()}
+          <a
+            href={this.state.audioSrc}
+            className="download-link"
+            download
+            aria-label="Download episode"
+            title="Download episode"
+          >
+            <span className="fa-layers fa-fw fa-3x">
+              <FontAwesomeIcon
+                icon="circle"
+                color="var(--themeHighlightColor)"
+              />
+              <FontAwesomeIcon icon="download" inverse transform="shrink-7" />
+            </span>
+          </a>
+        </div>
+        <div
+          className="d-flex"
+          style={{ marginLeft: "-30px", marginRight: "-30px" }}
+        >
+          <div
+            className={
+              this.state.isTranscriptActive ? "transcript-section" : "d-none"
+            }
+          >
+            {this.state.transcript ? (
+              <>
+                <iframe
+                  src={this.state.transcript}
+                  title="transcript"
+                  id="transcript1"
+                  frameBorder="0"
+                  border="0"
+                  cellSpacing="0"
+                ></iframe>
+                <a
+                  href={this.state.transcript}
+                  className="download-link"
+                  download
+                  aria-label="Download transcript"
+                >
+                  Download Transcript
+                </a>
+              </>
+            ) : (
+              <p>Loading transcript...</p>
+            )}
+          </div>
+        </div>
       </div>
     );
   }

--- a/src/components/PodcastMediaElement.js
+++ b/src/components/PodcastMediaElement.js
@@ -15,6 +15,7 @@ export default class PodcastMediaElement extends Component {
       player: null,
       audioImg: null,
       audioSrc: null,
+      captionSrc: null,
       transcript: null,
       isTranscriptActive: false
     };
@@ -34,6 +35,11 @@ export default class PodcastMediaElement extends Component {
     if (sources[0].src) {
       const audioUrl = sources[0].src;
       audioResponse = await asyncGetFile(audioUrl, "audio", this, "audioSrc");
+    }
+    if (audioResponse.success) {
+      const tracks = JSON.parse(this.props.tracks);
+      const captionSrc = tracks[0].src;
+      await asyncGetFile(captionSrc, "audio", this, "captionSrc");
     }
     if (audioResponse.success && this.props.poster) {
       await asyncGetFile(this.props.poster, "image", this, "audioImg");
@@ -140,7 +146,7 @@ export default class PodcastMediaElement extends Component {
     for (let i = 0, total = tracks.length; i < total; i++) {
       const track = tracks[i];
       tracksTags.push(
-        `<track src="${track.src}" kind="${track.kind}" srclang="${
+        `<track src="${this.state.captionSrc}" kind="${track.kind}" srclang="${
           track.lang
         }"${track.label ? ` label=${track.label}` : ""}>`
       );

--- a/src/css/ArchivePage.scss
+++ b/src/css/ArchivePage.scss
@@ -116,14 +116,14 @@ div.obj-wrapper {
   }
 }
 
-.media-element-container .transcript-section {
+.transcript-section {
   margin: 30px;
   height: 300px;
   width: 100%;
   text-align: right;
 }
 
-.media-element-container .transcript-section #transcript1 {
+.transcript-section #transcript1 {
   margin: 0;
   padding: 0;
   width: 100%;

--- a/src/css/podcastMediaElement.scss
+++ b/src/css/podcastMediaElement.scss
@@ -36,6 +36,7 @@
 .media-buttons {
   margin-left: 20px;
   margin-top: 15px;
+  text-align: right;
 }
 
 .transcript-button {

--- a/src/pages/archives/ArchivePage.js
+++ b/src/pages/archives/ArchivePage.js
@@ -160,12 +160,11 @@ class ArchivePage extends Component {
 
   buildTrack(url, thumbnail_path) {
     const nameExt = this.fileNameFromUrl(url);
-    const name = nameExt.split(".")[0];
-
+    const ext = nameExt.split(".").pop();
     const track = {};
     track["kind"] = "subtitles";
     track["label"] = "English";
-    track["src"] = url.replace(nameExt, name + ".srt");
+    track["src"] = url.replace(`.${ext}`, ".srt");
     track["srclang"] = "en";
     track["poster"] = thumbnail_path;
     return track;
@@ -279,6 +278,7 @@ class ArchivePage extends Component {
         options={JSON.stringify(config)}
         tracks={JSON.stringify(tracks)}
         title={title}
+        transcript={JSON.parse(this.state.item.archiveOptions)}
       />
     ) : (
       <PodcastMediaElement


### PR DESCRIPTION
**JIRA Ticket**: (link) (:star:)
none

# What does this Pull Request do? (:star:)
Allows media player to fetch .srt files so that captions can be used. Adds transcript section to non-podcast audio component.

# What's the changes? (:star:)
-MediaElement.js - adds transcript section and ability to fetch audio and .srt files.
-PodcastMediaElement.js - adds ability to fetch .srt files
-ArchivePage.js - fixes function to generate filename for .srt files.
-CSS updates

# How should this be tested?
non-podcast audio files should display transcript if one was uploaded. All audio files should fetch .srt files and player should show that captions can be turned on if .srt file is present.

# Additional Notes:
Branch is fetchCaptions

# Interested parties
@yinlinchen 

(:star:) Required fields
