### PR TITLE
display multi-valued field values on their own line

### DIFF
--- a/cypress/integration/admin_searchpage_facet_sort_config.spec.js
+++ b/cypress/integration/admin_searchpage_facet_sort_config.spec.js
@@ -153,9 +153,14 @@ describe("admin_searchpage_facet_sort_config: Displays and updates search page c
       cy.get("input[value='edit']").parent().click();
       cy.get("select").eq(0).select("subject");
       cy.contains("Add New Search Facet").click();
-      cy.get("input#Art")
-        .check();
+      cy.get("#subject > fieldset > button", {timeout: 2000})
+        .click();
+      cy.get("#subject fieldset ul li#subject_li_0 input[name='subject_value_0']", {timeout: 2000})
+        .first()
+        .clear()
+        .type("Art")
       cy.contains("Update Facet and Sort Fields").click();
+      cy.wait(2000)
       cy.contains("Facet Field: subject").should("be.visible");
       cy.contains("Art").should("be.visible");
     })

--- a/cypress/integration/archive_metadata_display.spec.js
+++ b/cypress/integration/archive_metadata_display.spec.js
@@ -31,7 +31,7 @@ describe('archive_metadata_display: A single Archive Show page metadata section'
       .invoke('text')
       .should('equal', 'Belongs to');
     cy.get('@metadataSection')
-      .find(':nth-child(2) > td.collection-detail-value > div > :nth-child(1)').click();
-    cy.url({ timeout: 2000 }).should('include', '/collection/4g825g7ddemo');
+      .find('tr.belongs_to > td > div > span:nth-child(1) > a').click();
+    cy.url({ timeout: 3000 }).should('include', '/collection/4g825g7ddemo');
   })
 })

--- a/cypress/integration/language_config.spec.js
+++ b/cypress/integration/language_config.spec.js
@@ -21,8 +21,8 @@ describe('language_config.spec: Selecting English loads English results', () => 
       .find('a')
       .click();
     cy.url().should("include", "/archive/");
-    cy.wait(2000);
-    cy.get('div.details-section-metadata > table[aria-label="Item Metadata"] tbody', { timeout: 2000 })
+    cy.wait(5000);
+    cy.get('div.details-section-metadata > table[aria-label="Item Metadata"] tbody', { timeout: 5000 })
       .find('tr.language td a')
       .invoke('text')
       .should('equal', 'English');

--- a/src/css/ListPages.scss
+++ b/src/css/ListPages.scss
@@ -76,11 +76,7 @@ div.collection-detail table tr .collection-detail-value {
 }
 
 td.collection-detail-value div span.list-unstyled {
-  margin-right: 2px;
-}
-
-span.list-unstyled:nth-of-type(n + 2)::before {
-  content: ", ";
+  display: block;
 }
 
 a.more-link {

--- a/src/pages/admin/SiteAdmin.js
+++ b/src/pages/admin/SiteAdmin.js
@@ -258,7 +258,7 @@ class SiteAdmin extends Component {
               </li>
             )}
           </ul>
-          <hr class="auth-divider" />
+          <hr className="auth-divider" />
           <Authenticator>
             {({ signOut, user }) => (
               <div className="auth-dialog">


### PR DESCRIPTION
**display multi-valued field values on their own line.**
* * *

**JIRA Ticket**: (https://webapps.es.vt.edu/jira/browse/LIBTD-2617) (:star:)

* Other Relevant Links (Meeting note, project page, related pull requests, etc.)

# What does this Pull Request do? (:star:)
display multi-valued field values on their own line.

# What's the changes? (:star:)
* Changes <span> to `display: block` so each will skip to a new line.
* Don't prepend a comma to each entry after the first

# How should this be tested?

A description of what steps someone could take to:
* Launch SWVA site
* Check that multi-valued fields are displayed correctly. Like this: https://libtd-2617.djf1n0m63xbku.amplifyapp.com/archive/0x56kb46 NOT like this: https://swva-pprd.cloud.lib.vt.edu/archive/0z43h83m

# Additional Notes:
Any additional information that you think would be helpful when reviewing this PR.

Example:
* branch: `LIBTD-2617`

# Interested parties
@yinlinchen 

(:star:) Required fields
