### PR TITLE
fetch html documents as blob

### DIFF
--- a/src/pages/AboutPage.js
+++ b/src/pages/AboutPage.js
@@ -18,6 +18,7 @@ class AboutPage extends Component {
   componentDidMount() {
     const htmlUrl = JSON.parse(this.props.site.sitePages)[this.props.parentKey]
       .data_url;
+
     getFileContent(htmlUrl, "html", this);
   }
 


### PR DESCRIPTION
**Fetch html documents as blob. Set's download to true so it returns an object with the file body instead of a Signed URL**
* * *

**JIRA Ticket**: (link) (:star:)

* Other Relevant Links (Meeting note, project page, related pull requests, etc.)

# What does this Pull Request do? (:star:)
Fetch html documents as blob. Set's download to true so it returns an object with the file body instead of a Signed URL*

# What's the changes? (:star:)
* Fetch html documents as blob. 
* Set's download to true so it returns an object with the file body instead of a Signed URL

# How should this be tested?
* visit `/about` and `/permissions` in the generated preview and check to see that page content is loading and rendering.

# Additional Notes:
* A bunch of the links in the site records for these "additional pages" aren't compatible w/ the current fetch methods. (Some of the links are just filenames w/ no path) I've fixed the links for the `default` site but it might take me a minute to fix the rest. And when we deploy to pprd or prod those records need to be fixed too.


# Interested parties
Tag (@ mention) interested parties
@andreaWaldren 
(:star:) Required fields
