### PR TITLE
Provides upload interface for metadata docs

### DIFF
--- a/cypress/integration/admin_csvExport.spec.js
+++ b/cypress/integration/admin_csvExport.spec.js
@@ -8,7 +8,7 @@ describe("admin_csvExport: Generates CSV files for items and collections", () =>
         cy.visit("/siteAdmin");
 
         cy.get("#content-wrapper > div > div > ul")
-            .find(":nth-child(11) > a")
+            .find("li.CSVExport > a")
             .contains("CSV Export")
             .click();
         cy.url().should("include", "/siteAdmin");

--- a/cypress/integration/admin_page_upload_file.spec.js
+++ b/cypress/integration/admin_page_upload_file.spec.js
@@ -58,7 +58,7 @@ describe("admin_page_upload_file: Upload Site Content test", () => {
       cy.get('[data-test="upload-message"]', { timeout: 5000 })
         .should("have.attr", "style", "color: red;")
         .invoke("text")
-        .should("equal", "Please upload image or HTML file only!!");
+        .should("equal", "Sorry, this is an unsupported file type. :(");
     })
   })
 });

--- a/src/css/adminForms.scss
+++ b/src/css/adminForms.scss
@@ -191,3 +191,7 @@ span.file-detail {
   padding-left: 10px;
   border-left: 1px solid black;
 }
+
+h2.content-upload-prompt {
+  font-size: 1.5rem;
+}

--- a/src/pages/admin/MetadataUpload.tsx
+++ b/src/pages/admin/MetadataUpload.tsx
@@ -1,0 +1,50 @@
+import { FC, ChangeEvent, useContext, useState } from "react";
+import SiteContext from "./SiteContext";
+import ContentUpload from "./ContentUpload";
+
+export const MetadataUpload: FC = () => {
+  const siteContext = useContext(SiteContext);
+  const [recordType, setRecordType] = useState<String>("collection");
+
+  const typeChangeHandler = (event: ChangeEvent<HTMLInputElement>): void => {
+    setRecordType(event.target.value);
+  };
+
+  return (
+    <div className="col-lg-9 col-sm-12 admin-content">
+      <div>Upload your metadata in CSV format to create or update your:</div>
+      <div className="field">
+        <div className="ui radio checkbox">
+          <input
+            type="radio"
+            name="metadataUploadRadioGroup"
+            value="collection"
+            id="collection"
+            checked={recordType === "collection"}
+            onChange={typeChangeHandler}
+          />
+          <label htmlFor="collection">Collection</label>
+        </div>
+      </div>
+
+      <div className="field">
+        <div className="ui radio checkbox">
+          <input
+            type="radio"
+            name="metadataUploadRadioGroup"
+            value="archive"
+            id="archive"
+            checked={recordType === "archive"}
+            onChange={typeChangeHandler}
+          />
+          <label htmlFor="archive">Archive</label>
+        </div>
+      </div>
+      <ContentUpload
+        contentType="metadata"
+        recordType={recordType}
+        prompt={`Upload ${recordType} metadata`}
+      />
+    </div>
+  );
+};

--- a/src/pages/admin/SiteAdmin.js
+++ b/src/pages/admin/SiteAdmin.js
@@ -15,6 +15,7 @@ import MediaSectionForm from "./MediaSectionForm";
 import IdentifierForm from "./ArchiveCollectionEdit/IdentifierForm";
 import SiteContext from "./SiteContext";
 import CSVExport from "./CSVExport";
+import { MetadataUpload } from "./MetadataUpload";
 
 import "@aws-amplify/ui-react/styles.css";
 import "../../css/SiteAdmin.scss";
@@ -98,6 +99,8 @@ class SiteAdmin extends Component {
         return <IdentifierForm type="podcast" identifier={null} />;
       case "CSVExport":
         return <CSVExport />;
+      case "metadataUpload":
+        return <MetadataUpload />;
       default:
         return <SiteForm siteChanged={this.props.siteChanged} />;
     }
@@ -143,196 +146,223 @@ class SiteAdmin extends Component {
   }
 
   render() {
-    return (
-      <div className="row admin-wrapper">
-        <div className="col-lg-3 col-sm-12 admin-sidebar">
-          <ul>
-            <li
-              className={
-                this.state.form === "site" ? "admin-active site" : "site"
-              }
-            >
-              <Link onClick={() => this.setForm("site")} to={"/siteAdmin"}>
-                General Site Config
-              </Link>
-            </li>
-            <li
-              className={
-                this.state.form === "sitePages"
-                  ? "admin-active sitePages"
-                  : "sitePages"
-              }
-            >
-              <Link onClick={() => this.setForm("sitePages")} to={"/siteAdmin"}>
-                Site Pages Config
-              </Link>
-            </li>
-            <li
-              className={
-                this.state.form === "contentUpload"
-                  ? "admin-active contentUpload"
-                  : "contentUpload"
-              }
-            >
-              <Link
-                onClick={() => this.setForm("contentUpload")}
-                to={"/siteAdmin"}
-              >
-                Upload Site Content
-              </Link>
-            </li>
-            <li
-              className={
-                this.state.form === "homepage"
-                  ? "admin-active homepage"
-                  : "homepage"
-              }
-            >
-              <Link onClick={() => this.setForm("homepage")} to={"/siteAdmin"}>
-                Homepage Config
-              </Link>
-            </li>
-            <li
-              className={
-                this.state.form === "searchPage"
-                  ? "admin-active searchPage"
-                  : "searchPage"
-              }
-            >
-              <Link
-                onClick={() => this.setForm("searchPage")}
-                to={"/siteAdmin"}
-              >
-                Search Page Config
-              </Link>
-            </li>
-            <li
-              className={
-                this.state.form === "browseCollections"
-                  ? "admin-active browseCollections"
-                  : "browseCollections"
-              }
-            >
-              <Link
-                onClick={() => this.setForm("browseCollections")}
-                to={"/siteAdmin"}
-              >
-                Browse Collections Page
-              </Link>
-            </li>
-            <li
-              className={
-                this.state.form === "displayedAttributes"
-                  ? "admin-active displayedAttributes"
-                  : "displayedAttributes"
-              }
-            >
-              <Link
-                onClick={() => this.setForm("displayedAttributes")}
-                to={"/siteAdmin"}
-              >
-                Displayed Attributes
-              </Link>
-            </li>
-            <li
-              className={
-                this.state.form === "mediaSection"
-                  ? "admin-active mediaSection"
-                  : "mediaSection"
-              }
-            >
-              <Link
-                onClick={() => this.setForm("mediaSection")}
-                to={"/siteAdmin"}
-              >
-                Homepage media section
-              </Link>
-            </li>
-            <li
-              className={
-                this.state.form === "updateArchive"
-                  ? "admin-active updateArchive"
-                  : "updateArchive"
-              }
-            >
-              <Link
-                onClick={() => this.setForm("updateArchive")}
-                to={"/siteAdmin"}
-              >
-                New / Update Item
-              </Link>
-            </li>
-            <li
-              className={`collectionFormLink ${
-                this.state.form === "collectionForm"
-                  ? " admin-active collectionForm"
-                  : "collectionForm"
-              }`}
-            >
-              <Link
-                onClick={() => this.setForm("collectionForm")}
-                to={"/siteAdmin"}
-              >
-                New / Update Collection
-              </Link>
-            </li>
-            {this.state.site && this.state.site.siteId === "podcasts" && (
-              <li
-                className={
-                  this.state.form === "podcastDeposit"
-                    ? "podcastDeposit admin-active"
-                    : "podcastDeposit"
-                }
-              >
-                <Link
-                  onClick={() => this.setForm("podcastDeposit")}
-                  to={"/siteAdmin"}
+    if (this.state.site) {
+      return (
+        <div className="row admin-wrapper">
+          <SiteContext.Provider
+            value={{
+              site: this.state.site,
+              updateSite: this.updateSiteHandler
+            }}
+          >
+            <div className="col-lg-3 col-sm-12 admin-sidebar">
+              <ul>
+                <li
+                  className={
+                    this.state.form === "site" ? "admin-active site" : "site"
+                  }
                 >
-                  New / Update Podcast Episode
-                </Link>
-              </li>
+                  <Link onClick={() => this.setForm("site")} to={"/siteAdmin"}>
+                    General Site Config
+                  </Link>
+                </li>
+                <li
+                  className={
+                    this.state.form === "sitePages"
+                      ? "admin-active sitePages"
+                      : "sitePages"
+                  }
+                >
+                  <Link
+                    onClick={() => this.setForm("sitePages")}
+                    to={"/siteAdmin"}
+                  >
+                    Site Pages Config
+                  </Link>
+                </li>
+                <li
+                  className={
+                    this.state.form === "contentUpload"
+                      ? "admin-active contentUpload"
+                      : "contentUpload"
+                  }
+                >
+                  <Link
+                    onClick={() => this.setForm("contentUpload")}
+                    to={"/siteAdmin"}
+                  >
+                    Upload Site Content
+                  </Link>
+                </li>
+                <li
+                  className={
+                    this.state.form === "homepage"
+                      ? "admin-active homepage"
+                      : "homepage"
+                  }
+                >
+                  <Link
+                    onClick={() => this.setForm("homepage")}
+                    to={"/siteAdmin"}
+                  >
+                    Homepage Config
+                  </Link>
+                </li>
+                <li
+                  className={
+                    this.state.form === "searchPage"
+                      ? "admin-active searchPage"
+                      : "searchPage"
+                  }
+                >
+                  <Link
+                    onClick={() => this.setForm("searchPage")}
+                    to={"/siteAdmin"}
+                  >
+                    Search Page Config
+                  </Link>
+                </li>
+                <li
+                  className={
+                    this.state.form === "browseCollections"
+                      ? "admin-active browseCollections"
+                      : "browseCollections"
+                  }
+                >
+                  <Link
+                    onClick={() => this.setForm("browseCollections")}
+                    to={"/siteAdmin"}
+                  >
+                    Browse Collections Page
+                  </Link>
+                </li>
+                <li
+                  className={
+                    this.state.form === "displayedAttributes"
+                      ? "admin-active displayedAttributes"
+                      : "displayedAttributes"
+                  }
+                >
+                  <Link
+                    onClick={() => this.setForm("displayedAttributes")}
+                    to={"/siteAdmin"}
+                  >
+                    Displayed Attributes
+                  </Link>
+                </li>
+                <li
+                  className={
+                    this.state.form === "mediaSection"
+                      ? "admin-active mediaSection"
+                      : "mediaSection"
+                  }
+                >
+                  <Link
+                    onClick={() => this.setForm("mediaSection")}
+                    to={"/siteAdmin"}
+                  >
+                    Homepage media section
+                  </Link>
+                </li>
+                <li
+                  className={
+                    this.state.form === "updateArchive"
+                      ? "admin-active updateArchive"
+                      : "updateArchive"
+                  }
+                >
+                  <Link
+                    onClick={() => this.setForm("updateArchive")}
+                    to={"/siteAdmin"}
+                  >
+                    New / Update Item
+                  </Link>
+                </li>
+                <li
+                  className={`collectionFormLink ${
+                    this.state.form === "collectionForm"
+                      ? " admin-active collectionForm"
+                      : "collectionForm"
+                  }`}
+                >
+                  <Link
+                    onClick={() => this.setForm("collectionForm")}
+                    to={"/siteAdmin"}
+                  >
+                    New / Update Collection
+                  </Link>
+                </li>
+                <li>
+                  <Link to={"/siteAdmin/pre-ingest-check"}>
+                    Pre-ingest check tool
+                  </Link>
+                </li>
+                <li
+                  className={`metadataUploadLink ${
+                    this.state.form === "metadataUpload"
+                      ? " admin-active metadataUpload"
+                      : "metadataUpload"
+                  }`}
+                >
+                  <Link
+                    onClick={() => this.setForm("metadataUpload")}
+                    to={"/siteAdmin"}
+                  >
+                    Upload Metadata CSV
+                  </Link>
+                </li>
+                {this.state.site && this.state.site.siteId === "podcasts" && (
+                  <li
+                    className={
+                      this.state.form === "podcastDeposit"
+                        ? "podcastDeposit admin-active"
+                        : "podcastDeposit"
+                    }
+                  >
+                    <Link
+                      onClick={() => this.setForm("podcastDeposit")}
+                      to={"/siteAdmin"}
+                    >
+                      New / Update Podcast Episode
+                    </Link>
+                  </li>
+                )}
+                <li
+                  className={
+                    this.state.form === "CSVExport"
+                      ? "admin-active CSVExport"
+                      : "CSVExport"
+                  }
+                >
+                  <Link
+                    onClick={() => this.setForm("CSVExport")}
+                    to={"/siteAdmin"}
+                  >
+                    CSV Export
+                  </Link>
+                </li>
+              </ul>
+              <hr className="auth-divider" />
+              <Authenticator>
+                {({ signOut, user }) => (
+                  <div className="auth-dialog">
+                    <p>{user.username} successfully logged in.</p>
+                    <button onClick={signOut}>Sign out</button>
+                  </div>
+                )}
+              </Authenticator>
+            </div>
+            {this.state.authorized && this.state.site ? (
+              this.getForm()
+            ) : (
+              <h1>"Not authorized to access this page!"</h1>
             )}
-            <li
-              className={
-                this.state.form === "CSVExport"
-                  ? "admin-active CSVExport"
-                  : "CSVExport"
-              }
-            >
-              <Link onClick={() => this.setForm("CSVExport")} to={"/siteAdmin"}>
-                CSV Export
-              </Link>
-            </li>
-            <li>
-              <Link to={"/siteAdmin/pre-ingest-check"}>
-                Pre-ingest check tool
-              </Link>
-            </li>
-          </ul>
-          <hr className="auth-divider" />
-          <Authenticator>
-            {({ signOut, user }) => (
-              <div className="auth-dialog">
-                <p>{user.username} successfully logged in.</p>
-                <button onClick={signOut}>Sign out</button>
-              </div>
-            )}
-          </Authenticator>
+          </SiteContext.Provider>
         </div>
-        <SiteContext.Provider
-          value={{
-            site: this.state.site,
-            updateSite: this.updateSiteHandler
-          }}
-        >
-          {this.state.authorized && this.state.site ? (
-            this.getForm()
-          ) : (
-            <h1>"Not authorized to access this page!"</h1>
-          )}
-        </SiteContext.Provider>
-      </div>
-    );
+      );
+    } else {
+      return <></>;
+    }
   }
 }
 


### PR DESCRIPTION
**Provides upload interface for metadata docs (csv format).**
* * *

**JIRA Ticket**: ([link](https://webapps.es.vt.edu/jira/browse/LIBTD-2625)) (:star:)

* Other Relevant Links (Meeting note, project page, related pull requests, etc.)

# What does this Pull Request do? (:star:)
Provides upload interface for metadata docs (csv format). Renames file depending on record type before writing to s3 bucket so that s3toDDB lambda function will know how to process the file.

# What's the changes? (:star:)
A in-depth description of the changes made by this PR. Technical details and possible side effects.
* Allows user to indicate if records are for Archives or Collections
* Allows user to upload their metadata to browser memory
* Renames csv file depending on whether it contains Archive records or Collection records
* Writes csv file to the s3 bucket that is configured to be the Storage for the current Amplify backend

# How should this be tested?
* visit `/siteAdmin` in the generated preview app
* Click on "Upload Metadata CSV"
* Select the radio button that corresponds to the type of your metadata
* Upload your file
* Check that it was written to the correct location in s3. For example, if you're running the `opendev` backend then your file should be written to: s3://collectionmap123850-opendev/public/sitecontent/metadata/default/
* Check that your metadata file was renamed correctly. Collection metadata filenames should end in "_collection_metadata.csv." Archive metadata filenames should end in "_archive_metadata.csv"

# Additional Notes:
* branch: `metadata_upload`
* The s3toDDB portion of this has not been implemented yet so the uploaded metadata records will not be written to Dynamo ...yet

# Interested parties
@andreaWaldren 

(:star:) Required fields
