### PR TITLE
Renders download links on Archive show page

### DIFF
--- a/cypress/integration/derivative_download_section.spec.js
+++ b/cypress/integration/derivative_download_section.spec.js
@@ -1,0 +1,18 @@
+describe('derivative download section: Archive Show page download section', () => {
+  beforeEach(() => {
+    cy.visit('archive/s253n51s');
+    cy.get('div.download-link-section', {timeout: 10000})
+      .as('downloadSection');
+  })
+
+  it('displays the size field and its corresponding value', () => {
+    cy.get('@downloadSection')
+      .find('h3')
+      .invoke('text')
+      .should('equal', 'Download this file');
+    cy.get('@downloadSection')
+      .find('ul li:nth-child(1)')
+      .invoke('text')
+      .should('contain', 'sm:')
+  })
+})

--- a/src/components/Citation.js
+++ b/src/components/Citation.js
@@ -1,5 +1,5 @@
 import React, { Component } from "react";
-import { createMuiTheme, MuiThemeProvider } from "@material-ui/core/styles";
+import { createTheme, MuiThemeProvider } from "@material-ui/core/styles";
 import Tooltip from "@material-ui/core/Tooltip";
 import { htmlParsedValue } from "../lib/MetadataRenderer";
 
@@ -20,7 +20,7 @@ class Citation extends Component {
   }
 
   render() {
-    const theme = createMuiTheme({
+    const theme = createTheme({
       overrides: {
         MuiTooltip: {
           tooltip: {

--- a/src/components/DownloadLinks.js
+++ b/src/components/DownloadLinks.js
@@ -1,0 +1,59 @@
+import React, { useState, useEffect } from "react";
+import { fetchSignedLink } from "../lib/fetchTools";
+import "../css/DownloadLinks.scss";
+
+const DownloadLinks = ({ title, links }) => {
+  const [linkElements, setLinkElements] = useState([]);
+
+  useEffect(() => {
+    createLinksSection();
+  }, [title, links]);
+
+  const linksExist = () => {
+    let exist = false;
+    linkElements.forEach(link => {
+      if (link.type == "li") {
+        exist = true;
+      }
+    });
+    return exist;
+  };
+
+  const sortLinks = (a, b) => {
+    let retVal = 0;
+    if (a.key > b.key) {
+      retVal = 1;
+    } else if (a.key < b.key) {
+      retVal = -1;
+    }
+    return retVal;
+  };
+
+  const createLinksSection = async () => {
+    let linksList = [];
+    for (const size in links) {
+      const signedLink = await fetchSignedLink(links[size]);
+      const fileName = new URL(links[size]).pathname.split("/").pop();
+      if (size && signedLink?.data?.length && fileName) {
+        linksList.push(
+          <li key={size}>
+            {size}: <a href={signedLink.data}>{fileName}</a>
+          </li>
+        );
+      }
+    }
+    setLinkElements(linksList.sort(sortLinks).reverse());
+  };
+  let downloadLinks = null;
+  if (linksExist()) {
+    downloadLinks = (
+      <div className="download-link-section">
+        <h3>{title}</h3>
+        <ul>{linkElements}</ul>
+      </div>
+    );
+  }
+  return downloadLinks;
+};
+
+export { DownloadLinks };

--- a/src/components/LinkDropdown.js
+++ b/src/components/LinkDropdown.js
@@ -1,0 +1,13 @@
+import React from "react";
+import "../css/LinkDropdown.scss";
+
+const DownloadLinks = ({ title, links }) => {
+  console.log(links);
+  return (
+    <div className="download-link-section">
+      <h3>{title}</h3>
+    </div>
+  );
+};
+
+export { DownloadLinks };

--- a/src/css/DownloadLinks.scss
+++ b/src/css/DownloadLinks.scss
@@ -1,0 +1,10 @@
+.download-link-section {
+  background-color: var(--light-gray);
+  margin-bottom: 30px;
+  padding: 10px;
+  h3 {
+    font-family: "gineso-condensed", sans-serif;
+    font-size: 1.3125rem;
+    font-weight: 500;
+  }
+}

--- a/src/css/LinkDropdown.scss
+++ b/src/css/LinkDropdown.scss
@@ -1,0 +1,9 @@
+.link-dropdown-section {
+  background-color: var(--light-gray);
+  margin-bottom: 30px;
+  h3 {
+    font-family: "gineso-condensed", sans-serif;
+    font-size: 1.3125rem;
+    font-weight: 500;
+  }
+}

--- a/src/lib/fetchTools.js
+++ b/src/lib/fetchTools.js
@@ -47,7 +47,7 @@ export const asyncGetFile = async (copyURL, type, component, attr) => {
   return response;
 };
 
-const fetchCopyFile = async (copyURL, type, component, attr) => {
+export const fetchCopyFile = async (copyURL, type, component, attr) => {
   let data = null;
   let filename = copyURL;
   let prefix = `public/sitecontent/${type}/${process.env.REACT_APP_REP_TYPE.toLowerCase()}/`;
@@ -88,6 +88,33 @@ const fetchCopyFile = async (copyURL, type, component, attr) => {
   } else {
     return { success: false };
   }
+};
+
+export const fetchSignedLink = async objLink => {
+  let filename = new URL(objLink).pathname.split("/").pop();
+  const bucket = Storage._config.AWSS3.bucket;
+  let prefix = objLink
+    .replace(`https://${bucket}.s3.amazonaws.com/`, "")
+    .replace(filename, "");
+  let signedLink = "";
+
+  try {
+    Storage.configure({
+      customPrefix: {
+        public: prefix
+      }
+    });
+    signedLink = await Storage.get(filename);
+    console.log(`fetching signedURL for: ${filename}`);
+  } catch (error) {
+    console.error(`Error fetching signedLink for ${filename}`);
+    console.error(error);
+  }
+  let success = false;
+  if (signedLink && signedLink.length) {
+    success = true;
+  }
+  return { success: true, data: signedLink };
 };
 
 export const mintNOID = async () => {

--- a/src/pages/archives/ArchivePage.js
+++ b/src/pages/archives/ArchivePage.js
@@ -26,6 +26,7 @@ import Thumbnail from "../../components/Thumbnail";
 import MtlElement from "../../components/MtlElement";
 import X3DElement from "../../components/X3DElement";
 import SocialButtons from "../../components/SocialButtons";
+import { DownloadLinks } from "../../components/DownloadLinks";
 
 import "../../css/ArchivePage.scss";
 
@@ -319,6 +320,7 @@ class ArchivePage extends Component {
       window.ga("send", "pageview", {
         dimension1: this.state.item.identifier
       });
+      const archiveOptions = JSON.parse(this.state.item.archiveOptions);
       return (
         <div className="item-page-wrapper">
           <SiteTitle
@@ -372,6 +374,12 @@ class ArchivePage extends Component {
               {addNewlineInDesc(this.state.item.description)}
             </div>
             <div className="col-lg-6 details-section-metadata">
+              {archiveOptions?.derivatives?.downloads && (
+                <DownloadLinks
+                  title="Download this file"
+                  links={archiveOptions.derivatives.downloads}
+                />
+              )}
               <SocialButtons
                 buttons={JSON.parse(this.props.site.siteOptions)}
                 url={window.location.href}


### PR DESCRIPTION
**Renders download links on Archive show page (if they exist).**
* * *

**JIRA Ticket**: (https://webapps.es.vt.edu/jira/browse/LIBTD-2607) (:star:)

* Other Relevant Links (Meeting note, project page, related pull requests, etc.)

# What does this Pull Request do? (:star:)
Renders download links on Archive show page (if they exist).

# What's the changes? (:star:)
A in-depth description of the changes made by this PR. Technical details and possible side effects.
* Renders download links on Archive show page (if they exist).
* Fetches signed URL for each link so that it can be accessed from s3

# How should this be tested?
* Visit "archive/s253n51s" in "Demo" site
* Check that download links exist in right column
* Check that download links function correctly
* Check that the image sizes are correct 

# Additional Notes:
Any additional information that you think would be helpful when reviewing this PR.

Example:
* branch: `download_links`
* Amplify backend: `dloadtest`

# Interested parties
Tag (@ mention) interested parties
@yinlinchen 

(:star:) Required fields
