### PR TITLE
Refactor the FileGetter class to allow removal of Storage.configure() calls.

### DIFF
--- a/src/App.js
+++ b/src/App.js
@@ -1,4 +1,5 @@
 import React, { Component } from "react";
+import { Storage } from "aws-amplify";
 import { BrowserRouter as Router, Route, Switch } from "react-router-dom";
 import ScrollToTop from "./lib/ScrollToTop";
 import RouteListener from "./lib/RouteListener";
@@ -76,6 +77,14 @@ class App extends Component {
     this.setState({ siteChanged: changed });
   };
 
+  configureStorage = () => {
+    Storage.configure({
+      customPrefix: {
+        public: ""
+      }
+    });
+  };
+
   componentDidUpdate() {
     if (this.state.siteChanged) {
       this.loadSite();
@@ -84,6 +93,7 @@ class App extends Component {
   }
 
   componentDidMount() {
+    this.configureStorage();
     this.loadSite();
   }
 

--- a/src/components/CollectionTopContent.js
+++ b/src/components/CollectionTopContent.js
@@ -1,7 +1,5 @@
 import React, { Component } from "react";
 import { addNewlineInDesc } from "../lib/MetadataRenderer";
-import { Storage } from "aws-amplify";
-import { getFile } from "../lib/fetchTools";
 import "../css/CollectionsShowPage.scss";
 import FileGetter from "../lib/FileGetter";
 
@@ -95,7 +93,6 @@ class CollectionTopContent extends Component {
             />
           </a>
         </li>`;
-
     return rssLinks;
   }
 
@@ -302,50 +299,41 @@ class CollectionTopContent extends Component {
     }
   }
 
-  async getWebFeed() {
+  getWebFeed = async () => {
+    let signed;
     if (this.props.siteId === "podcasts") {
-      let webFeed = null;
-      if (
-        this.props.collectionOptions &&
-        this.props.collectionOptions.webFeed
-      ) {
-        webFeed = this.props.collectionOptions.webFeed;
-      } else {
-        webFeed = `https://${
-          Storage._config.AWSS3.bucket
-        }.s3.amazonaws.com/public/sitecontent/text/${process.env.REACT_APP_REP_TYPE.toLowerCase()}/rss/${
-          this.props.customKey
-        }.rss`;
-      }
-      if (webFeed) {
-        getFile(webFeed, "text", this, "rss");
-      }
+      signed = await this.fileGetter.getFile(
+        `rss/${this.props.customKey}.rss`,
+        "text",
+        this,
+        "webFeed",
+        this.props.siteId,
+        "public/sitecontent"
+      );
     }
-  }
+    return signed;
+  };
+
+  getSignedThumbnailLink = () => {
+    this.fileGetter.getFile(
+      this.props.collectionImg,
+      "image",
+      this,
+      "collectionThumbnail",
+      this.props.siteId,
+      "public/sitecontent"
+    );
+  };
 
   componentDidUpdate(prevProps) {
     if (this.props.collectionImg !== prevProps.collectionImg) {
-      this.fileGetter.getFile(
-        this.props.collectionImg,
-        "image",
-        this,
-        "collectionThumbnail",
-        this.props.site.siteId,
-        "public/sitecontent"
-      );
+      this.getSignedThumbnailLink();
     }
   }
 
   componentDidMount() {
     if (this.props.collectionImg) {
-      this.fileGetter.getFile(
-        this.props.collectionImg,
-        "image",
-        this,
-        "collectionThumbnail",
-        this.props.site.siteId,
-        "public/sitecontent"
-      );
+      this.getSignedThumbnailLink();
     }
     this.getWebFeed();
   }
@@ -380,9 +368,7 @@ class CollectionTopContent extends Component {
           </div>
           {this.props.siteId === "podcasts" ? (
             <ul className="feed-links">
-              {this.props.collectionOptions &&
-              this.props.collectionOptions.podcast_links &&
-              this.props.collectionOptions.podcast_links.length ? (
+              {this?.props?.collectionOptions?.podcast_links?.length ? (
                 this.getFeeds()
               ) : (
                 <></>

--- a/src/components/DownloadLinks.js
+++ b/src/components/DownloadLinks.js
@@ -6,13 +6,28 @@ const DownloadLinks = ({ title, links }) => {
   const [linkElements, setLinkElements] = useState([]);
 
   useEffect(() => {
+    const createLinksSection = async () => {
+      let linksList = [];
+      for (const size in links) {
+        const signedLink = await fetchSignedLink(links[size]);
+        const fileName = links[size].split("/").pop();
+        if (size && signedLink?.data?.length && fileName) {
+          linksList.push(
+            <li key={size}>
+              {size}: <a href={signedLink.data}>{fileName}</a>
+            </li>
+          );
+        }
+      }
+      setLinkElements(linksList.sort(sortLinks).reverse());
+    };
     createLinksSection();
   }, [title, links]);
 
   const linksExist = () => {
     let exist = false;
     linkElements.forEach(link => {
-      if (link.type == "li") {
+      if (link.type === "li") {
         exist = true;
       }
     });
@@ -29,21 +44,21 @@ const DownloadLinks = ({ title, links }) => {
     return retVal;
   };
 
-  const createLinksSection = async () => {
-    let linksList = [];
-    for (const size in links) {
-      const signedLink = await fetchSignedLink(links[size]);
-      const fileName = links[size].split("/").pop();
-      if (size && signedLink?.data?.length && fileName) {
-        linksList.push(
-          <li key={size}>
-            {size}: <a href={signedLink.data}>{fileName}</a>
-          </li>
-        );
-      }
-    }
-    setLinkElements(linksList.sort(sortLinks).reverse());
-  };
+  // const createLinksSection = async () => {
+  //   let linksList = [];
+  //   for (const size in links) {
+  //     const signedLink = await fetchSignedLink(links[size]);
+  //     const fileName = links[size].split("/").pop();
+  //     if (size && signedLink?.data?.length && fileName) {
+  //       linksList.push(
+  //         <li key={size}>
+  //           {size}: <a href={signedLink.data}>{fileName}</a>
+  //         </li>
+  //       );
+  //     }
+  //   }
+  //   setLinkElements(linksList.sort(sortLinks).reverse());
+  // };
   let downloadLinks = null;
   if (linksExist()) {
     downloadLinks = (

--- a/src/components/FileUploadField.js
+++ b/src/components/FileUploadField.js
@@ -82,13 +82,9 @@ class FileUploadField extends Component {
       const folder = this.folderNameByFileType(this.state.file);
       const pathPrefix = `public/sitecontent/${folder}/${process.env.REACT_APP_REP_TYPE.toLowerCase()}/`;
       const prefixFolder = this.props.filepath ? `${this.props.filepath}/` : "";
-      Storage.configure({
-        customPrefix: {
-          public: `${pathPrefix}${prefixFolder}`
-        }
-      });
+      const s3Key = `${pathPrefix}${prefixFolder}${this.state.file.name}`;
 
-      await Storage.put(this.state.file.name, this.state.file, {
+      await Storage.put(s3Key, this.state.file, {
         contentType: this.state.file.type
       });
       const evt = {

--- a/src/components/MediaElement.js
+++ b/src/components/MediaElement.js
@@ -5,7 +5,6 @@ import "mediaelement";
 import { FontAwesomeIcon } from "@fortawesome/react-fontawesome";
 import "mediaelement/build/mediaelementplayer.min.css";
 import "mediaelement/build/mediaelement-flash-video.swf";
-import { asyncGetFile } from "../lib/fetchTools";
 import FileGetter from "../lib/FileGetter";
 
 export default class MediaElement extends Component {
@@ -19,6 +18,7 @@ export default class MediaElement extends Component {
       transcript: null,
       isTranscriptActive: false
     };
+    this.fileGetter = new FileGetter();
   }
 
   success(media, node, instance) {
@@ -35,19 +35,27 @@ export default class MediaElement extends Component {
     let audioResponse = null;
     if (sources[0].src) {
       const audioUrl = sources[0].src;
-      audioResponse = await fileGetter.getFile(
-        audioUrl,
+      const audioFilename = audioUrl.split("/").pop();
+      audioResponse = await this.fileGetter.getFile(
+        audioFilename,
         "audio",
         this,
         "audioSrc",
         this.props.site.siteId,
-        ""
+        "public/sitecontent"
       );
     }
-    if (!!audioResponse) {
+    if (!!audioResponse.length) {
       const tracks = JSON.parse(this.props.tracks);
       const captionSrc = tracks[0].src;
-      await asyncGetFile(captionSrc, "audio", this, "captionSrc");
+      await this.fileGetter.getFile(
+        captionSrc,
+        "audio",
+        this,
+        "captionSrc",
+        this.props.site.siteId,
+        "public/sitecontent"
+      );
     }
     if (!!audioResponse && this.props.poster) {
       await fileGetter.getFile(

--- a/src/components/PodcastMediaElement.js
+++ b/src/components/PodcastMediaElement.js
@@ -35,15 +35,16 @@ export default class PodcastMediaElement extends Component {
     if (this.props.tracks) {
       const tracks = JSON.parse(this.props.tracks);
       const captionSrc = tracks[0].src;
+      const captionFilename = captionSrc.split("/").pop();
       const captionGetter = new FileGetter();
-      const signedCaption = await captionGetter.getFile(
-        captionSrc,
+      await captionGetter.getFile(
+        captionFilename,
         "text",
         this,
         "captionSrc",
-        this.props.site.siteId
+        this.props.site.siteId,
+        "public/sitecontent"
       );
-      console.log("signedCaption", signedCaption);
     }
     if (this.props.poster) {
       const thumbGetter = new FileGetter();
@@ -52,17 +53,20 @@ export default class PodcastMediaElement extends Component {
         "image",
         this,
         "audioImg",
-        this.props.site.siteId
+        this.props.site.siteId,
+        "public/sitecontent"
       );
     }
-    if (this.props?.transcript?.audioTranscript) {
+    if (this?.props?.transcript?.audioTranscript) {
       const textGetter = new FileGetter();
+      const transcriptUrl = this.props.transcript.audioTranscript;
       await textGetter.getFile(
-        this.props.transcript.audioTranscript,
+        transcriptUrl,
         "text",
         this,
         "transcript",
-        this.props.site.siteId
+        this.props.site.siteId,
+        "public/sitecontent"
       );
     }
     if (sources[0].src) {
@@ -73,7 +77,8 @@ export default class PodcastMediaElement extends Component {
         "audio",
         this,
         "audioSrc",
-        this.props.site.siteId
+        this.props.site.siteId,
+        "public/sitecontent"
       );
     }
     return audioResponse;
@@ -86,6 +91,7 @@ export default class PodcastMediaElement extends Component {
       if (!MediaElementPlayer) {
         return;
       }
+
       const options = Object.assign({}, JSON.parse(this.props.options), {
         pluginPath: "./static/media/",
         success: (media, node, instance) => this.success(media, node, instance),

--- a/src/components/Thumbnail.js
+++ b/src/components/Thumbnail.js
@@ -11,7 +11,7 @@ class Thumbnail extends Component {
     this.fileGetter = new FileGetter();
   }
 
-  labelDisplay() {
+  labelDisplay = () => {
     if (this.props.label) {
       return (
         <div className={`${this.props.category}-label`}>
@@ -21,34 +21,35 @@ class Thumbnail extends Component {
     } else {
       return <></>;
     }
-  }
+  };
+
+  getSignedThumbnailLink = imgURL => {
+    if (imgURL.length) {
+      const fileGetter = new FileGetter();
+      fileGetter.getFile(
+        imgURL,
+        "image",
+        this,
+        "thumbnailImg",
+        this?.props?.site?.siteId,
+        "public/sitecontent"
+      );
+    }
+  };
 
   componentDidUpdate(prevProps) {
     const prevImgURL = prevProps.imgURL || prevProps.item.thumbnail_path;
     const imgURL = this.props.imgURL || this.props.item.thumbnail_path;
     if (imgURL && prevImgURL !== imgURL) {
-      this.fileGetter.getFile(
-        imgURL,
-        "image",
-        this,
-        "thumbnailImg",
-        this.props.site.siteId,
-        "public/sitecontent"
-      );
+      console.log("update");
+      this.getSignedThumbnailLink(imgURL);
     }
   }
 
   componentDidMount() {
     const imgURL = this.props.imgURL || this.props.item.thumbnail_path;
     if (imgURL) {
-      this.fileGetter.getFile(
-        imgURL,
-        "image",
-        this,
-        "thumbnailImg",
-        this.props.site.siteId,
-        "public/sitecontent"
-      );
+      this.getSignedThumbnailLink(imgURL);
     }
   }
 

--- a/src/pages/AboutPage.js
+++ b/src/pages/AboutPage.js
@@ -2,7 +2,7 @@ import React, { Component } from "react";
 import { Helmet } from "react-helmet";
 import SiteTitle from "../components/SiteTitle";
 import ContactSection from "../components/ContactSection";
-import { getFile } from "../lib/fetchTools";
+import { getFileContent } from "../lib/fetchTools";
 import { buildHeaderSchema } from "../lib/richSchemaTools";
 
 import "../css/AboutPage.scss";
@@ -18,7 +18,7 @@ class AboutPage extends Component {
   componentDidMount() {
     const htmlUrl = JSON.parse(this.props.site.sitePages)[this.props.parentKey]
       .data_url;
-    getFile(htmlUrl, "html", this);
+    getFileContent(htmlUrl, "html", this);
   }
 
   render() {

--- a/src/pages/AdditionalPages.js
+++ b/src/pages/AdditionalPages.js
@@ -1,5 +1,5 @@
 import React, { Component } from "react";
-import { getFile } from "../lib/fetchTools";
+import { getFileContent } from "../lib/fetchTools";
 
 import "../css/AdditionalPages.scss";
 
@@ -17,7 +17,7 @@ class AdditionalPages extends Component {
       copyObj = copyObj.children[this.props.childKey];
     }
     const copyUrl = copyObj.data_url;
-    getFile(copyUrl, "html", this);
+    getFileContent(copyUrl, "html", this);
   }
 
   render() {

--- a/src/pages/HomePage.js
+++ b/src/pages/HomePage.js
@@ -125,9 +125,14 @@ class HomePage extends Component {
           )}
           {this.state.staticImgLoaded && (
             <div>
-              <SiteSponsors sponsors={sponsors} style={sponsorsStyle} />
+              <SiteSponsors
+                sponsors={sponsors}
+                style={sponsorsStyle}
+                site={this.props.site}
+              />
               <CollectionHighlights
                 collectionHighlights={collectionHighlights}
+                site={this.props.site}
               />
             </div>
           )}

--- a/src/pages/PermissionsPage.js
+++ b/src/pages/PermissionsPage.js
@@ -1,7 +1,7 @@
 import React, { Component } from "react";
 import SiteTitle from "../components/SiteTitle";
 import ContactSection from "../components/ContactSection";
-import { getFile } from "../lib/fetchTools";
+import { getFileContent } from "../lib/fetchTools";
 
 import "../css/TermsPage.scss";
 class PermissionsPage extends Component {
@@ -15,7 +15,7 @@ class PermissionsPage extends Component {
   componentDidMount() {
     const htmlUrl = JSON.parse(this.props.site.sitePages)[this.props.parentKey]
       .data_url;
-    getFile(htmlUrl, "html", this);
+    getFileContent(htmlUrl, "html", this);
   }
 
   render() {

--- a/src/pages/admin/ArchiveCollectionEdit/ArchiveForm.js
+++ b/src/pages/admin/ArchiveCollectionEdit/ArchiveForm.js
@@ -3,7 +3,7 @@ import { Form, Input } from "semantic-ui-react";
 import { Link } from "react-router-dom";
 import ViewMetadata from "./ViewMetadata";
 import EditMetadata from "./EditMetadata";
-import { API, Storage } from "aws-amplify";
+import { API } from "aws-amplify";
 import {
   getArchiveByIdentifier,
   getAllCollections,

--- a/src/pages/admin/ContentUpload.js
+++ b/src/pages/admin/ContentUpload.js
@@ -25,12 +25,10 @@ class ContentUpload extends Component {
   uploadFile = async () => {
     if (!this.state.hasError) {
       const folder = this.state.file.type === "text/html" ? "html" : "image";
-      Storage.configure({
-        customPrefix: {
-          public: `public/sitecontent/${folder}/${process.env.REACT_APP_REP_TYPE.toLowerCase()}/`
-        }
-      });
-      await Storage.put(this.state.file.name, this.state.file, {
+      const prefix = `public/sitecontent/${folder}/${process.env.REACT_APP_REP_TYPE.toLowerCase()}`;
+      const s3Key = `${prefix}/${this.state.file.name}`;
+
+      await Storage.put(s3Key, this.state.file, {
         contentType: this.state.file.type
       });
       const eventInfo = {

--- a/src/pages/admin/PodcastDeposit.js
+++ b/src/pages/admin/PodcastDeposit.js
@@ -2,7 +2,7 @@ import React, { Component } from "react";
 import { Authenticator, withAuthenticator } from "@aws-amplify/ui-react";
 import { Form } from "semantic-ui-react";
 import { updatedDiff } from "deep-object-diff";
-import { API, Auth, Storage } from "aws-amplify";
+import { API, Auth } from "aws-amplify";
 import {
   getArchiveByIdentifier,
   getPodcastCollections,
@@ -64,8 +64,6 @@ class PodcastDeposit extends Component {
 
   async loadPodcast() {
     let item;
-    let editableArchive = {};
-    let item_id = null;
     try {
       item = await getArchiveByIdentifier(this.props.identifier);
     } catch (e) {

--- a/src/pages/admin/SitePagesForm.js
+++ b/src/pages/admin/SitePagesForm.js
@@ -3,7 +3,7 @@ import { withAuthenticator } from "@aws-amplify/ui-react";
 import { NavLink } from "react-router-dom";
 import { Form } from "semantic-ui-react";
 import { updatedDiff } from "deep-object-diff";
-import { API, Auth, Storage } from "aws-amplify";
+import { API, Auth } from "aws-amplify";
 import { getSite } from "../../lib/fetchTools";
 import { input } from "../../components/FormFields";
 import * as mutations from "../../graphql/mutations";

--- a/src/pages/archives/ArchivePage.js
+++ b/src/pages/archives/ArchivePage.js
@@ -271,6 +271,7 @@ class ArchivePage extends Component {
         tracks={JSON.stringify(tracks)}
         title={title}
         transcript={JSON.parse(this.state.item.archiveOptions)}
+        site={this.props.site}
       />
     ) : (
       <PodcastMediaElement
@@ -287,6 +288,7 @@ class ArchivePage extends Component {
         tracks={JSON.stringify(tracks)}
         title={title}
         transcript={JSON.parse(this.state.item.archiveOptions)}
+        site={this.props.site}
       />
     );
   }

--- a/src/pages/home/CollectionHighlights.js
+++ b/src/pages/home/CollectionHighlights.js
@@ -1,5 +1,5 @@
 import React, { Component } from "react";
-import { getImgUrl } from "../../lib/fetchTools";
+import FileGetter from "../../lib/FileGetter";
 
 import "../../css/CollectionHighlights.scss";
 
@@ -11,17 +11,29 @@ class CollectionHighlights extends Component {
     };
   }
 
-  componentDidMount() {
-    if (this.props.collectionHighlights) {
-      this.props.collectionHighlights.map(item => {
-        return getImgUrl(item.src).then(src => {
-          const imgUrls = this.state.highlightImgs.slice();
-          imgUrls.push(src);
-          this.setState({ highlightImgs: imgUrls });
-        });
-      });
+  getSignedLinks = async () => {
+    const highlights = this.props.collectionHighlights;
+    const imgUrls = [];
+    for (const highlight in highlights) {
+      const fileGetter = new FileGetter();
+      const highlightImgSrc = await fileGetter.getFile(
+        highlights[highlight].src,
+        "image",
+        this,
+        "highlights",
+        this.props?.site?.siteId,
+        "public/sitecontent"
+      );
+      imgUrls.push(highlightImgSrc);
     }
-  }
+    this.setState({ highlightImgs: imgUrls });
+  };
+
+  componentDidMount = async () => {
+    if (this.props.collectionHighlights) {
+      this.getSignedLinks();
+    }
+  };
 
   render() {
     if (

--- a/src/pages/home/SiteSponsors.js
+++ b/src/pages/home/SiteSponsors.js
@@ -1,5 +1,5 @@
 import React, { Component } from "react";
-import { getImgUrl } from "../../lib/fetchTools";
+import FileGetter from "../../lib/FileGetter";
 
 import "../../css/SiteSponsors.scss";
 
@@ -11,15 +11,27 @@ class SiteSponsors extends Component {
     };
   }
 
+  getSignedLinks = async () => {
+    const sponsors = this.props.sponsors;
+    const imgUrls = [];
+    for (const sponsor in sponsors) {
+      const fileGetter = new FileGetter();
+      const sponsorImgSrc = await fileGetter.getFile(
+        sponsors[sponsor].src,
+        "image",
+        this,
+        "sponsors",
+        this.props?.site?.siteId,
+        "public/sitecontent"
+      );
+      imgUrls.push(sponsorImgSrc);
+    }
+    this.setState({ sponsorImgs: imgUrls });
+  };
+
   componentDidMount() {
     if (this.props.sponsors && this.props.sponsors.length !== 0) {
-      this.props.sponsors.map(sponsor => {
-        return getImgUrl(sponsor.src).then(src => {
-          const imgUrls = this.state.sponsorImgs.slice();
-          imgUrls.push(src);
-          this.setState({ sponsorImgs: imgUrls });
-        });
-      });
+      this.getSignedLinks();
     }
   }
 


### PR DESCRIPTION
**Refactor the FileGetter class to allow removal of Storage.configure() calls that can cause a race condition.**
* * *

**JIRA Ticket**: (https://webapps.es.vt.edu/jira/browse/LIBTD-2643) (:star:)

* Other Relevant Links (Meeting note, project page, related pull requests, etc.)

# What does this Pull Request do? (:star:)
Multiple async fetches from multiple components at the same time can cause a race condition when they're all trying to set the s3 "public prefix" attribute by calling Storage.configure(). This PR sets the prefix to "" (empty string) once in `App.js` and then each fetch request just includes the prefix in it's "s3 key"

# What's the changes? (:star:)
* Removes Storage.configure() calls throughout application which can conflict
* Adds ONE Storage.configure() call in `App.js` that sets public prefix to "" (empty string)
* Refactors FileGetter class to include the prefix in the s3 key of each fetch
* Refactors FileGetter class to be cleaner and more maintainable
* Removes unused code from `fetchTools.js`

# How should this be tested?
* Check for instances of failed requests for assets (img/audio/video/text). Failed requests would be either 403 or 404 responses

# Additional Notes:
Any additional information that you think would be helpful when reviewing this PR.
* branch: `storage_conf_refactor`

# Interested parties
@andreaWaldren 

(:star:) Required fields
