### PR TITLE
Handles asset relative-urls with no domain to make site backend env agnostic

### DIFF
--- a/cypress/integration/additional_pages.spec.js
+++ b/cypress/integration/additional_pages.spec.js
@@ -16,6 +16,7 @@ describe('additional_pages: About link', () => {
     cy.visit('/');
     cy.get('nav.top-navbar > ul > li:nth-child(4) > a')
       .click();
+    cy.wait(5000);
     cy.get('#content-wrapper > div > div.col-12.about-heading > h1', { timeout: 2000 })
       .invoke('text')
       .should('contain', 'About');

--- a/cypress/integration/admin_archive_edit.spec.js
+++ b/cypress/integration/admin_archive_edit.spec.js
@@ -87,10 +87,7 @@ describe("admin_archive_edit: Update item metadata and change it back", function
 
   it("Can add multi-valued metadata", () => {
     cy.get("input[value='edit']").parent().click();
-    cy.get("textarea[name='belongs_to_0']")
-      .parent().parent()
-      .siblings(".small")
-      .click();
+    cy.get("#belongs_to_add_value_button").click();
     cy.get("textarea[name='belongs_to_1']").should("have.value", "new belongs_to")
       .clear()
       .type("Ms1990-025, Box 1, Folder 1");

--- a/cypress/integration/admin_displayed_attributes_config.spec.js
+++ b/cypress/integration/admin_displayed_attributes_config.spec.js
@@ -47,7 +47,7 @@ describe("admin_displayed_attributes_config: Update attribute and change it back
   it("Can delete attribute", () => {
     cy.get("input[value='edit']").parent().click();
     cy.get("section#archive", { timeout: 2000 })
-      .find('a.delete.active').last().click();
+      .find('div.archive_tags_wrapper > a.delete').click();
     cy.contains("Update Attributes", { timeout: 2000 }).click();
     cy.contains("field: tags", { timeout: 2000 }).should('not.exist');
     cy.contains("label: Tags").should('not.exist');
@@ -60,7 +60,7 @@ describe("admin_displayed_attributes_config: Update attribute and change it back
     cy.get("section#archive")
       .find('a.add.active').click();
     cy.get("section#archive", { timeout: 2000 })
-      .find('div.field.attributeLabel').last()
+      .find('div.archive_tags_wrapper > div.field.attributeLabel')
       .find('input').clear().type('Tags');
     cy.contains("Update Attributes").click();
     cy.contains("field: tags", { timeout: 2000 }).should('be.visible');

--- a/cypress/integration/admin_media_section_config.spec.js
+++ b/cypress/integration/admin_media_section_config.spec.js
@@ -13,7 +13,7 @@ describe("admin_media_section_config: Displays and updates media section configu
     cy.visit("/siteAdmin");
 
     cy.get("#content-wrapper > div > div > ul")
-      .find(":nth-child(8) > a")
+      .find("li.mediaSection > a")
       .contains("Homepage media section")
       .click();
     cy.url({ timeout: 2000 }).should("include", "/siteAdmin");
@@ -85,8 +85,10 @@ describe("admin_media_section_config: Displays and updates media section configu
       cy.get("button.submit").contains("Update Config").click();
 
       cy.visit("/");
+      cy.wait(5000);
       cy.get("div.media-section-wrapper", { timeout: 2000 }).should('not.exist');
       cy.visit("/siteAdmin");
+      cy.wait(5000);
     });
   });
 
@@ -111,7 +113,8 @@ describe("admin_media_section_config: Displays and updates media section configu
 
 
       cy.visit("/");
-      cy.get("div.media-section-wrapper", { timeout: 2000 }).should("be.visible");
+      cy.wait(5000);
+      cy.get("div.row.media-section-wrapper", { timeout: 5000 }).should("be.visible");
       cy.visit("/siteAdmin");
     });
   });

--- a/cypress/integration/archive_metadata_display.spec.js
+++ b/cypress/integration/archive_metadata_display.spec.js
@@ -7,7 +7,7 @@ describe('archive_metadata_display: A single Archive Show page metadata section'
 
   it('displays the identifier field and its corresponding value', () => {
     cy.get('@metadataSection')
-      .find(':nth-child(1) > th.collection-detail-key')
+      .find('tr.identifier > th.collection-detail-key')
       .invoke('text')
       .should('equal', 'Identifier');
     cy.get('@metadataSection')
@@ -17,17 +17,17 @@ describe('archive_metadata_display: A single Archive Show page metadata section'
 
   it('displays the custom key field and its corresponding value', () => {
     cy.get('@metadataSection')
-      .find(':nth-child(5) > th.collection-detail-key')
+      .find('tr.permanent_link > th.collection-detail-key')
       .invoke('text')
       .should('equal', 'Permanent Link');
     cy.get('@metadataSection')
-      .find(':nth-child(5) > td.collection-detail-value')
+      .find('tr.permanent_link > td.collection-detail-value')
       .contains('idn.lib.vt.edu/ark:/53696/cv65x38f');
   })
 
   it('displays the belongs_to field and its corresponding value', () => {
     cy.get('@metadataSection')
-      .find(':nth-child(2) > th.collection-detail-key')
+      .find('tr.belongs_to > th.collection-detail-key')
       .invoke('text')
       .should('equal', 'Belongs to');
     cy.get('@metadataSection')

--- a/cypress/integration/collection_metadata_display.spec.js
+++ b/cypress/integration/collection_metadata_display.spec.js
@@ -12,8 +12,9 @@ describe('collection_metadata_display: A single Collection Show page metadata se
       .invoke('text')
       .should('equal', 'Size');
     cy.get('@metadataSection', {timeout: 5000})
-      .find('tbody > tr.size > td > div > div:nth-child(1)', {timeout: 5000})
-      .contains('Collections:');
+      .find('#num-collections', {timeout: 5000})
+      .invoke('text')
+      .should('contain', 'Collections');
   })
 
   it('displays the identifier field and its corresponding value', () => {

--- a/cypress/integration/language_config.spec.js
+++ b/cypress/integration/language_config.spec.js
@@ -1,18 +1,20 @@
 describe('language_config.spec: Selecting English loads English results', () => {
   it('Language checkbox exists and updates url', () => {
     cy.visit("/search");
+    cy.wait(10000)
     cy.get('div.facet-fields')
-      .find(':nth-child(1) h3 button#category')
+      .find('div.category > div > h3 > button#category')
       .click()
       .invoke('text')
       .should('equal', 'Category');
     cy.get('input#archive', { timeout: 2000 }).click();
     cy.get('div.facet-fields')
-      .find('button#language')
+      .find('div.language > div > h3 > button#language')
       .click()
       .invoke('text')
       .should('equal', 'Language');
     cy.get('input#en', { timeout: 2000 }).click();
+    cy.wait(5000);
     cy.url().should("include", "language=en");
   });
 
@@ -20,10 +22,10 @@ describe('language_config.spec: Selecting English loads English results', () => 
     cy.get('div.gallery-item').first()
       .find('a')
       .click();
+      cy.wait(5000);
     cy.url().should("include", "/archive/");
-    cy.wait(5000);
     cy.get('div.details-section-metadata > table[aria-label="Item Metadata"] tbody', { timeout: 5000 })
-      .find('tr.language td a')
+      .find('tr.language td a', { timeout: 5000 })
       .invoke('text')
       .should('equal', 'English');
   });

--- a/cypress/integration/linked_metadata.spec.js
+++ b/cypress/integration/linked_metadata.spec.js
@@ -1,18 +1,18 @@
 describe('linked_metadata: Archive metadata', () => {
   it('lands on search facet by the metadata field', () => {
     cy.visit('/archive/cv65x38f');
-    cy.get('[data-cy=multi-field-span] a')
-      .eq(2)
+    cy.get('tr.creator > td.collection-detail-value > div > span.list-unstyled > a')
       .click();
+    cy.wait(5000)
     cy.url({ timeout: 2000 })
       .should('eq', 'http://localhost:3000/search/?category=archive&creator=Green%2C%20Terence%20M.%20&field=title&q=&view=Gallery');
   });
 
   it('first entry in "Is Part of" directs to the top level collection show page', () => {
     cy.visit('/archive/cv65x38f');
-    cy.get('[data-cy=multi-field-span] a')
-      .eq(0)
+    cy.get('tr.belongs_to > td > div > span:nth-child(1) > a')
       .click();
+    cy.wait(5000)
     cy.url({ timeout: 2000 })
       .should('eq', 'http://localhost:3000/collection/4g825g7ddemo');
   });
@@ -21,9 +21,10 @@ describe('linked_metadata: Archive metadata', () => {
 describe('linked_metadata: Collection metadata', () => {
   it('lands on search facet by the metadata field', () => {
     cy.visit('/collection/vb765t25demo');
-    cy.get('[data-cy=multi-field-span] a')
-      .eq(1)
+    cy.wait(5000);
+    cy.get('tr.language > td > div > span:nth-child(1) > a')
       .click();
+    cy.wait(5000);
     cy.url({ timeout: 2000 })
       .should('eq', 'http://localhost:3000/search/?category=collection&field=title&language=en&q=&view=Gallery');
   });

--- a/package-lock.json
+++ b/package-lock.json
@@ -20135,9 +20135,9 @@
       }
     },
     "node_modules/caniuse-lite": {
-      "version": "1.0.30001370",
-      "resolved": "https://registry.npmjs.org/caniuse-lite/-/caniuse-lite-1.0.30001370.tgz",
-      "integrity": "sha512-3PDmaP56wz/qz7G508xzjx8C+MC2qEm4SYhSEzC9IBROo+dGXFWRuaXkWti0A9tuI00g+toiriVqxtWMgl350g==",
+      "version": "1.0.30001427",
+      "resolved": "https://registry.npmjs.org/caniuse-lite/-/caniuse-lite-1.0.30001427.tgz",
+      "integrity": "sha512-lfXQ73oB9c8DP5Suxaszm+Ta2sr/4tf8+381GkIm1MLj/YdLf+rEDyDSRCzeltuyTVGm+/s18gdZ0q+Wmp8VsQ==",
       "funding": [
         {
           "type": "opencollective",
@@ -56820,9 +56820,9 @@
       }
     },
     "caniuse-lite": {
-      "version": "1.0.30001370",
-      "resolved": "https://registry.npmjs.org/caniuse-lite/-/caniuse-lite-1.0.30001370.tgz",
-      "integrity": "sha512-3PDmaP56wz/qz7G508xzjx8C+MC2qEm4SYhSEzC9IBROo+dGXFWRuaXkWti0A9tuI00g+toiriVqxtWMgl350g=="
+      "version": "1.0.30001427",
+      "resolved": "https://registry.npmjs.org/caniuse-lite/-/caniuse-lite-1.0.30001427.tgz",
+      "integrity": "sha512-lfXQ73oB9c8DP5Suxaszm+Ta2sr/4tf8+381GkIm1MLj/YdLf+rEDyDSRCzeltuyTVGm+/s18gdZ0q+Wmp8VsQ=="
     },
     "capital-case": {
       "version": "1.0.4",

--- a/src/App.js
+++ b/src/App.js
@@ -26,6 +26,7 @@ class App extends Component {
     super(props);
     this.state = {
       site: null,
+      siteChanged: false,
       paginationClick: null,
       path: "",
       isLoading: true
@@ -33,7 +34,8 @@ class App extends Component {
   }
 
   setPathname(pathName, context) {
-    context.setState({ path: pathName });
+    context?.setState({ path: pathName });
+    return pathName;
   }
 
   async loadSite() {
@@ -70,11 +72,23 @@ class App extends Component {
     this.setState({ paginationClick: event });
   }
 
+  siteChanged = changed => {
+    this.setState({ siteChanged: changed });
+  };
+
+  componentDidUpdate() {
+    if (this.state.siteChanged) {
+      this.loadSite();
+      this.setState({ siteChanged: false });
+    }
+  }
+
   componentDidMount() {
     this.loadSite();
   }
 
   render() {
+    console.log("siteChanged", this.state.siteChanged);
     if (!this.state.isLoading && this.state.site) {
       this.setStyles();
       const customRoutes = buildRoutes(this.state.site);
@@ -139,7 +153,13 @@ class App extends Component {
                     />
                   )}
                 />
-                <Route path="/siteAdmin" exact component={SiteAdmin} />
+                <Route
+                  path="/siteAdmin"
+                  exact
+                  render={props => (
+                    <SiteAdmin siteChanged={this.siteChanged.bind(this)} />
+                  )}
+                />
                 <Route
                   path="/podcastDeposit"
                   exact

--- a/src/components/Collapsible.js
+++ b/src/components/Collapsible.js
@@ -148,7 +148,7 @@ class Collapsible extends Component {
     };
 
     return (
-      <div>
+      <div className={this.props.filterLabel.toLowerCase().replace(" ", "_")}>
         <div
           onClick={e => this.togglePanel(e)}
           className="facet-title"

--- a/src/components/CollectionTopContent.js
+++ b/src/components/CollectionTopContent.js
@@ -3,6 +3,7 @@ import { addNewlineInDesc } from "../lib/MetadataRenderer";
 import { Storage } from "aws-amplify";
 import { getFile } from "../lib/fetchTools";
 import "../css/CollectionsShowPage.scss";
+import FileGetter from "../lib/FileGetter";
 
 class CollectionTopContent extends Component {
   constructor(props) {
@@ -12,6 +13,7 @@ class CollectionTopContent extends Component {
       collectionThumbnail: "",
       rss: ""
     };
+    this.fileGetter = new FileGetter();
   }
 
   getDescription() {
@@ -323,13 +325,27 @@ class CollectionTopContent extends Component {
 
   componentDidUpdate(prevProps) {
     if (this.props.collectionImg !== prevProps.collectionImg) {
-      getFile(this.props.collectionImg, "image", this, "collectionThumbnail");
+      this.fileGetter.getFile(
+        this.props.collectionImg,
+        "image",
+        this,
+        "collectionThumbnail",
+        this.props.site.siteId,
+        "public/sitecontent"
+      );
     }
   }
 
   componentDidMount() {
     if (this.props.collectionImg) {
-      getFile(this.props.collectionImg, "image", this, "collectionThumbnail");
+      this.fileGetter.getFile(
+        this.props.collectionImg,
+        "image",
+        this,
+        "collectionThumbnail",
+        this.props.site.siteId,
+        "public/sitecontent"
+      );
     }
     this.getWebFeed();
   }

--- a/src/components/DownloadLinks.js
+++ b/src/components/DownloadLinks.js
@@ -33,7 +33,7 @@ const DownloadLinks = ({ title, links }) => {
     let linksList = [];
     for (const size in links) {
       const signedLink = await fetchSignedLink(links[size]);
-      const fileName = new URL(links[size]).pathname.split("/").pop();
+      const fileName = links[size].split("/").pop();
       if (size && signedLink?.data?.length && fileName) {
         linksList.push(
           <li key={size}>

--- a/src/components/RelatedItems.js
+++ b/src/components/RelatedItems.js
@@ -78,6 +78,7 @@ class RelatedItems extends Component {
                   item={item}
                   className={"card-img-top"}
                   altText={item.title}
+                  site={this.props.site}
                 />
                 <div className="card-body">
                   <h4 className="card-title crop-text-4">{item.title}</h4>

--- a/src/components/Thumbnail.js
+++ b/src/components/Thumbnail.js
@@ -1,7 +1,6 @@
 import React, { Component } from "react";
-
-import { getFile } from "../lib/fetchTools";
 import "../css/Thumbnail.scss";
+import FileGetter from "../lib/FileGetter";
 
 class Thumbnail extends Component {
   constructor(props) {
@@ -9,6 +8,7 @@ class Thumbnail extends Component {
     this.state = {
       thumbnailImg: null
     };
+    this.fileGetter = new FileGetter();
   }
 
   labelDisplay() {
@@ -23,10 +23,32 @@ class Thumbnail extends Component {
     }
   }
 
+  componentDidUpdate(prevProps) {
+    const prevImgURL = prevProps.imgURL || prevProps.item.thumbnail_path;
+    const imgURL = this.props.imgURL || this.props.item.thumbnail_path;
+    if (imgURL && prevImgURL !== imgURL) {
+      this.fileGetter.getFile(
+        imgURL,
+        "image",
+        this,
+        "thumbnailImg",
+        this.props.site.siteId,
+        "public/sitecontent"
+      );
+    }
+  }
+
   componentDidMount() {
-    const imgUrl = this.props.imgURL || this.props.item.thumbnail_path;
-    if (imgUrl) {
-      getFile(imgUrl, "image", this, "thumbnailImg");
+    const imgURL = this.props.imgURL || this.props.item.thumbnail_path;
+    if (imgURL) {
+      this.fileGetter.getFile(
+        imgURL,
+        "image",
+        this,
+        "thumbnailImg",
+        this.props.site.siteId,
+        "public/sitecontent"
+      );
     }
   }
 

--- a/src/lib/FileGetter.js
+++ b/src/lib/FileGetter.js
@@ -1,0 +1,79 @@
+import { Storage } from "aws-amplify";
+
+export default class FileGetter {
+  async getFile(copyURL, type, component, attr, siteId = "", pathPrefix = "") {
+    const stateObj = {};
+    const stateAttr = attr || "copy";
+    let prefix;
+    let filename;
+    const anyBucketMatches = copyURL?.match(/(collectionmap\d{6}-)/);
+    if (
+      copyURL?.indexOf("http") === 0 &&
+      copyURL?.indexOf(Storage._config.AWSS3.bucket) === -1 &&
+      anyBucketMatches === null &&
+      copyURL?.indexOf("s3") === -1
+    ) {
+      // external
+      stateObj[stateAttr] = copyURL;
+      component.setState(stateObj);
+      return copyURL;
+    } else if (
+      copyURL?.indexOf("http") === 0 &&
+      copyURL?.indexOf(Storage._config.AWSS3.bucket) !== -1 &&
+      copyURL?.indexOf("s3") !== -1
+    ) {
+      // correct bucket
+      console.log("correct bucket");
+      filename = copyURL.split("/").pop();
+      const domain = `https://${Storage._config.AWSS3.bucket}.s3.amazonaws.com`;
+      prefix = copyURL.replace(filename, "").replace(domain, "");
+    } else if (
+      copyURL?.indexOf("http") === 0 &&
+      copyURL?.indexOf(Storage._config.AWSS3.bucket) === -1 &&
+      anyBucketMatches?.length &&
+      copyURL?.indexOf("s3") !== -1
+    ) {
+      // full url, incorrect bucket
+      const domain = "amazonaws.com/";
+      const start = copyURL.indexOf(domain);
+      const length = start + domain.length;
+      copyURL = copyURL.replace(copyURL.substr(0, length), "");
+      filename = copyURL.split("/").pop();
+      prefix = `${pathPrefix}/${type}/${siteId}/`;
+    } else if (
+      // rel url / prefix/filename
+      copyURL?.indexOf("http") === -1 &&
+      copyURL?.indexOf("https") === -1 &&
+      copyURL?.indexOf("amazonaws.com") === -1 &&
+      copyURL?.indexOf("www.") === -1
+    ) {
+      filename = copyURL.split("/").pop();
+      prefix = copyURL.replace(filename, "");
+      if (prefix.charAt(0) === "/") {
+        prefix = prefix.substring(1);
+      }
+    }
+    if ((attr === "featured" || attr === "featuredStatic") && !!siteId.length) {
+      prefix = `${pathPrefix}/${type}/${siteId}/${prefix}`;
+    }
+
+    try {
+      await Storage.configure({
+        customPrefix: {
+          public: prefix
+        }
+      });
+
+      let copyLink = await Storage.get(filename);
+
+      if (type === "audio") {
+        copyLink = copyLink.replace(/%20/g, "+");
+      }
+      stateObj[stateAttr] = copyLink;
+      component.setState(stateObj);
+      return copyLink;
+    } catch (e) {
+      console.error(e);
+    }
+  }
+}

--- a/src/lib/MetadataRenderer.js
+++ b/src/lib/MetadataRenderer.js
@@ -55,14 +55,12 @@ function yearmonthDate(date) {
 }
 
 export function collectionSizeText(collection) {
-  let subCollections = null;
-  subCollections =
-    collection.subCollection_total != null ? collection.subCollection_total : 0;
-  let archives = collection.archives || 0;
+  let subCollections = collection?.subCollection_total?.toString() || "1";
+  let archives = collection?.archives?.toString() || "0";
   return (
     <div>
-      {subCollections > 0 && <div>Collections: {subCollections}</div>}
-      {archives > 0 && <div>Items: {archives}</div>}
+      {<div id="num-collections">Collections: {subCollections}</div>}
+      {<div id="num-archives">Items: {archives}</div>}
     </div>
   );
 }
@@ -177,8 +175,9 @@ function textFormat(item, attr, languages, collectionCustomKey, site) {
   } else if (attr === "display_date" || attr === "start_date") {
     return dateFormatted(item);
   } else if (attr === "size") {
-    if (category === "collection") return collectionSizeText(item);
-    else return 0;
+    if (category === "collection") {
+      return collectionSizeText(item);
+    } else return 0;
   } else {
     return item[attr];
   }

--- a/src/pages/HomePage.js
+++ b/src/pages/HomePage.js
@@ -11,6 +11,25 @@ import CollectionHighlights from "./home/CollectionHighlights";
 import "../css/HomePage.scss";
 
 class HomePage extends Component {
+  constructor(props) {
+    super(props);
+    this.state = {
+      staticImgLoaded: false,
+      hasMediaSection: false
+    };
+  }
+
+  hasMediaSection() {
+    const homePageInfo = JSON.parse(this.props.site.homePage);
+    return !!(
+      homePageInfo.mediaSection &&
+      homePageInfo.mediaSection.link &&
+      homePageInfo.mediaSection.mediaEmbed &&
+      homePageInfo.mediaSection.title &&
+      homePageInfo.mediaSection.text
+    );
+  }
+
   getStyles = styles => {
     let titleStyle = {
       fontFamily: styles.titleFont || "crimson-text, serif",
@@ -18,6 +37,29 @@ class HomePage extends Component {
     };
     return titleStyle;
   };
+
+  staticImgLoaded = () => {
+    this.setState({ staticImgLoaded: true });
+    return true;
+  };
+
+  componentDidUpdate(prevProps) {
+    const homePageInfo = JSON.parse(this.props.site.homePage);
+    const prevHomePage = JSON.parse(prevProps.site.homePage);
+    if (
+      prevHomePage?.mediaSection?.link !== homePageInfo?.mediaSection?.link ||
+      prevHomePage?.mediaSection?.mediaEmbed !==
+        homePageInfo?.mediaSection?.mediaEmbed ||
+      prevHomePage?.mediaSection?.title !== homePageInfo?.mediaSection?.title ||
+      prevHomePage?.mediaSection?.text !== homePageInfo?.mediaSection?.text
+    ) {
+      this.setState({ hasMediaSection: this.hasMediaSection() });
+    }
+  }
+
+  componentDidMount() {
+    this.setState({ hasMediaSection: this.hasMediaSection() });
+  }
 
   render() {
     let featuredItems = null;
@@ -44,7 +86,11 @@ class HomePage extends Component {
         <SiteTitle siteTitle={this.props.site.siteTitle} pageTitle="Home" />
         <div className="home-wrapper">
           <div className="home-featured-image-wrapper">
-            <FeaturedStaticImage staticImage={staticImage} />
+            <FeaturedStaticImage
+              staticImage={staticImage}
+              site={this.props.site}
+              staticImgLoaded={this.staticImgLoaded.bind(this)}
+            />
             <div id="home-site-title-wrapper">
               <h1 style={this.getStyles(staticImage)}>
                 {this.props.site.siteName}
@@ -64,10 +110,27 @@ class HomePage extends Component {
             <a href="/search">View All Items</a>
             <a href="/collections">View All Collections</a>
           </div>
-          <FeaturedItems featuredItems={featuredItems} />
-          <MultimediaSection mediaSection={mediaSection} />
-          <SiteSponsors sponsors={sponsors} style={sponsorsStyle} />
-          <CollectionHighlights collectionHighlights={collectionHighlights} />
+          {this.state.staticImgLoaded && (
+            <div>
+              <FeaturedItems
+                featuredItems={featuredItems}
+                site={this.props.site}
+              />
+            </div>
+          )}
+          {this.state.hasMediaSection && (
+            <div>
+              <MultimediaSection mediaSection={mediaSection} />
+            </div>
+          )}
+          {this.state.staticImgLoaded && (
+            <div>
+              <SiteSponsors sponsors={sponsors} style={sponsorsStyle} />
+              <CollectionHighlights
+                collectionHighlights={collectionHighlights}
+              />
+            </div>
+          )}
         </div>
       </>
     );

--- a/src/pages/admin/ArchiveCollectionEdit/ArchiveForm.js
+++ b/src/pages/admin/ArchiveCollectionEdit/ArchiveForm.js
@@ -349,9 +349,8 @@ const ArchiveForm = React.memo(props => {
   };
 
   const getFileUrl = (name, value, type) => {
-    const bucket = Storage._config.AWSS3.bucket;
     const pathPrefix = `public/sitecontent/${type}/${process.env.REACT_APP_REP_TYPE.toLowerCase()}/`;
-    return `https://${bucket}.s3.amazonaws.com/${pathPrefix}${value}`;
+    return `${pathPrefix}${value}`;
   };
 
   const setSrc = (event, type, field) => {

--- a/src/pages/admin/ArchiveCollectionEdit/CollectionForm.js
+++ b/src/pages/admin/ArchiveCollectionEdit/CollectionForm.js
@@ -425,10 +425,9 @@ const CollectionForm = React.memo(props => {
   };
 
   const getFileUrl = (name, value) => {
-    const bucket = Storage._config.AWSS3.bucket;
     const folder = "image";
     const pathPrefix = `public/sitecontent/${folder}/${process.env.REACT_APP_REP_TYPE.toLowerCase()}/`;
-    return `https://${bucket}.s3.amazonaws.com/${pathPrefix}${value}`;
+    return `${pathPrefix}${value}`;
   };
 
   const setThumbnailSrc = event => {

--- a/src/pages/admin/ArchiveCollectionEdit/EditMetadata.js
+++ b/src/pages/admin/ArchiveCollectionEdit/EditMetadata.js
@@ -33,6 +33,7 @@ const EditMetadata = React.memo(props => {
           type="button"
           onClick={() => props.onAddValue(props.field)}
           className="small"
+          id={`${props.field}_add_value_button`}
         >
           Add Value
         </button>

--- a/src/pages/admin/DisplayedAttributesForm.js
+++ b/src/pages/admin/DisplayedAttributesForm.js
@@ -154,6 +154,10 @@ class DisplayedAttributesForm extends Component {
     });
 
     this.recordDeletedAttributes(historyInfo);
+
+    if (typeof this.props.siteChanged === "function") {
+      this.props.siteChanged(true);
+    }
   };
 
   handleChange = (e, { value }) => {
@@ -282,7 +286,11 @@ class DisplayedAttributesForm extends Component {
                 ? `Labels for ${attribute.field} attribute *`
                 : null;
             return (
-              <div id={`${item[0]}_${idx}_wrapper`} key={`${item[0]}_${idx}`}>
+              <div
+                id={`${item[0]}_${idx}_wrapper`}
+                className={`${item[0]}_${attribute.field}_wrapper`}
+                key={`${item[0]}_${idx}`}
+              >
                 <Form.Input
                   className="attributeLabel"
                   id={`${item[0]}_${idx}`}

--- a/src/pages/admin/MediaSectionForm.js
+++ b/src/pages/admin/MediaSectionForm.js
@@ -97,6 +97,9 @@ class MediaSectionForm extends Component {
       variables: { input: historyInfo },
       authMode: "AMAZON_COGNITO_USER_POOLS"
     });
+    if (typeof this.props.siteChanged === "function") {
+      this.props.siteChanged(true);
+    }
   };
 
   handleChange = (e, { value }) => {

--- a/src/pages/admin/PodcastDeposit.js
+++ b/src/pages/admin/PodcastDeposit.js
@@ -185,10 +185,9 @@ class PodcastDeposit extends Component {
   }
 
   getFileUrl(name, value) {
-    const bucket = Storage._config.AWSS3.bucket;
     const folder = this.getFolderByName(name);
     const pathPrefix = `public/sitecontent/${folder}/${process.env.REACT_APP_REP_TYPE.toLowerCase()}/`;
-    return `https://${bucket}.s3.amazonaws.com/${pathPrefix}${value}`;
+    return `${pathPrefix}${value}`;
   }
 
   setFileCharacterization(context, file) {

--- a/src/pages/admin/SiteAdmin.js
+++ b/src/pages/admin/SiteAdmin.js
@@ -70,11 +70,12 @@ class SiteAdmin extends Component {
   getForm = () => {
     const formProps = {
       site: this.state.site,
-      updateSite: this.updateSiteHandler
+      updateSite: this.updateSiteHandler,
+      siteChanged: this.props.siteChanged
     };
     switch (this.state.form) {
       case "site":
-        return <SiteForm />;
+        return <SiteForm siteChanged={this.props.siteChanged} />;
       case "contentUpload":
         return <ContentUpload {...formProps} />;
       case "sitePages":
@@ -86,9 +87,9 @@ class SiteAdmin extends Component {
       case "browseCollections":
         return <BrowseCollectionsForm {...formProps} />;
       case "displayedAttributes":
-        return <DisplayedAttributesForm />;
+        return <DisplayedAttributesForm siteChanged={this.props.siteChanged} />;
       case "mediaSection":
-        return <MediaSectionForm />;
+        return <MediaSectionForm siteChanged={this.props.siteChanged} />;
       case "updateArchive":
         return <IdentifierForm type="archive" identifier={null} />;
       case "collectionForm":
@@ -98,7 +99,7 @@ class SiteAdmin extends Component {
       case "CSVExport":
         return <CSVExport />;
       default:
-        return <SiteForm />;
+        return <SiteForm siteChanged={this.props.siteChanged} />;
     }
   };
 
@@ -131,6 +132,9 @@ class SiteAdmin extends Component {
       variables: { input: historyInfo },
       authMode: "AMAZON_COGNITO_USER_POOLS"
     });
+    if (typeof this.props.siteChanged === "function") {
+      this.props.siteChanged(true);
+    }
   };
 
   componentDidMount() {
@@ -143,13 +147,21 @@ class SiteAdmin extends Component {
       <div className="row admin-wrapper">
         <div className="col-lg-3 col-sm-12 admin-sidebar">
           <ul>
-            <li className={this.state.form === "site" ? "admin-active" : ""}>
+            <li
+              className={
+                this.state.form === "site" ? "admin-active site" : "site"
+              }
+            >
               <Link onClick={() => this.setForm("site")} to={"/siteAdmin"}>
                 General Site Config
               </Link>
             </li>
             <li
-              className={this.state.form === "sitePages" ? "admin-active" : ""}
+              className={
+                this.state.form === "sitePages"
+                  ? "admin-active sitePages"
+                  : "sitePages"
+              }
             >
               <Link onClick={() => this.setForm("sitePages")} to={"/siteAdmin"}>
                 Site Pages Config
@@ -157,7 +169,9 @@ class SiteAdmin extends Component {
             </li>
             <li
               className={
-                this.state.form === "contentUpload" ? "admin-active" : ""
+                this.state.form === "contentUpload"
+                  ? "admin-active contentUpload"
+                  : "contentUpload"
               }
             >
               <Link
@@ -168,14 +182,22 @@ class SiteAdmin extends Component {
               </Link>
             </li>
             <li
-              className={this.state.form === "homepage" ? "admin-active" : ""}
+              className={
+                this.state.form === "homepage"
+                  ? "admin-active homepage"
+                  : "homepage"
+              }
             >
               <Link onClick={() => this.setForm("homepage")} to={"/siteAdmin"}>
                 Homepage Config
               </Link>
             </li>
             <li
-              className={this.state.form === "searchPage" ? "admin-active" : ""}
+              className={
+                this.state.form === "searchPage"
+                  ? "admin-active searchPage"
+                  : "searchPage"
+              }
             >
               <Link
                 onClick={() => this.setForm("searchPage")}
@@ -186,7 +208,9 @@ class SiteAdmin extends Component {
             </li>
             <li
               className={
-                this.state.form === "browseCollections" ? "admin-active" : ""
+                this.state.form === "browseCollections"
+                  ? "admin-active browseCollections"
+                  : "browseCollections"
               }
             >
               <Link
@@ -198,7 +222,9 @@ class SiteAdmin extends Component {
             </li>
             <li
               className={
-                this.state.form === "displayedAttributes" ? "admin-active" : ""
+                this.state.form === "displayedAttributes"
+                  ? "admin-active displayedAttributes"
+                  : "displayedAttributes"
               }
             >
               <Link
@@ -210,7 +236,9 @@ class SiteAdmin extends Component {
             </li>
             <li
               className={
-                this.state.form === "mediaSection" ? "admin-active" : ""
+                this.state.form === "mediaSection"
+                  ? "admin-active mediaSection"
+                  : "mediaSection"
               }
             >
               <Link
@@ -222,7 +250,9 @@ class SiteAdmin extends Component {
             </li>
             <li
               className={
-                this.state.form === "updateArchive" ? "admin-active" : ""
+                this.state.form === "updateArchive"
+                  ? "admin-active updateArchive"
+                  : "updateArchive"
               }
             >
               <Link
@@ -234,7 +264,9 @@ class SiteAdmin extends Component {
             </li>
             <li
               className={`collectionFormLink ${
-                this.state.form === "collectionForm" ? " admin-active" : ""
+                this.state.form === "collectionForm"
+                  ? " admin-active collectionForm"
+                  : "collectionForm"
               }`}
             >
               <Link
@@ -261,7 +293,11 @@ class SiteAdmin extends Component {
               </li>
             )}
             <li
-              className={this.state.form === "CSVExport" ? "admin-active" : ""}
+              className={
+                this.state.form === "CSVExport"
+                  ? "admin-active CSVExport"
+                  : "CSVExport"
+              }
             >
               <Link onClick={() => this.setForm("CSVExport")} to={"/siteAdmin"}>
                 CSV Export

--- a/src/pages/admin/SiteForm.js
+++ b/src/pages/admin/SiteForm.js
@@ -173,6 +173,9 @@ class SiteForm extends Component {
       variables: { input: historyInfo },
       authMode: "AMAZON_COGNITO_USER_POOLS"
     });
+    if (typeof this.props.siteChanged === "function") {
+      this.props.siteChanged(true);
+    }
   };
 
   handleChange = (e, { value }) => {

--- a/src/pages/admin/SitePagesForm.js
+++ b/src/pages/admin/SitePagesForm.js
@@ -54,10 +54,9 @@ class SitePagesForm extends Component {
   }
 
   getFileUrl(value) {
-    const bucket = Storage._config.AWSS3.bucket;
     const folder = this.state.fileFolder;
     const pathPrefix = `public/sitecontent/${folder}/${process.env.REACT_APP_REP_TYPE.toLowerCase()}/`;
-    return `https://${bucket}.s3.amazonaws.com/${pathPrefix}${value}`;
+    return `${pathPrefix}${value}`;
   }
 
   updateInputValue = event => {
@@ -169,6 +168,9 @@ class SitePagesForm extends Component {
       variables: { input: historyInfo },
       authMode: "AMAZON_COGNITO_USER_POOLS"
     });
+    if (typeof this.props.siteChanged === "function") {
+      this.props.siteChanged(true);
+    }
   };
 
   handleChange = (e, { value }) => {

--- a/src/pages/archives/ArchivePage.js
+++ b/src/pages/archives/ArchivePage.js
@@ -178,6 +178,7 @@ class ArchivePage extends Component {
           item={item}
           imgURL={item.manifest_url}
           altText={item.title}
+          site={this.props.site}
         />
       );
     } else if (this.isAudioURL(item.manifest_url)) {
@@ -233,8 +234,7 @@ class ArchivePage extends Component {
   }
 
   fileNameFromUrl(manifest_url) {
-    let url = new URL(manifest_url);
-    return url.pathname.split("/").reverse()[0];
+    return manifest_url.split("/").pop();
   }
 
   findResourceType() {
@@ -264,6 +264,7 @@ class ArchivePage extends Component {
         controls
         width="100%"
         height="640"
+        site={this.props.site}
         poster={tracks[0].poster}
         sources={JSON.stringify(srcArray)}
         options={JSON.stringify(config)}
@@ -279,6 +280,7 @@ class ArchivePage extends Component {
         controls
         width="100%"
         height="640"
+        site={this.props.site}
         poster={tracks[0].poster}
         sources={JSON.stringify(srcArray)}
         options={JSON.stringify(config)}
@@ -400,7 +402,7 @@ class ArchivePage extends Component {
               </table>
             </div>
           </div>
-          <RelatedItems collection={this.state.item} />
+          <RelatedItems collection={this.state.item} site={this.props.site} />
         </div>
       );
     } else {

--- a/src/pages/collections/CollectionItemsList.js
+++ b/src/pages/collections/CollectionItemsList.js
@@ -25,7 +25,11 @@ class CollectionItemsList extends Component {
                 <div key={item.identifier} className="collection-entry">
                   <NavLink to={`/archive/${arkLinkFormatted(item.custom_key)}`}>
                     <div className="collection-img">
-                      <Thumbnail item={item} category="archive" />
+                      <Thumbnail
+                        item={item}
+                        site={this.props.site}
+                        category="archive"
+                      />
                     </div>
                     <div className="collection-details">
                       <h3>{item.title}</h3>
@@ -46,7 +50,11 @@ class CollectionItemsList extends Component {
                   <div className="collection-item-wrapper">
                     <a href={`/archive/${arkLinkFormatted(item.custom_key)}`}>
                       <div className="item-image">
-                        <Thumbnail item={item} category="archive" />
+                        <Thumbnail
+                          item={item}
+                          site={this.props.site}
+                          category="archive"
+                        />
                       </div>
                       <div className="item-info">
                         <h3>{item.title}</h3>

--- a/src/pages/collections/CollectionsShowPage.js
+++ b/src/pages/collections/CollectionsShowPage.js
@@ -358,7 +358,7 @@ class CollectionsShowPage extends Component {
             collectionOptions={JSON.parse(
               this.state.collection.collectionOptions
             )}
-            siteId={this.props.site.siteId}
+            site={this.props.site}
             headings={this.getHeadings()}
           />
           {viewOption === "list" ? (

--- a/src/pages/home/FeaturedItem.js
+++ b/src/pages/home/FeaturedItem.js
@@ -1,23 +1,45 @@
 import React, { Component } from "react";
-import { getFile } from "../../lib/fetchTools";
+import FileGetter from "../../lib/FileGetter";
 
 class FeaturedItem extends Component {
   constructor(props) {
     super(props);
     this.state = {
-      copy: null
+      featured: null
     };
+    this.fileGetter = null;
   }
 
+  getFeaturedItem = async () => {
+    const imgUrl = this.props.tile.src;
+    this.fileGetter = new FileGetter();
+    await this.fileGetter.getFile(
+      imgUrl,
+      "image",
+      this,
+      "featured",
+      this.props?.site?.siteId,
+      "public/sitecontent"
+    );
+    this.fileGetter = null;
+  };
+
   componentDidUpdate(prevProps) {
-    if (this.props.tile && this.props !== prevProps) {
-      const imgUrl = this.props.tile.src;
-      getFile(imgUrl, "image", this);
+    if (this?.props?.tile !== prevProps?.tile) {
+      this.getFeaturedItem();
     }
   }
 
+  componentDidMount() {
+    this.getFeaturedItem();
+  }
+
+  componentWillUnmount() {
+    this.fileGetter = null;
+  }
+
   render() {
-    if (this.props.tile && this.state.copy) {
+    if (this.props.tile && this.state.featured) {
       return (
         <div
           className="col-md-6 col-lg-3"
@@ -30,7 +52,7 @@ class FeaturedItem extends Component {
         >
           <a href={this.props.tile.link}>
             <div className="card">
-              <img className="card-img-top" src={this.state.copy} alt="" />
+              <img className="card-img-top" src={this.state.featured} alt="" />
               <div className="card-body">
                 <h3 className="card-title crop-text-4">
                   {this.props.tile.cardTitle}

--- a/src/pages/home/FeaturedItems.js
+++ b/src/pages/home/FeaturedItems.js
@@ -69,6 +69,7 @@ class FeaturedItems extends Component {
             tile={item}
             position={this.state.startIndex + index + 1}
             length={this.props.featuredItems.length}
+            site={this.props.site}
           />
         );
       });

--- a/src/pages/home/FeaturedStaticImage.js
+++ b/src/pages/home/FeaturedStaticImage.js
@@ -1,27 +1,55 @@
 import React, { Component } from "react";
-import { getFile } from "../../lib/fetchTools";
+import FileGetter from "../../lib/FileGetter";
 import "../../css/FeaturedStaticImage.scss";
 
 class FeaturedStaticImage extends Component {
   constructor(props) {
     super(props);
     this.state = {
-      copy: null
+      featuredStatic: null
     };
+    this.fileGetter = null;
+  }
+
+  getStaticImage = async () => {
+    const imgUrl = this.props.staticImage.src.split("/").pop();
+    this.fileGetter = new FileGetter();
+    await this.fileGetter.getFile(
+      imgUrl,
+      "image",
+      this,
+      "featuredStatic",
+      this.props?.site?.siteId,
+      "public/sitecontent"
+    );
+    this.fileGetter = null;
+    this.props.staticImgLoaded();
+  };
+
+  componentDidUpdate(prevProps) {
+    if (this.props.staticImage.src !== prevProps.staticImage.src) {
+      this.getStaticImage();
+    }
   }
 
   componentDidMount() {
     if (this.props.staticImage) {
-      const imgUrl = this.props.staticImage.src.split("/").pop();
-      getFile(imgUrl, "image", this);
+      this.getStaticImage();
     }
   }
 
+  componentWillUnmount() {
+    this.fileGetter = null;
+  }
+
   render() {
-    if (this.props.staticImage && this.state.copy) {
+    if (this.props.staticImage && this.state.featuredStatic) {
       return (
         <div className="home-static-image-wrapper">
-          <img src={this.state.copy} alt={this.props.staticImage.altText} />
+          <img
+            src={this.state.featuredStatic}
+            alt={this.props.staticImage.altText}
+          />
         </div>
       );
     } else {

--- a/src/pages/home/MultimediaSection.js
+++ b/src/pages/home/MultimediaSection.js
@@ -3,56 +3,40 @@ import React, { Component } from "react";
 import "../../css/MultimediaSection.scss";
 
 class MultimediaSection extends Component {
-  hasMediaSection() {
-    return !!(
-      this.props.mediaSection &&
-      this.props.mediaSection.link &&
-      this.props.mediaSection.mediaEmbed &&
-      this.props.mediaSection.title &&
-      this.props.mediaSection.text
-    );
-  }
-
   render() {
-    if (this.hasMediaSection()) {
-      return (
-        <div
-          className="row media-section-wrapper"
-          role="region"
-          aria-labelledby="multimedia-region"
-        >
-          <div className="col-lg-6">
-            <div
-              className="multimedia-column"
-              dangerouslySetInnerHTML={{
-                __html: this.props.mediaSection.mediaEmbed
-              }}
-            ></div>
-          </div>
-          <div className="col-lg-6">
-            <div className="multimedia-text-column">
-              <div className="media-section-title-wrapper">
-                <h2 id="multimedia-region">{this.props.mediaSection.title}</h2>
-              </div>
-              <div className="media-section-divider"></div>
-              <p className="media-section-text">
-                {this.props.mediaSection.text}
-              </p>
-              <a
-                className="media-section-link"
-                href={this.props.mediaSection.link}
-                target="_blank"
-                rel="noopener noreferrer"
-              >
-                Learn More
-              </a>
+    return (
+      <div
+        className="row media-section-wrapper"
+        role="region"
+        aria-labelledby="multimedia-region"
+      >
+        <div className="col-lg-6">
+          <div
+            className="multimedia-column"
+            dangerouslySetInnerHTML={{
+              __html: this.props.mediaSection.mediaEmbed
+            }}
+          ></div>
+        </div>
+        <div className="col-lg-6">
+          <div className="multimedia-text-column">
+            <div className="media-section-title-wrapper">
+              <h2 id="multimedia-region">{this.props.mediaSection.title}</h2>
             </div>
+            <div className="media-section-divider"></div>
+            <p className="media-section-text">{this.props.mediaSection.text}</p>
+            <a
+              className="media-section-link"
+              href={this.props.mediaSection.link}
+              target="_blank"
+              rel="noopener noreferrer"
+            >
+              Learn More
+            </a>
           </div>
         </div>
-      );
-    } else {
-      return <></>;
-    }
+      </div>
+    );
   }
 }
 

--- a/src/pages/search/GalleryView.js
+++ b/src/pages/search/GalleryView.js
@@ -16,6 +16,7 @@ const GalleryView = props => {
             category={props.category}
             className="card-img-top"
             label={props.label}
+            site={props.site}
           />
           <div className="card-body">
             <h3 className="card-title crop-text-3">{props.item.title}</h3>

--- a/src/pages/search/ItemListView.js
+++ b/src/pages/search/ItemListView.js
@@ -36,6 +36,7 @@ class ItemListView extends Component {
                 item={this.props.item}
                 category={this.props.category}
                 label={this.props.label}
+                site={this.props.site}
               />
             </div>
             <div className="collection-details">

--- a/src/pages/search/ItemsList.js
+++ b/src/pages/search/ItemsList.js
@@ -30,6 +30,7 @@ class ItemsList extends Component {
                   item={item}
                   category={getCategory(item)}
                   label={true}
+                  site={this.props.site}
                 />
               );
             } else if (this.props.view === "Masonry") {
@@ -39,6 +40,7 @@ class ItemsList extends Component {
                   item={item}
                   category={getCategory(item)}
                   label={true}
+                  site={this.props.site}
                 />
               );
             } else {
@@ -48,6 +50,7 @@ class ItemsList extends Component {
                   item={item}
                   category={getCategory(item)}
                   label={true}
+                  site={this.props.site}
                 />
               );
             }

--- a/src/pages/search/SearchResults.js
+++ b/src/pages/search/SearchResults.js
@@ -220,7 +220,11 @@ class SearchResults extends Component {
                     <FiltersDisplay />
                   </div>
                 </div>
-                <ItemsList items={this.props.items} view={this.props.view} />
+                <ItemsList
+                  items={this.props.items}
+                  site={this.props.site}
+                  view={this.props.view}
+                />
               </div>
             </div>
             <div aria-live="polite">


### PR DESCRIPTION
**Handles asset relative-urls with no domain to make site backend env agnostic**
* * *

**JIRA Ticket**: ([link](https://webapps.es.vt.edu/jira/browse/LIBTD-2643)) (:star:)

* Other Relevant Links (Meeting note, project page, related pull requests, etc.)

# What does this Pull Request do? (:star:)
Handles asset relative-urls with no domain so that DB records don't point to old (and possibly deleted) s3 buckets that the app does not have access to. This PR also updates a boatload of tests and refactors code to support more reliable testing. Finally, this PR refactors the admin section to notify the application when a site record gets modified so that the application can fetch the newest version

# What's the changes? (:star:)
* Adds domain to relative urls in the database so that application will request them from the correct bucket
* Refactors to save urls to DB without domain attached
* Refactor tests to be more reliable
* Refactor admin section to notify application of changes to site record so that application can fetch changes.

# How should this be tested?
* Check that assets continue to load correctly
* Check that multi-media section on homepage updates immediately after changes to the "Homepage Media Section" form without a browser refresh.

# Additional Notes:
Any additional information that you think would be helpful when reviewing this PR.

* branch: `LIBTD-2643`

# Interested parties
@andreaWaldren 

(:star:) Required fields
