### PR TITLE
fix es_lint warnings

### DIFF
--- a/src/components/DownloadLinks.js
+++ b/src/components/DownloadLinks.js
@@ -6,13 +6,33 @@ const DownloadLinks = ({ title, links }) => {
   const [linkElements, setLinkElements] = useState([]);
 
   useEffect(() => {
-    createLinksSection();
-  }, [title, links]);
+    const createLinksSection = async () => {
+      let linksList = [];
+      for (const size in links) {
+        const signedLink = await fetchSignedLink(links[size]);
+        const fileName = new URL(links[size]).pathname.split("/").pop();
+        if (size && signedLink?.data?.length && fileName) {
+          linksList.push(
+            <li key={size}>
+              {size}: <a href={signedLink.data}>{fileName}</a>
+            </li>
+          );
+        }
+      }
+      setLinkElements(linksList.sort(sortLinks).reverse());
+    };
+    const init = async () => {
+      if (!linkElements.length) {
+        await createLinksSection();
+      }
+    };
+    init();
+  }, [title, links, linkElements.length]);
 
   const linksExist = () => {
     let exist = false;
     linkElements.forEach(link => {
-      if (link.type == "li") {
+      if (link.type === "li") {
         exist = true;
       }
     });
@@ -29,21 +49,6 @@ const DownloadLinks = ({ title, links }) => {
     return retVal;
   };
 
-  const createLinksSection = async () => {
-    let linksList = [];
-    for (const size in links) {
-      const signedLink = await fetchSignedLink(links[size]);
-      const fileName = new URL(links[size]).pathname.split("/").pop();
-      if (size && signedLink?.data?.length && fileName) {
-        linksList.push(
-          <li key={size}>
-            {size}: <a href={signedLink.data}>{fileName}</a>
-          </li>
-        );
-      }
-    }
-    setLinkElements(linksList.sort(sortLinks).reverse());
-  };
   let downloadLinks = null;
   if (linksExist()) {
     downloadLinks = (

--- a/src/lib/fetchTools.js
+++ b/src/lib/fetchTools.js
@@ -110,10 +110,7 @@ export const fetchSignedLink = async objLink => {
     console.error(`Error fetching signedLink for ${filename}`);
     console.error(error);
   }
-  let success = false;
-  if (signedLink && signedLink.length) {
-    success = true;
-  }
+
   return { success: true, data: signedLink };
 };
 

--- a/src/pages/admin/PodcastDeposit.js
+++ b/src/pages/admin/PodcastDeposit.js
@@ -64,8 +64,6 @@ class PodcastDeposit extends Component {
 
   async loadPodcast() {
     let item;
-    let editableArchive = {};
-    let item_id = null;
     try {
       item = await getArchiveByIdentifier(this.props.identifier);
     } catch (e) {


### PR DESCRIPTION
**fix es_lint warnings.**
* * *

**JIRA Ticket**: () (:star:)

* Other Relevant Links (Meeting note, project page, related pull requests, etc.)

# What does this Pull Request do? (:star:)
Fixes multiple coding issues listed by es_lint

# What's the changes? (:star:)
A in-depth description of the changes made by this PR. Technical details and possible side effects.
Addresses these issues:
```
WARNING in [eslint] 
src/components/DownloadLinks.js
  Line 10:6:   React Hook useEffect has a missing dependency: 'createLinksSection'. Either include it or remove the dependency array  react-hooks/exhaustive-deps
  Line 15:21:  Expected '===' and instead saw '=='                                                                                    eqeqeq

src/lib/fetchTools.js
  Line 115:5:  'success' is assigned a value but never used  no-unused-vars

src/pages/admin/PodcastDeposit.js
  Line 67:9:  'editableArchive' is assigned a value but never used  no-unused-vars
  Line 68:9:  'item_id' is assigned a value but never used          no-unused-vars
```

# How should this be tested?

A description of what steps someone could take to:
* Run locally and check that the es_lint warnings listed above do not show in the terminal when you start the local server

# Additional Notes:
Any additional information that you think would be helpful when reviewing this PR.

Example:
* branch: `es_lint`

# Interested parties
@andreaWaldren 

(:star:) Required fields
