### PR TITLE
HTML Editor

### DIFF
--- a/amplify/backend/api/collectionarchives/schema.graphql
+++ b/amplify/backend/api/collectionarchives/schema.graphql
@@ -86,6 +86,19 @@ type Collectionmap
     collection: Collection  @hasOne
   }
 
+type PageContent
+  @model
+  @auth(rules: [
+    { allow: public, operations: [read] },
+    { allow: groups, groups: ["Admin", "Editor"] },
+    { allow: groups, groupsField: "page_content_category" }
+  ]){
+    page_content_category: String!
+    id: ID!
+    content: String!
+    pageContentSiteId: Site  @hasOne
+  }
+
 type Archive implements Object
   @model
   @searchable

--- a/amplify/backend/types/amplify-dependent-resources-ref.d.ts
+++ b/amplify/backend/types/amplify-dependent-resources-ref.d.ts
@@ -1,47 +1,47 @@
 export type AmplifyDependentResourcesAttributes = {
-  "api": {
-    "collectionarchives": {
-      "GraphQLAPIEndpointOutput": "string",
-      "GraphQLAPIIdOutput": "string",
-      "GraphQLAPIKeyOutput": "string"
-    }
-  },
-  "auth": {
-    "iawav2658176f3": {
-      "AppClientID": "string",
-      "AppClientIDWeb": "string",
-      "AppClientSecret": "string",
-      "IdentityPoolId": "string",
-      "IdentityPoolName": "string",
-      "UserPoolId": "string",
-      "UserPoolName": "string"
+    "api": {
+        "collectionarchives": {
+            "GraphQLAPIKeyOutput": "string",
+            "GraphQLAPIIdOutput": "string",
+            "GraphQLAPIEndpointOutput": "string"
+        }
     },
-    "userPoolGroups": {
-      "AdminGroupRole": "string",
-      "DefaultGroupRole": "string",
-      "EditorGroupRole": "string",
-      "IAWAGroupRole": "string",
-      "SWVAGroupRole": "string",
-      "SiteAdminGroupRole": "string",
-      "federatedGroupRole": "string",
-      "hokiesGroupRole": "string",
-      "podcastsGroupRole": "string",
-      "testGroupRole": "string"
-    }
-  },
-  "function": {
-    "iawav2658176f3PostConfirmation": {
-      "Arn": "string",
-      "LambdaExecutionRole": "string",
-      "LambdaExecutionRoleArn": "string",
-      "Name": "string",
-      "Region": "string"
-    }
-  },
-  "storage": {
-    "Collectionmap": {
-      "BucketName": "string",
-      "Region": "string"
+    "auth": {
+        "iawav2658176f3": {
+            "IdentityPoolId": "string",
+            "IdentityPoolName": "string",
+            "UserPoolId": "string",
+            "UserPoolName": "string",
+            "AppClientIDWeb": "string",
+            "AppClientID": "string",
+            "AppClientSecret": "string"
+        },
+        "userPoolGroups": {
+            "AdminGroupRole": "string",
+            "EditorGroupRole": "string",
+            "SiteAdminGroupRole": "string",
+            "IAWAGroupRole": "string",
+            "hokiesGroupRole": "string",
+            "SWVAGroupRole": "string",
+            "podcastsGroupRole": "string",
+            "DefaultGroupRole": "string",
+            "federatedGroupRole": "string",
+            "testGroupRole": "string"
+        }
+    },
+    "function": {
+      "iawav2658176f3PostConfirmation": {
+        "Arn": "string",
+        "LambdaExecutionRole": "string",
+        "LambdaExecutionRoleArn": "string",
+        "Name": "string",
+        "Region": "string"
+      }
+    },
+    "storage": {
+      "Collectionmap": {
+        "BucketName": "string",
+        "Region": "string"
+      }
     }
   }
-}

--- a/amplify/team-provider-info.json
+++ b/amplify/team-provider-info.json
@@ -214,5 +214,31 @@
         }
       }
     }
+  },
+  "trytable": {
+    "awscloudformation": {
+      "AuthRoleName": "amplify-iawav2-trytable-113702-authRole",
+      "UnauthRoleArn": "arn:aws:iam::909117335741:role/amplify-iawav2-trytable-113702-unauthRole",
+      "AuthRoleArn": "arn:aws:iam::909117335741:role/amplify-iawav2-trytable-113702-authRole",
+      "Region": "us-east-1",
+      "DeploymentBucketName": "amplify-iawav2-trytable-113702-deployment",
+      "UnauthRoleName": "amplify-iawav2-trytable-113702-unauthRole",
+      "StackName": "amplify-iawav2-trytable-113702",
+      "StackId": "arn:aws:cloudformation:us-east-1:909117335741:stack/amplify-iawav2-trytable-113702/24c65820-ae18-11ed-a7dc-12f94afc5527",
+      "AmplifyAppId": "d2dwg7uvhcx1m8"
+    },
+    "categories": {
+      "auth": {
+        "iawav2658176f3": {},
+        "userPoolGroups": {}
+      },
+      "function": {
+        "iawav2658176f3PostConfirmation": {
+          "GROUP": "public",
+          "deploymentBucketName": "amplify-iawav2-trytable-113702-deployment",
+          "s3Key": "amplify-builds/iawav2658176f3PostConfirmation-634844337947316a6c56-build.zip"
+        }
+      }
+    }
   }
 }

--- a/cypress/integration/admin_archive_edit.spec.js
+++ b/cypress/integration/admin_archive_edit.spec.js
@@ -62,18 +62,18 @@ describe("admin_archive_edit: Update item metadata and change it back", function
 
   it("Can delete single-valued metadata", () => {
     cy.get("input[value='edit']").parent().click();
-    cy.get("textarea[name='rights_statement']")
+    cy.get("textarea[name='bibliographic_citation']")
       .clear();
     cy.contains("Update Item Metadata").click();
-    cy.contains("Rights statement: ").should('not.exist');
+    cy.contains("Bibliographic citation:").should('not.exist');
   })
 
   it("Can add single-valued metadata", () => {
     cy.get("input[value='edit']").parent().click();
-    cy.get("textarea[name='rights_statement']")
-      .clear().type("Permission to publish material from the Unidentified building site, c. 1979. Photographs (Ms1990-025) must be obtained from University Libraries Special Collections, Virginia Tech.");
+    cy.get("textarea[name='bibliographic_citation']")
+      .clear().type("Researchers wishing to cite this collection should include the following information: Unidentified building site, c. 1979. Photographs (Ms1990-025) - Special Collections, Virginia Polytechnic Institute and State University, Blacksburg, Va.");
       cy.contains("Update Item Metadata").click();
-      cy.contains("Rights statement: Permission to publish material from the Unidentified building site, c. 1979. Photographs (Ms1990-025) must be obtained from University Libraries Special Collections, Virginia Tech.").should('be.visible');
+      cy.contains("Bibliographic citation: Researchers wishing to cite this collection should include the following information: Unidentified building site, c. 1979. Photographs (Ms1990-025) - Special Collections, Virginia Polytechnic Institute and State University, Blacksburg, Va.").should('be.visible');
   })
 
   it("Can delete multi-valued metadata", () => {
@@ -94,4 +94,16 @@ describe("admin_archive_edit: Update item metadata and change it back", function
     cy.contains("Update Item Metadata").click();
     cy.contains("Ms1990-025, Box 1, Folder 1").should('be.visible');
   })
+
+  it("Can change metadata using text editor", () => {
+    cy.get("input[value='edit']").parent().click();
+    cy.get("#description_0").find(".ql-editor").clear().type("Description field test");
+    cy.contains("Update Item Metadata").click();
+    cy.contains("Description field test").should('be.visible');
+    cy.get("input[value='edit']").parent().click();
+    cy.get("#description_0").find(".ql-editor").clear().type("Two photographs of an unidentified industrial building site");
+    cy.contains("Update Item Metadata").click();
+    cy.contains("Two photographs of an unidentified industrial building site").should('be.visible');
+  })
+
 });

--- a/cypress/integration/admin_collection_edit.spec.js
+++ b/cypress/integration/admin_collection_edit.spec.js
@@ -21,7 +21,7 @@ describe("admin_collection_edit: Update collection metadata and change it back",
     .parent()
     .find('input')
     .should('be.checked')
-    cy.contains("Description: Alberta Pfeiffer’s architectural career spanned 55 years, where she worked primarily in Hadlyme, Connecticut.").should("be.visible");
+    cy.contains("Alberta Pfeiffer’s architectural career spanned 55 years, where she worked primarily in Hadlyme, Connecticut.").should("be.visible");
   })
 
   after(() => {

--- a/cypress/integration/admin_homepage_top_config.spec.js
+++ b/cypress/integration/admin_homepage_top_config.spec.js
@@ -37,6 +37,17 @@ describe("admin_homepage_top_config: Update Homepage fields and revert", functio
     cy.contains("Heading: Welcome").should('be.visible');
   })
 
+  it("Update Homepage statement using editor", () => {
+    cy.get("input[value='edit']").parent().click();
+    cy.get(".ql-editor").clear().type("Test statement");
+    cy.contains("Update Config").click();
+    cy.contains("Test statement").should('be.visible');
+    cy.get("input[value='edit']").parent().click();
+    cy.get(".ql-editor").clear().type("A visual exhibit of selected items from the International Archive of Women in Architecture, a joint partnership between the College of Architecture and Urban Studies and the University Libraries.");
+    cy.contains("Update Config").click();
+    cy.contains("A visual exhibit of selected items from the International Archive of Women in Architecture, a joint partnership between the College of Architecture and Urban Studies and the University Libraries.").should('be.visible');
+  })
+
   it("displays successful upload", () => {
     cy.get("input[value='edit']").parent().click();
     const imgPath = "sitecontent/cover_image1.jpg";

--- a/cypress/integration/admin_page_sitepages_config.spec.js
+++ b/cypress/integration/admin_page_sitepages_config.spec.js
@@ -29,10 +29,10 @@ describe("admin_page_sitepages_config: Displays and updates sitepages configurat
         .parent()
         .click();
       cy.contains("Page ID: terms", { timeout: 5000 }).should("be.visible");
-      cy.contains("Component: PermissionsPage").should("be.visible");
+      cy.contains("Page Type: PermissionsPage").should("be.visible");
       cy.contains("Assets:").should("be.visible");
-      cy.contains("Local URL: /permissions").should("be.visible");
-      cy.contains("Text: Permission").should("be.visible");
+      cy.contains("Page URL: /permissions").should("be.visible");
+      cy.contains("Page Title: Permissions").should("be.visible");
       cy.contains("terms.html").should("be.visible");
     });
   });
@@ -74,7 +74,7 @@ describe("admin_page_sitepages_config: Displays and updates sitepages configurat
         .invoke("text")
         .should("include", "uploaded successfully");
     });
-    it("Uploads data file", () => {
+    it("Uploads HTML file", () => {
       cy.get("input[value='edit']").parent().click();
       const dataPath = "sitecontent/about1.html";
       cy.get("input#terms_dataURL").attachFile(dataPath).trigger('change', { force: true });
@@ -85,6 +85,25 @@ describe("admin_page_sitepages_config: Displays and updates sitepages configurat
         .should('have.attr', 'style', 'color: green;')
         .invoke("text")
         .should("include", "uploaded successfully");
+      cy.contains("Current HTML file: about1.html").should("be.visible");
+      cy.get("#terms_useDataUrl").parent().should("have.class", "checked");
+    })
+  })
+
+  describe("admin_page_sitepages_config: Can use text editor", () =>{
+    it("Can edit page content using text editor", () => {
+      cy.get("input[value='edit']").parent().click();
+      cy.get("#terms_openEditor").click();
+      cy.wait(3000);
+      cy.get(".ql-editor").click().type(" Testing123");
+      cy.get("button").contains("Save").click();
+      cy.get("input[value='edit']").parent().click();
+      cy.get("#terms_openEditor").click();
+      cy.wait(3000);
+      cy.contains("Testing123").should("be.visible");
+      cy.get(".ql-editor").click().type("{end}{backspace}{backspace}{backspace}{backspace}{backspace}{backspace}{backspace}{backspace}{backspace}{backspace}{backspace}");
+      cy.contains("Testing123").should("not.be.visible");
+      cy.get("button").contains("Save").click();
     })
   })
 });

--- a/package-lock.json
+++ b/package-lock.json
@@ -46,6 +46,7 @@
         "react-fontawesome": "^1.7.1",
         "react-helmet": "^5.2.1",
         "react-html-parser": "^2.0.2",
+        "react-quill": "^2.0.0",
         "react-router-dom": "^5.1.2",
         "react-scripts": "5.0.0",
         "react-share": "^4.4.0",
@@ -17602,6 +17603,14 @@
       "resolved": "https://registry.npmjs.org/@types/qs/-/qs-6.9.7.tgz",
       "integrity": "sha512-FGa1F62FT09qcrueBA6qYTrJPVDzah9a+493+o2PCXsesWHIn27G98TsSMs3WPNbZIEj4+VJf6saSFpvD+3Zsw=="
     },
+    "node_modules/@types/quill": {
+      "version": "1.3.10",
+      "resolved": "https://registry.npmjs.org/@types/quill/-/quill-1.3.10.tgz",
+      "integrity": "sha512-IhW3fPW+bkt9MLNlycw8u8fWb7oO7W5URC9MfZYHBlA24rex9rs23D5DETChu1zvgVdc5ka64ICjJOgQMr6Shw==",
+      "dependencies": {
+        "parchment": "^1.1.2"
+      }
+    },
     "node_modules/@types/range-parser": {
       "version": "1.2.4",
       "resolved": "https://registry.npmjs.org/@types/range-parser/-/range-parser-1.2.4.tgz",
@@ -24366,6 +24375,11 @@
       "version": "3.1.3",
       "resolved": "https://registry.npmjs.org/fast-deep-equal/-/fast-deep-equal-3.1.3.tgz",
       "integrity": "sha512-f3qQ9oQy9j2AhBe/H9VC91wLmKBCCU/gDOnKNAYG5hswO7BLKj09Hc5HYNz9cGI++xlpDCIgDaitVs03ATR84Q=="
+    },
+    "node_modules/fast-diff": {
+      "version": "1.1.2",
+      "resolved": "https://registry.npmjs.org/fast-diff/-/fast-diff-1.1.2.tgz",
+      "integrity": "sha512-KaJUt+M9t1qaIteSvjc6P3RbMdXsNhK61GRftR6SNxqmhthcd9MGIi4T+o0jD8LUSpSnSKXE20nLtJ3fOHxQig=="
     },
     "node_modules/fast-glob": {
       "version": "3.2.11",
@@ -32618,6 +32632,11 @@
       "resolved": "https://registry.npmjs.org/tslib/-/tslib-2.4.0.tgz",
       "integrity": "sha512-d6xOpEDfsi2CZVlPQzGeux8XMwLT9hssAsaPYExaQMuYskwb+x1x7J371tWlbBdWHroy99KnVB6qIkUbs5X3UQ=="
     },
+    "node_modules/parchment": {
+      "version": "1.1.4",
+      "resolved": "https://registry.npmjs.org/parchment/-/parchment-1.1.4.tgz",
+      "integrity": "sha512-J5FBQt/pM2inLzg4hEWmzQx/8h8D0CiDxaG3vyp9rKrQRSDgBlhjdP5jQGgosEajXPSQouXGHOmVdgo7QmJuOg=="
+    },
     "node_modules/parent-module": {
       "version": "1.0.1",
       "resolved": "https://registry.npmjs.org/parent-module/-/parent-module-1.0.1.tgz",
@@ -34914,6 +34933,45 @@
       "resolved": "https://registry.npmjs.org/quickselect/-/quickselect-2.0.0.tgz",
       "integrity": "sha512-RKJ22hX8mHe3Y6wH/N3wCM6BWtjaxIyyUIkpHOvfFnxdI4yD4tBXEBKSbriGujF6jnSVkJrffuo6vxACiSSxIw=="
     },
+    "node_modules/quill": {
+      "version": "1.3.7",
+      "resolved": "https://registry.npmjs.org/quill/-/quill-1.3.7.tgz",
+      "integrity": "sha512-hG/DVzh/TiknWtE6QmWAF/pxoZKYxfe3J/d/+ShUWkDvvkZQVTPeVmUJVu1uE6DDooC4fWTiCLh84ul89oNz5g==",
+      "dependencies": {
+        "clone": "^2.1.1",
+        "deep-equal": "^1.0.1",
+        "eventemitter3": "^2.0.3",
+        "extend": "^3.0.2",
+        "parchment": "^1.1.4",
+        "quill-delta": "^3.6.2"
+      }
+    },
+    "node_modules/quill-delta": {
+      "version": "3.6.3",
+      "resolved": "https://registry.npmjs.org/quill-delta/-/quill-delta-3.6.3.tgz",
+      "integrity": "sha512-wdIGBlcX13tCHOXGMVnnTVFtGRLoP0imqxM696fIPwIf5ODIYUHIvHbZcyvGlZFiFhK5XzDC2lpjbxRhnM05Tg==",
+      "dependencies": {
+        "deep-equal": "^1.0.1",
+        "extend": "^3.0.2",
+        "fast-diff": "1.1.2"
+      },
+      "engines": {
+        "node": ">=0.10"
+      }
+    },
+    "node_modules/quill/node_modules/clone": {
+      "version": "2.1.2",
+      "resolved": "https://registry.npmjs.org/clone/-/clone-2.1.2.tgz",
+      "integrity": "sha512-3Pe/CF1Nn94hyhIYpjtiLhdCoEoz0DqQ+988E9gmeEdQZlojxnOb74wctFyuwWQHzqyf9X7C7MG8juUpqBJT8w==",
+      "engines": {
+        "node": ">=0.8"
+      }
+    },
+    "node_modules/quill/node_modules/eventemitter3": {
+      "version": "2.0.3",
+      "resolved": "https://registry.npmjs.org/eventemitter3/-/eventemitter3-2.0.3.tgz",
+      "integrity": "sha512-jLN68Dx5kyFHaePoXWPsCGW5qdyZQtLYHkxkg02/Mz6g0kYpDx4FyP6XfArhQdlOC4b8Mv+EMxPo/8La7Tzghg=="
+    },
     "node_modules/raf": {
       "version": "3.4.1",
       "resolved": "https://registry.npmjs.org/raf/-/raf-3.4.1.tgz",
@@ -35591,6 +35649,20 @@
       "integrity": "sha512-rpJyN222KWIvHJ/F53XSZv0Zl/accqHR8et1kpaMTD/fLCRxtV8iX8czMzY7sVZupTI3zcUTg8eycS2kNF9l6w==",
       "dependencies": {
         "loose-envify": "^1.0.0"
+      }
+    },
+    "node_modules/react-quill": {
+      "version": "2.0.0",
+      "resolved": "https://registry.npmjs.org/react-quill/-/react-quill-2.0.0.tgz",
+      "integrity": "sha512-4qQtv1FtCfLgoD3PXAur5RyxuUbPXQGOHgTlFie3jtxp43mXDtzCKaOgQ3mLyZfi1PUlyjycfivKelFhy13QUg==",
+      "dependencies": {
+        "@types/quill": "^1.3.10",
+        "lodash": "^4.17.4",
+        "quill": "^1.3.7"
+      },
+      "peerDependencies": {
+        "react": "^16 || ^17 || ^18",
+        "react-dom": "^16 || ^17 || ^18"
       }
     },
     "node_modules/react-redux": {
@@ -56188,6 +56260,14 @@
       "resolved": "https://registry.npmjs.org/@types/qs/-/qs-6.9.7.tgz",
       "integrity": "sha512-FGa1F62FT09qcrueBA6qYTrJPVDzah9a+493+o2PCXsesWHIn27G98TsSMs3WPNbZIEj4+VJf6saSFpvD+3Zsw=="
     },
+    "@types/quill": {
+      "version": "1.3.10",
+      "resolved": "https://registry.npmjs.org/@types/quill/-/quill-1.3.10.tgz",
+      "integrity": "sha512-IhW3fPW+bkt9MLNlycw8u8fWb7oO7W5URC9MfZYHBlA24rex9rs23D5DETChu1zvgVdc5ka64ICjJOgQMr6Shw==",
+      "requires": {
+        "parchment": "^1.1.2"
+      }
+    },
     "@types/range-parser": {
       "version": "1.2.4",
       "resolved": "https://registry.npmjs.org/@types/range-parser/-/range-parser-1.2.4.tgz",
@@ -61422,6 +61502,11 @@
       "version": "3.1.3",
       "resolved": "https://registry.npmjs.org/fast-deep-equal/-/fast-deep-equal-3.1.3.tgz",
       "integrity": "sha512-f3qQ9oQy9j2AhBe/H9VC91wLmKBCCU/gDOnKNAYG5hswO7BLKj09Hc5HYNz9cGI++xlpDCIgDaitVs03ATR84Q=="
+    },
+    "fast-diff": {
+      "version": "1.1.2",
+      "resolved": "https://registry.npmjs.org/fast-diff/-/fast-diff-1.1.2.tgz",
+      "integrity": "sha512-KaJUt+M9t1qaIteSvjc6P3RbMdXsNhK61GRftR6SNxqmhthcd9MGIi4T+o0jD8LUSpSnSKXE20nLtJ3fOHxQig=="
     },
     "fast-glob": {
       "version": "3.2.11",
@@ -67813,6 +67898,11 @@
         }
       }
     },
+    "parchment": {
+      "version": "1.1.4",
+      "resolved": "https://registry.npmjs.org/parchment/-/parchment-1.1.4.tgz",
+      "integrity": "sha512-J5FBQt/pM2inLzg4hEWmzQx/8h8D0CiDxaG3vyp9rKrQRSDgBlhjdP5jQGgosEajXPSQouXGHOmVdgo7QmJuOg=="
+    },
     "parent-module": {
       "version": "1.0.1",
       "resolved": "https://registry.npmjs.org/parent-module/-/parent-module-1.0.1.tgz",
@@ -69309,6 +69399,41 @@
       "resolved": "https://registry.npmjs.org/quickselect/-/quickselect-2.0.0.tgz",
       "integrity": "sha512-RKJ22hX8mHe3Y6wH/N3wCM6BWtjaxIyyUIkpHOvfFnxdI4yD4tBXEBKSbriGujF6jnSVkJrffuo6vxACiSSxIw=="
     },
+    "quill": {
+      "version": "1.3.7",
+      "resolved": "https://registry.npmjs.org/quill/-/quill-1.3.7.tgz",
+      "integrity": "sha512-hG/DVzh/TiknWtE6QmWAF/pxoZKYxfe3J/d/+ShUWkDvvkZQVTPeVmUJVu1uE6DDooC4fWTiCLh84ul89oNz5g==",
+      "requires": {
+        "clone": "^2.1.1",
+        "deep-equal": "^1.0.1",
+        "eventemitter3": "^2.0.3",
+        "extend": "^3.0.2",
+        "parchment": "^1.1.4",
+        "quill-delta": "^3.6.2"
+      },
+      "dependencies": {
+        "clone": {
+          "version": "2.1.2",
+          "resolved": "https://registry.npmjs.org/clone/-/clone-2.1.2.tgz",
+          "integrity": "sha512-3Pe/CF1Nn94hyhIYpjtiLhdCoEoz0DqQ+988E9gmeEdQZlojxnOb74wctFyuwWQHzqyf9X7C7MG8juUpqBJT8w=="
+        },
+        "eventemitter3": {
+          "version": "2.0.3",
+          "resolved": "https://registry.npmjs.org/eventemitter3/-/eventemitter3-2.0.3.tgz",
+          "integrity": "sha512-jLN68Dx5kyFHaePoXWPsCGW5qdyZQtLYHkxkg02/Mz6g0kYpDx4FyP6XfArhQdlOC4b8Mv+EMxPo/8La7Tzghg=="
+        }
+      }
+    },
+    "quill-delta": {
+      "version": "3.6.3",
+      "resolved": "https://registry.npmjs.org/quill-delta/-/quill-delta-3.6.3.tgz",
+      "integrity": "sha512-wdIGBlcX13tCHOXGMVnnTVFtGRLoP0imqxM696fIPwIf5ODIYUHIvHbZcyvGlZFiFhK5XzDC2lpjbxRhnM05Tg==",
+      "requires": {
+        "deep-equal": "^1.0.1",
+        "extend": "^3.0.2",
+        "fast-diff": "1.1.2"
+      }
+    },
     "raf": {
       "version": "3.4.1",
       "resolved": "https://registry.npmjs.org/raf/-/raf-3.4.1.tgz",
@@ -69839,6 +69964,16 @@
             "loose-envify": "^1.0.0"
           }
         }
+      }
+    },
+    "react-quill": {
+      "version": "2.0.0",
+      "resolved": "https://registry.npmjs.org/react-quill/-/react-quill-2.0.0.tgz",
+      "integrity": "sha512-4qQtv1FtCfLgoD3PXAur5RyxuUbPXQGOHgTlFie3jtxp43mXDtzCKaOgQ3mLyZfi1PUlyjycfivKelFhy13QUg==",
+      "requires": {
+        "@types/quill": "^1.3.10",
+        "lodash": "^4.17.4",
+        "quill": "^1.3.7"
       }
     },
     "react-redux": {

--- a/package.json
+++ b/package.json
@@ -40,6 +40,7 @@
     "react-fontawesome": "^1.7.1",
     "react-helmet": "^5.2.1",
     "react-html-parser": "^2.0.2",
+    "react-quill": "^2.0.0",
     "react-router-dom": "^5.1.2",
     "react-scripts": "5.0.0",
     "react-share": "^4.4.0",

--- a/src/components/Citation.js
+++ b/src/components/Citation.js
@@ -1,7 +1,7 @@
 import React, { Component } from "react";
 import { createTheme, MuiThemeProvider } from "@material-ui/core/styles";
 import Tooltip from "@material-ui/core/Tooltip";
-import { htmlParsedValue } from "../lib/MetadataRenderer";
+import ReactHtmlParser from "react-html-parser";
 
 import "../css/Citation.scss";
 
@@ -57,7 +57,7 @@ class Citation extends Component {
             </MuiThemeProvider>
           </div>
           <div className="link-text">
-            {htmlParsedValue(
+            {ReactHtmlParser(
               `<a href="${redirect}/${this.props.item.custom_key}">${redirect}/${this.props.item.custom_key}</a>`
             )}
           </div>

--- a/src/components/Editor.js
+++ b/src/components/Editor.js
@@ -1,0 +1,27 @@
+import React from "react";
+import ReactQuill from "react-quill";
+import "react-quill/dist/quill.snow.css";
+
+function Editor({
+  value,
+  placeholder,
+  onChange,
+  fieldName,
+  modules,
+  formats,
+  id
+}) {
+  return (
+    <ReactQuill
+      theme="snow"
+      value={value}
+      onChange={e => onChange(e, fieldName)}
+      placeholder={placeholder}
+      modules={modules}
+      formats={formats}
+      id={id}
+    />
+  );
+}
+
+export default Editor;

--- a/src/components/MediaElement.js
+++ b/src/components/MediaElement.js
@@ -17,7 +17,6 @@ export default class MediaElement extends Component {
       audioImg: null,
       audioSrc: null,
       captionSrc: null,
-      transcript: null,
       isTranscriptActive: false,
       copy: null
     };
@@ -239,16 +238,7 @@ export default class MediaElement extends Component {
                   className="download-link"
                   title="Download transcript"
                   aria-label="Download transcript"
-                  onClick={() =>
-                    downloadFile(
-                      this.props.transcript,
-                      "text",
-                      this,
-                      "transcript",
-                      this.props.site.siteId,
-                      "public/sitecontent"
-                    )
-                  }
+                  onClick={() => downloadFile(this.props.transcript)}
                 >
                   Download Transcript
                 </button>

--- a/src/components/PodcastMediaElement.js
+++ b/src/components/PodcastMediaElement.js
@@ -18,7 +18,6 @@ export default class PodcastMediaElement extends Component {
       audioImg: null,
       audioSrc: null,
       captionSrc: null,
-      transcript: null,
       isTranscriptActive: false,
       copy: null
     };
@@ -242,16 +241,7 @@ export default class PodcastMediaElement extends Component {
                 className="download-link"
                 title="Download transcript"
                 aria-label="Download transcript"
-                onClick={() =>
-                  downloadFile(
-                    this.props.transcript,
-                    "text",
-                    this,
-                    "transcript",
-                    this.props.site.siteId,
-                    "public/sitecontent"
-                  )
-                }
+                onClick={() => downloadFile(this.props.transcript)}
               >
                 Download Transcript
               </button>

--- a/src/css/Editor.scss
+++ b/src/css/Editor.scss
@@ -1,0 +1,268 @@
+.quill-styles ol li.ql-indent-1 {
+  counter-increment: list-1;
+}
+.quill-styles ol li.ql-indent-1:before {
+  content: counter(list-1, lower-alpha) ". ";
+}
+.quill-styles ol li.ql-indent-1 {
+  counter-reset: list-2 list-3 list-4 list-5 list-6 list-7 list-8 list-9;
+}
+.quill-styles ol li.ql-indent-2 {
+  counter-increment: list-2;
+}
+.quill-styles ol li.ql-indent-2:before {
+  content: counter(list-2, lower-roman) ". ";
+}
+.quill-styles ol li.ql-indent-2 {
+  counter-reset: list-3 list-4 list-5 list-6 list-7 list-8 list-9;
+}
+.quill-styles ol li.ql-indent-3 {
+  counter-increment: list-3;
+}
+.quill-styles ol li.ql-indent-3:before {
+  content: counter(list-3, decimal) ". ";
+}
+.quill-styles ol li.ql-indent-3 {
+  counter-reset: list-4 list-5 list-6 list-7 list-8 list-9;
+}
+.quill-styles ol li.ql-indent-4 {
+  counter-increment: list-4;
+}
+.quill-styles ol li.ql-indent-4:before {
+  content: counter(list-4, lower-alpha) ". ";
+}
+.quill-styles ol li.ql-indent-4 {
+  counter-reset: list-5 list-6 list-7 list-8 list-9;
+}
+.quill-styles ol li.ql-indent-5 {
+  counter-increment: list-5;
+}
+.quill-styles ol li.ql-indent-5:before {
+  content: counter(list-5, lower-roman) ". ";
+}
+.quill-styles ol li.ql-indent-5 {
+  counter-reset: list-6 list-7 list-8 list-9;
+}
+.quill-styles ol li.ql-indent-6 {
+  counter-increment: list-6;
+}
+.quill-styles ol li.ql-indent-6:before {
+  content: counter(list-6, decimal) ". ";
+}
+.quill-styles ol li.ql-indent-6 {
+  counter-reset: list-7 list-8 list-9;
+}
+.quill-styles ol li.ql-indent-7 {
+  counter-increment: list-7;
+}
+.quill-styles ol li.ql-indent-7:before {
+  content: counter(list-7, lower-alpha) ". ";
+}
+.quill-styles ol li.ql-indent-7 {
+  counter-reset: list-8 list-9;
+}
+.quill-styles ol li.ql-indent-8 {
+  counter-increment: list-8;
+}
+.quill-styles ol li.ql-indent-8:before {
+  content: counter(list-8, lower-roman) ". ";
+}
+.quill-styles ol li.ql-indent-8 {
+  counter-reset: list-9;
+}
+.quill-styles ol li.ql-indent-9 {
+  counter-increment: list-9;
+}
+.quill-styles ol li.ql-indent-9:before {
+  content: counter(list-9, decimal) ". ";
+}
+.quill-styles .ql-indent-1:not(.ql-direction-rtl) {
+  padding-left: 3em;
+}
+.quill-styles li.ql-indent-1:not(.ql-direction-rtl) {
+  padding-left: 4.5em;
+}
+.quill-styles .ql-indent-1.ql-direction-rtl.ql-align-right {
+  padding-right: 3em;
+}
+.quill-styles li.ql-indent-1.ql-direction-rtl.ql-align-right {
+  padding-right: 4.5em;
+}
+.quill-styles .ql-indent-2:not(.ql-direction-rtl) {
+  padding-left: 6em;
+}
+.quill-styles li.ql-indent-2:not(.ql-direction-rtl) {
+  padding-left: 7.5em;
+}
+.quill-styles .ql-indent-2.ql-direction-rtl.ql-align-right {
+  padding-right: 6em;
+}
+.quill-styles li.ql-indent-2.ql-direction-rtl.ql-align-right {
+  padding-right: 7.5em;
+}
+.quill-styles .ql-indent-3:not(.ql-direction-rtl) {
+  padding-left: 9em;
+}
+.quill-styles li.ql-indent-3:not(.ql-direction-rtl) {
+  padding-left: 10.5em;
+}
+.quill-styles .ql-indent-3.ql-direction-rtl.ql-align-right {
+  padding-right: 9em;
+}
+.quill-styles li.ql-indent-3.ql-direction-rtl.ql-align-right {
+  padding-right: 10.5em;
+}
+.quill-styles .ql-indent-4:not(.ql-direction-rtl) {
+  padding-left: 12em;
+}
+.quill-styles li.ql-indent-4:not(.ql-direction-rtl) {
+  padding-left: 13.5em;
+}
+.quill-styles .ql-indent-4.ql-direction-rtl.ql-align-right {
+  padding-right: 12em;
+}
+.quill-styles li.ql-indent-4.ql-direction-rtl.ql-align-right {
+  padding-right: 13.5em;
+}
+.quill-styles .ql-indent-5:not(.ql-direction-rtl) {
+  padding-left: 15em;
+}
+.quill-styles li.ql-indent-5:not(.ql-direction-rtl) {
+  padding-left: 16.5em;
+}
+.quill-styles .ql-indent-5.ql-direction-rtl.ql-align-right {
+  padding-right: 15em;
+}
+.quill-styles li.ql-indent-5.ql-direction-rtl.ql-align-right {
+  padding-right: 16.5em;
+}
+.quill-styles .ql-indent-6:not(.ql-direction-rtl) {
+  padding-left: 18em;
+}
+.quill-styles li.ql-indent-6:not(.ql-direction-rtl) {
+  padding-left: 19.5em;
+}
+.quill-styles .ql-indent-6.ql-direction-rtl.ql-align-right {
+  padding-right: 18em;
+}
+.quill-styles li.ql-indent-6.ql-direction-rtl.ql-align-right {
+  padding-right: 19.5em;
+}
+.quill-styles .ql-indent-7:not(.ql-direction-rtl) {
+  padding-left: 21em;
+}
+.quill-styles li.ql-indent-7:not(.ql-direction-rtl) {
+  padding-left: 22.5em;
+}
+.quill-styles .ql-indent-7.ql-direction-rtl.ql-align-right {
+  padding-right: 21em;
+}
+.quill-styles li.ql-indent-7.ql-direction-rtl.ql-align-right {
+  padding-right: 22.5em;
+}
+.quill-styles .ql-indent-8:not(.ql-direction-rtl) {
+  padding-left: 24em;
+}
+.quill-styles li.ql-indent-8:not(.ql-direction-rtl) {
+  padding-left: 25.5em;
+}
+.quill-styles .ql-indent-8.ql-direction-rtl.ql-align-right {
+  padding-right: 24em;
+}
+.quill-styles li.ql-indent-8.ql-direction-rtl.ql-align-right {
+  padding-right: 25.5em;
+}
+.quill-styles .ql-indent-9:not(.ql-direction-rtl) {
+  padding-left: 27em;
+}
+.quill-styles li.ql-indent-9:not(.ql-direction-rtl) {
+  padding-left: 28.5em;
+}
+.quill-styles .ql-indent-9.ql-direction-rtl.ql-align-right {
+  padding-right: 27em;
+}
+.quill-styles li.ql-indent-9.ql-direction-rtl.ql-align-right {
+  padding-right: 28.5em;
+}
+
+.quill-styles .ql-indent-1.ql-direction-rtl.ql-align-right {
+  padding-right: 3em;
+}
+.quill-styles li.ql-indent-1.ql-direction-rtl.ql-align-right {
+  padding-right: 4.5em;
+}
+
+.quill-styles .ql-indent-2.ql-direction-rtl.ql-align-right {
+  padding-right: 6em;
+}
+.quill-styles li.ql-indent-2.ql-direction-rtl.ql-align-right {
+  padding-right: 7.5em;
+}
+
+.quill-styles .ql-indent-3.ql-direction-rtl.ql-align-right {
+  padding-right: 9em;
+}
+.quill-styles li.ql-indent-3.ql-direction-rtl.ql-align-right {
+  padding-right: 10.5em;
+}
+.quill-styles .ql-indent-4.ql-direction-rtl.ql-align-right {
+  padding-right: 12em;
+}
+.quill-styles li.ql-indent-4.ql-direction-rtl.ql-align-right {
+  padding-right: 13.5em;
+}
+.quill-styles .ql-indent-5.ql-direction-rtl.ql-align-right {
+  padding-right: 15em;
+}
+.quill-styles li.ql-indent-5.ql-direction-rtl.ql-align-right {
+  padding-right: 16.5em;
+}
+.quill-styles .ql-indent-6.ql-direction-rtl.ql-align-right {
+  padding-right: 18em;
+}
+.quill-styles li.ql-indent-6.ql-direction-rtl.ql-align-right {
+  padding-right: 19.5em;
+}
+.quill-styles .ql-indent-7.ql-direction-rtl.ql-align-right {
+  padding-right: 21em;
+}
+.quill-styles li.ql-indent-7.ql-direction-rtl.ql-align-right {
+  padding-right: 22.5em;
+}
+.quill-styles .ql-indent-8.ql-direction-rtl.ql-align-right {
+  padding-right: 24em;
+}
+.quill-styles li.ql-indent-8.ql-direction-rtl.ql-align-right {
+  padding-right: 25.5em;
+}
+.quill-styles .ql-indent-9.ql-direction-rtl.ql-align-right {
+  padding-right: 27em;
+}
+.quill-styles li.ql-indent-9.ql-direction-rtl.ql-align-right {
+  padding-right: 28.5em;
+}
+.quill-styles .ql-video.ql-align-center {
+  margin: 0 auto;
+}
+.quill-styles .ql-video.ql-align-right {
+  margin: 0 0 0 auto;
+}
+.quill-styles .ql-align-center {
+  text-align: center;
+}
+.quill-styles .ql-align-justify {
+  text-align: justify;
+}
+.quill-styles .ql-align-right {
+  text-align: right;
+}
+.quill-styles ul {
+  list-style: disc;
+  list-style-position: inside;
+}
+.quill-styles blockquote {
+  border-left: 4px solid #ccc;
+  margin-bottom: 5px;
+  margin-top: 5px;
+  padding-left: 16px;
+}

--- a/src/css/SiteAdmin.scss
+++ b/src/css/SiteAdmin.scss
@@ -33,6 +33,15 @@
   font-family: "Acherus", sans-serif;
 }
 
+.admin-content h1,
+.admin-content h2,
+.admin-content h3,
+.admin-content h4,
+.admin-content h5,
+.admin-content h6 {
+  font-family: "gineso-condensed", sans-serif;
+}
+
 .ui.form div.fields.sharing-options {
   margin: 0 0.5em 1em;
 }

--- a/src/css/adminForms.scss
+++ b/src/css/adminForms.scss
@@ -96,6 +96,41 @@ span.required {
   text-transform: none;
 }
 
+.ui.input .ui.label {
+  display: flex;
+  align-items: center;
+}
+
+.ui.form section > fieldset {
+  margin: 1rem;
+  padding: 1rem;
+  border-width: 2px;
+  border-style: solid;
+  border-color: #e0e1e2;
+}
+
+.ui.form section > fieldset > legend {
+  font-family: "gineso-condensed", sans-serif;
+}
+
+.ui.form section > fieldset .file-status {
+  padding: 1rem 0px;
+}
+
+.file-status > div > span {
+  font-weight: 700;
+}
+
+.file-status .download-link {
+  background-color: var(--light-gray);
+  border: none;
+  margin-left: 15px;
+}
+
+div.quill div.ql-tooltip.ql-editing input[type="text"] {
+  width: auto;
+}
+
 .wrap-content {
   overflow-wrap: anywhere;
 }
@@ -194,4 +229,46 @@ span.file-detail {
 
 h2.content-upload-prompt {
   font-size: 1.5rem;
+}
+
+.editor-modal-wrapper {
+  position: fixed;
+  top: 0;
+  left: 0;
+  width: 100%;
+  height: 100%;
+  z-index: 99999;
+  overflow: auto;
+  background-color: rgba(0, 0, 0, 0.4);
+}
+
+.editor-modal-wrapper .editor-wrapper {
+  position: absolute;
+  inset: 10%;
+}
+
+.quill {
+  background-color: white;
+  height: 100%;
+}
+
+.editor-wrapper .quill .ql-container {
+  height: calc(100% - 6rem);
+}
+
+@media (min-width: 465px) {
+  .editor-wrapper .quill .ql-container {
+    height: calc(100% - 4.375rem);
+  }
+}
+
+@media (min-width: 854px) {
+  .editor-wrapper .quill .ql-container {
+    height: calc(100% - 2.75rem);
+  }
+}
+
+.editor-wrapper .ui.button {
+  margin: 5px 0px 0px 0px;
+  width: 10rem;
 }

--- a/src/graphql/mutations.js
+++ b/src/graphql/mutations.js
@@ -664,6 +664,114 @@ export const deleteCollectionmap = /* GraphQL */ `
     }
   }
 `;
+export const createPageContent = /* GraphQL */ `
+  mutation CreatePageContent(
+    $input: CreatePageContentInput!
+    $condition: ModelPageContentConditionInput
+  ) {
+    createPageContent(input: $input, condition: $condition) {
+      page_content_category
+      id
+      content
+      pageContentSiteId {
+        analyticsID
+        assetBasePath
+        browseCollections
+        contact
+        displayedAttributes
+        groups
+        homePage
+        id
+        lang
+        miradorOptions
+        searchPage
+        siteColor
+        siteId
+        siteName
+        siteOptions
+        sitePages
+        siteTitle
+        createdAt
+        updatedAt
+      }
+      createdAt
+      updatedAt
+      pageContentPageContentSiteIdId
+    }
+  }
+`;
+export const updatePageContent = /* GraphQL */ `
+  mutation UpdatePageContent(
+    $input: UpdatePageContentInput!
+    $condition: ModelPageContentConditionInput
+  ) {
+    updatePageContent(input: $input, condition: $condition) {
+      page_content_category
+      id
+      content
+      pageContentSiteId {
+        analyticsID
+        assetBasePath
+        browseCollections
+        contact
+        displayedAttributes
+        groups
+        homePage
+        id
+        lang
+        miradorOptions
+        searchPage
+        siteColor
+        siteId
+        siteName
+        siteOptions
+        sitePages
+        siteTitle
+        createdAt
+        updatedAt
+      }
+      createdAt
+      updatedAt
+      pageContentPageContentSiteIdId
+    }
+  }
+`;
+export const deletePageContent = /* GraphQL */ `
+  mutation DeletePageContent(
+    $input: DeletePageContentInput!
+    $condition: ModelPageContentConditionInput
+  ) {
+    deletePageContent(input: $input, condition: $condition) {
+      page_content_category
+      id
+      content
+      pageContentSiteId {
+        analyticsID
+        assetBasePath
+        browseCollections
+        contact
+        displayedAttributes
+        groups
+        homePage
+        id
+        lang
+        miradorOptions
+        searchPage
+        siteColor
+        siteId
+        siteName
+        siteOptions
+        sitePages
+        siteTitle
+        createdAt
+        updatedAt
+      }
+      createdAt
+      updatedAt
+      pageContentPageContentSiteIdId
+    }
+  }
+`;
 export const createArchive = /* GraphQL */ `
   mutation CreateArchive(
     $input: CreateArchiveInput!

--- a/src/graphql/queries.js
+++ b/src/graphql/queries.js
@@ -804,6 +804,79 @@ export const listCollectionmaps = /* GraphQL */ `
     }
   }
 `;
+export const getPageContent = /* GraphQL */ `
+  query GetPageContent($id: ID!) {
+    getPageContent(id: $id) {
+      page_content_category
+      id
+      content
+      pageContentSiteId {
+        analyticsID
+        assetBasePath
+        browseCollections
+        contact
+        displayedAttributes
+        groups
+        homePage
+        id
+        lang
+        miradorOptions
+        searchPage
+        siteColor
+        siteId
+        siteName
+        siteOptions
+        sitePages
+        siteTitle
+        createdAt
+        updatedAt
+      }
+      createdAt
+      updatedAt
+      pageContentPageContentSiteIdId
+    }
+  }
+`;
+export const listPageContents = /* GraphQL */ `
+  query ListPageContents(
+    $filter: ModelPageContentFilterInput
+    $limit: Int
+    $nextToken: String
+  ) {
+    listPageContents(filter: $filter, limit: $limit, nextToken: $nextToken) {
+      items {
+        page_content_category
+        id
+        content
+        pageContentSiteId {
+          analyticsID
+          assetBasePath
+          browseCollections
+          contact
+          displayedAttributes
+          groups
+          homePage
+          id
+          lang
+          miradorOptions
+          searchPage
+          siteColor
+          siteId
+          siteName
+          siteOptions
+          sitePages
+          siteTitle
+          createdAt
+          updatedAt
+        }
+        createdAt
+        updatedAt
+        pageContentPageContentSiteIdId
+      }
+      nextToken
+    }
+  }
+`;
 export const getArchive = /* GraphQL */ `
   query GetArchive($id: ID!) {
     getArchive(id: $id) {

--- a/src/graphql/schema.json
+++ b/src/graphql/schema.json
@@ -494,6 +494,76 @@
               "deprecationReason": null
             },
             {
+              "name": "getPageContent",
+              "description": null,
+              "args": [
+                {
+                  "name": "id",
+                  "description": null,
+                  "type": {
+                    "kind": "NON_NULL",
+                    "name": null,
+                    "ofType": {
+                      "kind": "SCALAR",
+                      "name": "ID",
+                      "ofType": null
+                    }
+                  },
+                  "defaultValue": null
+                }
+              ],
+              "type": {
+                "kind": "OBJECT",
+                "name": "PageContent",
+                "ofType": null
+              },
+              "isDeprecated": false,
+              "deprecationReason": null
+            },
+            {
+              "name": "listPageContents",
+              "description": null,
+              "args": [
+                {
+                  "name": "filter",
+                  "description": null,
+                  "type": {
+                    "kind": "INPUT_OBJECT",
+                    "name": "ModelPageContentFilterInput",
+                    "ofType": null
+                  },
+                  "defaultValue": null
+                },
+                {
+                  "name": "limit",
+                  "description": null,
+                  "type": {
+                    "kind": "SCALAR",
+                    "name": "Int",
+                    "ofType": null
+                  },
+                  "defaultValue": null
+                },
+                {
+                  "name": "nextToken",
+                  "description": null,
+                  "type": {
+                    "kind": "SCALAR",
+                    "name": "String",
+                    "ofType": null
+                  },
+                  "defaultValue": null
+                }
+              ],
+              "type": {
+                "kind": "OBJECT",
+                "name": "ModelPageContentConnection",
+                "ofType": null
+              },
+              "isDeprecated": false,
+              "deprecationReason": null
+            },
+            {
               "name": "getArchive",
               "description": null,
               "args": [
@@ -7414,6 +7484,552 @@
           "possibleTypes": null
         },
         {
+          "kind": "OBJECT",
+          "name": "PageContent",
+          "description": null,
+          "fields": [
+            {
+              "name": "page_content_category",
+              "description": null,
+              "args": [],
+              "type": {
+                "kind": "NON_NULL",
+                "name": null,
+                "ofType": {
+                  "kind": "SCALAR",
+                  "name": "String",
+                  "ofType": null
+                }
+              },
+              "isDeprecated": false,
+              "deprecationReason": null
+            },
+            {
+              "name": "id",
+              "description": null,
+              "args": [],
+              "type": {
+                "kind": "NON_NULL",
+                "name": null,
+                "ofType": {
+                  "kind": "SCALAR",
+                  "name": "ID",
+                  "ofType": null
+                }
+              },
+              "isDeprecated": false,
+              "deprecationReason": null
+            },
+            {
+              "name": "content",
+              "description": null,
+              "args": [],
+              "type": {
+                "kind": "NON_NULL",
+                "name": null,
+                "ofType": {
+                  "kind": "SCALAR",
+                  "name": "String",
+                  "ofType": null
+                }
+              },
+              "isDeprecated": false,
+              "deprecationReason": null
+            },
+            {
+              "name": "pageContentSiteId",
+              "description": null,
+              "args": [],
+              "type": {
+                "kind": "OBJECT",
+                "name": "Site",
+                "ofType": null
+              },
+              "isDeprecated": false,
+              "deprecationReason": null
+            },
+            {
+              "name": "createdAt",
+              "description": null,
+              "args": [],
+              "type": {
+                "kind": "NON_NULL",
+                "name": null,
+                "ofType": {
+                  "kind": "SCALAR",
+                  "name": "AWSDateTime",
+                  "ofType": null
+                }
+              },
+              "isDeprecated": false,
+              "deprecationReason": null
+            },
+            {
+              "name": "updatedAt",
+              "description": null,
+              "args": [],
+              "type": {
+                "kind": "NON_NULL",
+                "name": null,
+                "ofType": {
+                  "kind": "SCALAR",
+                  "name": "AWSDateTime",
+                  "ofType": null
+                }
+              },
+              "isDeprecated": false,
+              "deprecationReason": null
+            },
+            {
+              "name": "pageContentPageContentSiteIdId",
+              "description": null,
+              "args": [],
+              "type": {
+                "kind": "SCALAR",
+                "name": "ID",
+                "ofType": null
+              },
+              "isDeprecated": false,
+              "deprecationReason": null
+            }
+          ],
+          "inputFields": null,
+          "interfaces": [],
+          "enumValues": null,
+          "possibleTypes": null
+        },
+        {
+          "kind": "OBJECT",
+          "name": "Site",
+          "description": null,
+          "fields": [
+            {
+              "name": "analyticsID",
+              "description": null,
+              "args": [],
+              "type": {
+                "kind": "SCALAR",
+                "name": "String",
+                "ofType": null
+              },
+              "isDeprecated": false,
+              "deprecationReason": null
+            },
+            {
+              "name": "assetBasePath",
+              "description": null,
+              "args": [],
+              "type": {
+                "kind": "SCALAR",
+                "name": "String",
+                "ofType": null
+              },
+              "isDeprecated": false,
+              "deprecationReason": null
+            },
+            {
+              "name": "browseCollections",
+              "description": null,
+              "args": [],
+              "type": {
+                "kind": "NON_NULL",
+                "name": null,
+                "ofType": {
+                  "kind": "SCALAR",
+                  "name": "AWSJSON",
+                  "ofType": null
+                }
+              },
+              "isDeprecated": false,
+              "deprecationReason": null
+            },
+            {
+              "name": "contact",
+              "description": null,
+              "args": [],
+              "type": {
+                "kind": "NON_NULL",
+                "name": null,
+                "ofType": {
+                  "kind": "LIST",
+                  "name": null,
+                  "ofType": {
+                    "kind": "NON_NULL",
+                    "name": null,
+                    "ofType": {
+                      "kind": "SCALAR",
+                      "name": "AWSJSON",
+                      "ofType": null
+                    }
+                  }
+                }
+              },
+              "isDeprecated": false,
+              "deprecationReason": null
+            },
+            {
+              "name": "displayedAttributes",
+              "description": null,
+              "args": [],
+              "type": {
+                "kind": "NON_NULL",
+                "name": null,
+                "ofType": {
+                  "kind": "SCALAR",
+                  "name": "AWSJSON",
+                  "ofType": null
+                }
+              },
+              "isDeprecated": false,
+              "deprecationReason": null
+            },
+            {
+              "name": "groups",
+              "description": null,
+              "args": [],
+              "type": {
+                "kind": "NON_NULL",
+                "name": null,
+                "ofType": {
+                  "kind": "LIST",
+                  "name": null,
+                  "ofType": {
+                    "kind": "SCALAR",
+                    "name": "String",
+                    "ofType": null
+                  }
+                }
+              },
+              "isDeprecated": false,
+              "deprecationReason": null
+            },
+            {
+              "name": "homePage",
+              "description": null,
+              "args": [],
+              "type": {
+                "kind": "NON_NULL",
+                "name": null,
+                "ofType": {
+                  "kind": "SCALAR",
+                  "name": "AWSJSON",
+                  "ofType": null
+                }
+              },
+              "isDeprecated": false,
+              "deprecationReason": null
+            },
+            {
+              "name": "id",
+              "description": null,
+              "args": [],
+              "type": {
+                "kind": "NON_NULL",
+                "name": null,
+                "ofType": {
+                  "kind": "SCALAR",
+                  "name": "ID",
+                  "ofType": null
+                }
+              },
+              "isDeprecated": false,
+              "deprecationReason": null
+            },
+            {
+              "name": "lang",
+              "description": null,
+              "args": [],
+              "type": {
+                "kind": "SCALAR",
+                "name": "String",
+                "ofType": null
+              },
+              "isDeprecated": false,
+              "deprecationReason": null
+            },
+            {
+              "name": "miradorOptions",
+              "description": null,
+              "args": [],
+              "type": {
+                "kind": "SCALAR",
+                "name": "AWSJSON",
+                "ofType": null
+              },
+              "isDeprecated": false,
+              "deprecationReason": null
+            },
+            {
+              "name": "searchPage",
+              "description": null,
+              "args": [],
+              "type": {
+                "kind": "NON_NULL",
+                "name": null,
+                "ofType": {
+                  "kind": "SCALAR",
+                  "name": "AWSJSON",
+                  "ofType": null
+                }
+              },
+              "isDeprecated": false,
+              "deprecationReason": null
+            },
+            {
+              "name": "siteColor",
+              "description": null,
+              "args": [],
+              "type": {
+                "kind": "SCALAR",
+                "name": "String",
+                "ofType": null
+              },
+              "isDeprecated": false,
+              "deprecationReason": null
+            },
+            {
+              "name": "siteId",
+              "description": null,
+              "args": [],
+              "type": {
+                "kind": "NON_NULL",
+                "name": null,
+                "ofType": {
+                  "kind": "SCALAR",
+                  "name": "String",
+                  "ofType": null
+                }
+              },
+              "isDeprecated": false,
+              "deprecationReason": null
+            },
+            {
+              "name": "siteName",
+              "description": null,
+              "args": [],
+              "type": {
+                "kind": "NON_NULL",
+                "name": null,
+                "ofType": {
+                  "kind": "SCALAR",
+                  "name": "String",
+                  "ofType": null
+                }
+              },
+              "isDeprecated": false,
+              "deprecationReason": null
+            },
+            {
+              "name": "siteOptions",
+              "description": null,
+              "args": [],
+              "type": {
+                "kind": "SCALAR",
+                "name": "AWSJSON",
+                "ofType": null
+              },
+              "isDeprecated": false,
+              "deprecationReason": null
+            },
+            {
+              "name": "sitePages",
+              "description": null,
+              "args": [],
+              "type": {
+                "kind": "SCALAR",
+                "name": "AWSJSON",
+                "ofType": null
+              },
+              "isDeprecated": false,
+              "deprecationReason": null
+            },
+            {
+              "name": "siteTitle",
+              "description": null,
+              "args": [],
+              "type": {
+                "kind": "NON_NULL",
+                "name": null,
+                "ofType": {
+                  "kind": "SCALAR",
+                  "name": "String",
+                  "ofType": null
+                }
+              },
+              "isDeprecated": false,
+              "deprecationReason": null
+            },
+            {
+              "name": "createdAt",
+              "description": null,
+              "args": [],
+              "type": {
+                "kind": "NON_NULL",
+                "name": null,
+                "ofType": {
+                  "kind": "SCALAR",
+                  "name": "AWSDateTime",
+                  "ofType": null
+                }
+              },
+              "isDeprecated": false,
+              "deprecationReason": null
+            },
+            {
+              "name": "updatedAt",
+              "description": null,
+              "args": [],
+              "type": {
+                "kind": "NON_NULL",
+                "name": null,
+                "ofType": {
+                  "kind": "SCALAR",
+                  "name": "AWSDateTime",
+                  "ofType": null
+                }
+              },
+              "isDeprecated": false,
+              "deprecationReason": null
+            }
+          ],
+          "inputFields": null,
+          "interfaces": [],
+          "enumValues": null,
+          "possibleTypes": null
+        },
+        {
+          "kind": "OBJECT",
+          "name": "ModelPageContentConnection",
+          "description": null,
+          "fields": [
+            {
+              "name": "items",
+              "description": null,
+              "args": [],
+              "type": {
+                "kind": "NON_NULL",
+                "name": null,
+                "ofType": {
+                  "kind": "LIST",
+                  "name": null,
+                  "ofType": {
+                    "kind": "OBJECT",
+                    "name": "PageContent",
+                    "ofType": null
+                  }
+                }
+              },
+              "isDeprecated": false,
+              "deprecationReason": null
+            },
+            {
+              "name": "nextToken",
+              "description": null,
+              "args": [],
+              "type": {
+                "kind": "SCALAR",
+                "name": "String",
+                "ofType": null
+              },
+              "isDeprecated": false,
+              "deprecationReason": null
+            }
+          ],
+          "inputFields": null,
+          "interfaces": [],
+          "enumValues": null,
+          "possibleTypes": null
+        },
+        {
+          "kind": "INPUT_OBJECT",
+          "name": "ModelPageContentFilterInput",
+          "description": null,
+          "fields": null,
+          "inputFields": [
+            {
+              "name": "page_content_category",
+              "description": null,
+              "type": {
+                "kind": "INPUT_OBJECT",
+                "name": "ModelStringInput",
+                "ofType": null
+              },
+              "defaultValue": null
+            },
+            {
+              "name": "id",
+              "description": null,
+              "type": {
+                "kind": "INPUT_OBJECT",
+                "name": "ModelIDInput",
+                "ofType": null
+              },
+              "defaultValue": null
+            },
+            {
+              "name": "content",
+              "description": null,
+              "type": {
+                "kind": "INPUT_OBJECT",
+                "name": "ModelStringInput",
+                "ofType": null
+              },
+              "defaultValue": null
+            },
+            {
+              "name": "and",
+              "description": null,
+              "type": {
+                "kind": "LIST",
+                "name": null,
+                "ofType": {
+                  "kind": "INPUT_OBJECT",
+                  "name": "ModelPageContentFilterInput",
+                  "ofType": null
+                }
+              },
+              "defaultValue": null
+            },
+            {
+              "name": "or",
+              "description": null,
+              "type": {
+                "kind": "LIST",
+                "name": null,
+                "ofType": {
+                  "kind": "INPUT_OBJECT",
+                  "name": "ModelPageContentFilterInput",
+                  "ofType": null
+                }
+              },
+              "defaultValue": null
+            },
+            {
+              "name": "not",
+              "description": null,
+              "type": {
+                "kind": "INPUT_OBJECT",
+                "name": "ModelPageContentFilterInput",
+                "ofType": null
+              },
+              "defaultValue": null
+            },
+            {
+              "name": "pageContentPageContentSiteIdId",
+              "description": null,
+              "type": {
+                "kind": "INPUT_OBJECT",
+                "name": "ModelIDInput",
+                "ofType": null
+              },
+              "defaultValue": null
+            }
+          ],
+          "interfaces": null,
+          "enumValues": null,
+          "possibleTypes": null
+        },
+        {
           "kind": "INPUT_OBJECT",
           "name": "SearchableArchiveAggregationInput",
           "description": null,
@@ -8111,305 +8727,6 @@
             }
           ],
           "interfaces": null,
-          "enumValues": null,
-          "possibleTypes": null
-        },
-        {
-          "kind": "OBJECT",
-          "name": "Site",
-          "description": null,
-          "fields": [
-            {
-              "name": "analyticsID",
-              "description": null,
-              "args": [],
-              "type": {
-                "kind": "SCALAR",
-                "name": "String",
-                "ofType": null
-              },
-              "isDeprecated": false,
-              "deprecationReason": null
-            },
-            {
-              "name": "assetBasePath",
-              "description": null,
-              "args": [],
-              "type": {
-                "kind": "SCALAR",
-                "name": "String",
-                "ofType": null
-              },
-              "isDeprecated": false,
-              "deprecationReason": null
-            },
-            {
-              "name": "browseCollections",
-              "description": null,
-              "args": [],
-              "type": {
-                "kind": "NON_NULL",
-                "name": null,
-                "ofType": {
-                  "kind": "SCALAR",
-                  "name": "AWSJSON",
-                  "ofType": null
-                }
-              },
-              "isDeprecated": false,
-              "deprecationReason": null
-            },
-            {
-              "name": "contact",
-              "description": null,
-              "args": [],
-              "type": {
-                "kind": "NON_NULL",
-                "name": null,
-                "ofType": {
-                  "kind": "LIST",
-                  "name": null,
-                  "ofType": {
-                    "kind": "NON_NULL",
-                    "name": null,
-                    "ofType": {
-                      "kind": "SCALAR",
-                      "name": "AWSJSON",
-                      "ofType": null
-                    }
-                  }
-                }
-              },
-              "isDeprecated": false,
-              "deprecationReason": null
-            },
-            {
-              "name": "displayedAttributes",
-              "description": null,
-              "args": [],
-              "type": {
-                "kind": "NON_NULL",
-                "name": null,
-                "ofType": {
-                  "kind": "SCALAR",
-                  "name": "AWSJSON",
-                  "ofType": null
-                }
-              },
-              "isDeprecated": false,
-              "deprecationReason": null
-            },
-            {
-              "name": "groups",
-              "description": null,
-              "args": [],
-              "type": {
-                "kind": "NON_NULL",
-                "name": null,
-                "ofType": {
-                  "kind": "LIST",
-                  "name": null,
-                  "ofType": {
-                    "kind": "SCALAR",
-                    "name": "String",
-                    "ofType": null
-                  }
-                }
-              },
-              "isDeprecated": false,
-              "deprecationReason": null
-            },
-            {
-              "name": "homePage",
-              "description": null,
-              "args": [],
-              "type": {
-                "kind": "NON_NULL",
-                "name": null,
-                "ofType": {
-                  "kind": "SCALAR",
-                  "name": "AWSJSON",
-                  "ofType": null
-                }
-              },
-              "isDeprecated": false,
-              "deprecationReason": null
-            },
-            {
-              "name": "id",
-              "description": null,
-              "args": [],
-              "type": {
-                "kind": "NON_NULL",
-                "name": null,
-                "ofType": {
-                  "kind": "SCALAR",
-                  "name": "ID",
-                  "ofType": null
-                }
-              },
-              "isDeprecated": false,
-              "deprecationReason": null
-            },
-            {
-              "name": "lang",
-              "description": null,
-              "args": [],
-              "type": {
-                "kind": "SCALAR",
-                "name": "String",
-                "ofType": null
-              },
-              "isDeprecated": false,
-              "deprecationReason": null
-            },
-            {
-              "name": "miradorOptions",
-              "description": null,
-              "args": [],
-              "type": {
-                "kind": "SCALAR",
-                "name": "AWSJSON",
-                "ofType": null
-              },
-              "isDeprecated": false,
-              "deprecationReason": null
-            },
-            {
-              "name": "searchPage",
-              "description": null,
-              "args": [],
-              "type": {
-                "kind": "NON_NULL",
-                "name": null,
-                "ofType": {
-                  "kind": "SCALAR",
-                  "name": "AWSJSON",
-                  "ofType": null
-                }
-              },
-              "isDeprecated": false,
-              "deprecationReason": null
-            },
-            {
-              "name": "siteColor",
-              "description": null,
-              "args": [],
-              "type": {
-                "kind": "SCALAR",
-                "name": "String",
-                "ofType": null
-              },
-              "isDeprecated": false,
-              "deprecationReason": null
-            },
-            {
-              "name": "siteId",
-              "description": null,
-              "args": [],
-              "type": {
-                "kind": "NON_NULL",
-                "name": null,
-                "ofType": {
-                  "kind": "SCALAR",
-                  "name": "String",
-                  "ofType": null
-                }
-              },
-              "isDeprecated": false,
-              "deprecationReason": null
-            },
-            {
-              "name": "siteName",
-              "description": null,
-              "args": [],
-              "type": {
-                "kind": "NON_NULL",
-                "name": null,
-                "ofType": {
-                  "kind": "SCALAR",
-                  "name": "String",
-                  "ofType": null
-                }
-              },
-              "isDeprecated": false,
-              "deprecationReason": null
-            },
-            {
-              "name": "siteOptions",
-              "description": null,
-              "args": [],
-              "type": {
-                "kind": "SCALAR",
-                "name": "AWSJSON",
-                "ofType": null
-              },
-              "isDeprecated": false,
-              "deprecationReason": null
-            },
-            {
-              "name": "sitePages",
-              "description": null,
-              "args": [],
-              "type": {
-                "kind": "SCALAR",
-                "name": "AWSJSON",
-                "ofType": null
-              },
-              "isDeprecated": false,
-              "deprecationReason": null
-            },
-            {
-              "name": "siteTitle",
-              "description": null,
-              "args": [],
-              "type": {
-                "kind": "NON_NULL",
-                "name": null,
-                "ofType": {
-                  "kind": "SCALAR",
-                  "name": "String",
-                  "ofType": null
-                }
-              },
-              "isDeprecated": false,
-              "deprecationReason": null
-            },
-            {
-              "name": "createdAt",
-              "description": null,
-              "args": [],
-              "type": {
-                "kind": "NON_NULL",
-                "name": null,
-                "ofType": {
-                  "kind": "SCALAR",
-                  "name": "AWSDateTime",
-                  "ofType": null
-                }
-              },
-              "isDeprecated": false,
-              "deprecationReason": null
-            },
-            {
-              "name": "updatedAt",
-              "description": null,
-              "args": [],
-              "type": {
-                "kind": "NON_NULL",
-                "name": null,
-                "ofType": {
-                  "kind": "SCALAR",
-                  "name": "AWSDateTime",
-                  "ofType": null
-                }
-              },
-              "isDeprecated": false,
-              "deprecationReason": null
-            }
-          ],
-          "inputFields": null,
-          "interfaces": [],
           "enumValues": null,
           "possibleTypes": null
         },
@@ -9176,6 +9493,117 @@
               "type": {
                 "kind": "OBJECT",
                 "name": "Collectionmap",
+                "ofType": null
+              },
+              "isDeprecated": false,
+              "deprecationReason": null
+            },
+            {
+              "name": "createPageContent",
+              "description": null,
+              "args": [
+                {
+                  "name": "input",
+                  "description": null,
+                  "type": {
+                    "kind": "NON_NULL",
+                    "name": null,
+                    "ofType": {
+                      "kind": "INPUT_OBJECT",
+                      "name": "CreatePageContentInput",
+                      "ofType": null
+                    }
+                  },
+                  "defaultValue": null
+                },
+                {
+                  "name": "condition",
+                  "description": null,
+                  "type": {
+                    "kind": "INPUT_OBJECT",
+                    "name": "ModelPageContentConditionInput",
+                    "ofType": null
+                  },
+                  "defaultValue": null
+                }
+              ],
+              "type": {
+                "kind": "OBJECT",
+                "name": "PageContent",
+                "ofType": null
+              },
+              "isDeprecated": false,
+              "deprecationReason": null
+            },
+            {
+              "name": "updatePageContent",
+              "description": null,
+              "args": [
+                {
+                  "name": "input",
+                  "description": null,
+                  "type": {
+                    "kind": "NON_NULL",
+                    "name": null,
+                    "ofType": {
+                      "kind": "INPUT_OBJECT",
+                      "name": "UpdatePageContentInput",
+                      "ofType": null
+                    }
+                  },
+                  "defaultValue": null
+                },
+                {
+                  "name": "condition",
+                  "description": null,
+                  "type": {
+                    "kind": "INPUT_OBJECT",
+                    "name": "ModelPageContentConditionInput",
+                    "ofType": null
+                  },
+                  "defaultValue": null
+                }
+              ],
+              "type": {
+                "kind": "OBJECT",
+                "name": "PageContent",
+                "ofType": null
+              },
+              "isDeprecated": false,
+              "deprecationReason": null
+            },
+            {
+              "name": "deletePageContent",
+              "description": null,
+              "args": [
+                {
+                  "name": "input",
+                  "description": null,
+                  "type": {
+                    "kind": "NON_NULL",
+                    "name": null,
+                    "ofType": {
+                      "kind": "INPUT_OBJECT",
+                      "name": "DeletePageContentInput",
+                      "ofType": null
+                    }
+                  },
+                  "defaultValue": null
+                },
+                {
+                  "name": "condition",
+                  "description": null,
+                  "type": {
+                    "kind": "INPUT_OBJECT",
+                    "name": "ModelPageContentConditionInput",
+                    "ofType": null
+                  },
+                  "defaultValue": null
+                }
+              ],
+              "type": {
+                "kind": "OBJECT",
+                "name": "PageContent",
                 "ofType": null
               },
               "isDeprecated": false,
@@ -11163,6 +11591,224 @@
         {
           "kind": "INPUT_OBJECT",
           "name": "DeleteCollectionmapInput",
+          "description": null,
+          "fields": null,
+          "inputFields": [
+            {
+              "name": "id",
+              "description": null,
+              "type": {
+                "kind": "NON_NULL",
+                "name": null,
+                "ofType": {
+                  "kind": "SCALAR",
+                  "name": "ID",
+                  "ofType": null
+                }
+              },
+              "defaultValue": null
+            }
+          ],
+          "interfaces": null,
+          "enumValues": null,
+          "possibleTypes": null
+        },
+        {
+          "kind": "INPUT_OBJECT",
+          "name": "CreatePageContentInput",
+          "description": null,
+          "fields": null,
+          "inputFields": [
+            {
+              "name": "page_content_category",
+              "description": null,
+              "type": {
+                "kind": "NON_NULL",
+                "name": null,
+                "ofType": {
+                  "kind": "SCALAR",
+                  "name": "String",
+                  "ofType": null
+                }
+              },
+              "defaultValue": null
+            },
+            {
+              "name": "id",
+              "description": null,
+              "type": {
+                "kind": "SCALAR",
+                "name": "ID",
+                "ofType": null
+              },
+              "defaultValue": null
+            },
+            {
+              "name": "content",
+              "description": null,
+              "type": {
+                "kind": "NON_NULL",
+                "name": null,
+                "ofType": {
+                  "kind": "SCALAR",
+                  "name": "String",
+                  "ofType": null
+                }
+              },
+              "defaultValue": null
+            },
+            {
+              "name": "pageContentPageContentSiteIdId",
+              "description": null,
+              "type": {
+                "kind": "SCALAR",
+                "name": "ID",
+                "ofType": null
+              },
+              "defaultValue": null
+            }
+          ],
+          "interfaces": null,
+          "enumValues": null,
+          "possibleTypes": null
+        },
+        {
+          "kind": "INPUT_OBJECT",
+          "name": "ModelPageContentConditionInput",
+          "description": null,
+          "fields": null,
+          "inputFields": [
+            {
+              "name": "page_content_category",
+              "description": null,
+              "type": {
+                "kind": "INPUT_OBJECT",
+                "name": "ModelStringInput",
+                "ofType": null
+              },
+              "defaultValue": null
+            },
+            {
+              "name": "content",
+              "description": null,
+              "type": {
+                "kind": "INPUT_OBJECT",
+                "name": "ModelStringInput",
+                "ofType": null
+              },
+              "defaultValue": null
+            },
+            {
+              "name": "and",
+              "description": null,
+              "type": {
+                "kind": "LIST",
+                "name": null,
+                "ofType": {
+                  "kind": "INPUT_OBJECT",
+                  "name": "ModelPageContentConditionInput",
+                  "ofType": null
+                }
+              },
+              "defaultValue": null
+            },
+            {
+              "name": "or",
+              "description": null,
+              "type": {
+                "kind": "LIST",
+                "name": null,
+                "ofType": {
+                  "kind": "INPUT_OBJECT",
+                  "name": "ModelPageContentConditionInput",
+                  "ofType": null
+                }
+              },
+              "defaultValue": null
+            },
+            {
+              "name": "not",
+              "description": null,
+              "type": {
+                "kind": "INPUT_OBJECT",
+                "name": "ModelPageContentConditionInput",
+                "ofType": null
+              },
+              "defaultValue": null
+            },
+            {
+              "name": "pageContentPageContentSiteIdId",
+              "description": null,
+              "type": {
+                "kind": "INPUT_OBJECT",
+                "name": "ModelIDInput",
+                "ofType": null
+              },
+              "defaultValue": null
+            }
+          ],
+          "interfaces": null,
+          "enumValues": null,
+          "possibleTypes": null
+        },
+        {
+          "kind": "INPUT_OBJECT",
+          "name": "UpdatePageContentInput",
+          "description": null,
+          "fields": null,
+          "inputFields": [
+            {
+              "name": "page_content_category",
+              "description": null,
+              "type": {
+                "kind": "SCALAR",
+                "name": "String",
+                "ofType": null
+              },
+              "defaultValue": null
+            },
+            {
+              "name": "id",
+              "description": null,
+              "type": {
+                "kind": "NON_NULL",
+                "name": null,
+                "ofType": {
+                  "kind": "SCALAR",
+                  "name": "ID",
+                  "ofType": null
+                }
+              },
+              "defaultValue": null
+            },
+            {
+              "name": "content",
+              "description": null,
+              "type": {
+                "kind": "SCALAR",
+                "name": "String",
+                "ofType": null
+              },
+              "defaultValue": null
+            },
+            {
+              "name": "pageContentPageContentSiteIdId",
+              "description": null,
+              "type": {
+                "kind": "SCALAR",
+                "name": "ID",
+                "ofType": null
+              },
+              "defaultValue": null
+            }
+          ],
+          "interfaces": null,
+          "enumValues": null,
+          "possibleTypes": null
+        },
+        {
+          "kind": "INPUT_OBJECT",
+          "name": "DeletePageContentInput",
           "description": null,
           "fields": null,
           "inputFields": [
@@ -14849,6 +15495,42 @@
               "deprecationReason": null
             },
             {
+              "name": "onCreatePageContent",
+              "description": null,
+              "args": [],
+              "type": {
+                "kind": "OBJECT",
+                "name": "PageContent",
+                "ofType": null
+              },
+              "isDeprecated": false,
+              "deprecationReason": null
+            },
+            {
+              "name": "onUpdatePageContent",
+              "description": null,
+              "args": [],
+              "type": {
+                "kind": "OBJECT",
+                "name": "PageContent",
+                "ofType": null
+              },
+              "isDeprecated": false,
+              "deprecationReason": null
+            },
+            {
+              "name": "onDeletePageContent",
+              "description": null,
+              "args": [],
+              "type": {
+                "kind": "OBJECT",
+                "name": "PageContent",
+                "ofType": null
+              },
+              "isDeprecated": false,
+              "deprecationReason": null
+            },
+            {
               "name": "onCreateArchive",
               "description": null,
               "args": [
@@ -15131,336 +15813,439 @@
           "possibleTypes": null
         },
         {
+          "kind": "UNION",
+          "name": "SearchableAggregateGenericResult",
+          "description": null,
+          "fields": null,
+          "inputFields": null,
+          "interfaces": null,
+          "enumValues": null,
+          "possibleTypes": [
+            {
+              "kind": "OBJECT",
+              "name": "SearchableAggregateScalarResult",
+              "ofType": null
+            },
+            {
+              "kind": "OBJECT",
+              "name": "SearchableAggregateBucketResult",
+              "ofType": null
+            }
+          ]
+        },
+        {
+          "kind": "OBJECT",
+          "name": "SearchableAggregateScalarResult",
+          "description": null,
+          "fields": [
+            {
+              "name": "value",
+              "description": null,
+              "args": [],
+              "type": {
+                "kind": "NON_NULL",
+                "name": null,
+                "ofType": {
+                  "kind": "SCALAR",
+                  "name": "Float",
+                  "ofType": null
+                }
+              },
+              "isDeprecated": false,
+              "deprecationReason": null
+            }
+          ],
+          "inputFields": null,
+          "interfaces": [],
+          "enumValues": null,
+          "possibleTypes": null
+        },
+        {
+          "kind": "SCALAR",
+          "name": "Float",
+          "description": "Built-in Float",
+          "fields": null,
+          "inputFields": null,
+          "interfaces": null,
+          "enumValues": null,
+          "possibleTypes": null
+        },
+        {
+          "kind": "OBJECT",
+          "name": "SearchableAggregateBucketResult",
+          "description": null,
+          "fields": [
+            {
+              "name": "buckets",
+              "description": null,
+              "args": [],
+              "type": {
+                "kind": "LIST",
+                "name": null,
+                "ofType": {
+                  "kind": "OBJECT",
+                  "name": "SearchableAggregateBucketResultItem",
+                  "ofType": null
+                }
+              },
+              "isDeprecated": false,
+              "deprecationReason": null
+            }
+          ],
+          "inputFields": null,
+          "interfaces": [],
+          "enumValues": null,
+          "possibleTypes": null
+        },
+        {
+          "kind": "OBJECT",
+          "name": "SearchableAggregateBucketResultItem",
+          "description": null,
+          "fields": [
+            {
+              "name": "key",
+              "description": null,
+              "args": [],
+              "type": {
+                "kind": "NON_NULL",
+                "name": null,
+                "ofType": {
+                  "kind": "SCALAR",
+                  "name": "String",
+                  "ofType": null
+                }
+              },
+              "isDeprecated": false,
+              "deprecationReason": null
+            },
+            {
+              "name": "doc_count",
+              "description": null,
+              "args": [],
+              "type": {
+                "kind": "NON_NULL",
+                "name": null,
+                "ofType": {
+                  "kind": "SCALAR",
+                  "name": "Int",
+                  "ofType": null
+                }
+              },
+              "isDeprecated": false,
+              "deprecationReason": null
+            }
+          ],
+          "inputFields": null,
+          "interfaces": [],
+          "enumValues": null,
+          "possibleTypes": null
+        },
+        {
           "kind": "INPUT_OBJECT",
-          "name": "ModelSubscriptionCollectionFilterInput",
+          "name": "SearchableIntFilterInput",
           "description": null,
           "fields": null,
           "inputFields": [
             {
-              "name": "belongs_to",
+              "name": "ne",
               "description": null,
               "type": {
-                "kind": "INPUT_OBJECT",
-                "name": "ModelSubscriptionStringInput",
+                "kind": "SCALAR",
+                "name": "Int",
                 "ofType": null
               },
               "defaultValue": null
             },
             {
-              "name": "bibliographic_citation",
+              "name": "gt",
               "description": null,
               "type": {
-                "kind": "INPUT_OBJECT",
-                "name": "ModelSubscriptionStringInput",
+                "kind": "SCALAR",
+                "name": "Int",
                 "ofType": null
               },
               "defaultValue": null
             },
             {
-              "name": "circa",
+              "name": "lt",
               "description": null,
               "type": {
-                "kind": "INPUT_OBJECT",
-                "name": "ModelSubscriptionStringInput",
+                "kind": "SCALAR",
+                "name": "Int",
                 "ofType": null
               },
               "defaultValue": null
             },
             {
-              "name": "collectionmap_id",
+              "name": "gte",
               "description": null,
               "type": {
-                "kind": "INPUT_OBJECT",
-                "name": "ModelSubscriptionStringInput",
+                "kind": "SCALAR",
+                "name": "Int",
                 "ofType": null
               },
               "defaultValue": null
             },
             {
-              "name": "collectionOptions",
+              "name": "lte",
               "description": null,
               "type": {
-                "kind": "INPUT_OBJECT",
-                "name": "ModelSubscriptionStringInput",
+                "kind": "SCALAR",
+                "name": "Int",
                 "ofType": null
               },
               "defaultValue": null
             },
             {
-              "name": "create_date",
+              "name": "eq",
               "description": null,
               "type": {
-                "kind": "INPUT_OBJECT",
-                "name": "ModelSubscriptionStringInput",
+                "kind": "SCALAR",
+                "name": "Int",
                 "ofType": null
               },
               "defaultValue": null
             },
             {
-              "name": "creator",
-              "description": null,
-              "type": {
-                "kind": "INPUT_OBJECT",
-                "name": "ModelSubscriptionStringInput",
-                "ofType": null
-              },
-              "defaultValue": null
-            },
-            {
-              "name": "custom_key",
-              "description": null,
-              "type": {
-                "kind": "INPUT_OBJECT",
-                "name": "ModelSubscriptionStringInput",
-                "ofType": null
-              },
-              "defaultValue": null
-            },
-            {
-              "name": "description",
-              "description": null,
-              "type": {
-                "kind": "INPUT_OBJECT",
-                "name": "ModelSubscriptionStringInput",
-                "ofType": null
-              },
-              "defaultValue": null
-            },
-            {
-              "name": "display_date",
-              "description": null,
-              "type": {
-                "kind": "INPUT_OBJECT",
-                "name": "ModelSubscriptionStringInput",
-                "ofType": null
-              },
-              "defaultValue": null
-            },
-            {
-              "name": "end_date",
-              "description": null,
-              "type": {
-                "kind": "INPUT_OBJECT",
-                "name": "ModelSubscriptionStringInput",
-                "ofType": null
-              },
-              "defaultValue": null
-            },
-            {
-              "name": "explicit_content",
-              "description": null,
-              "type": {
-                "kind": "INPUT_OBJECT",
-                "name": "ModelSubscriptionBooleanInput",
-                "ofType": null
-              },
-              "defaultValue": null
-            },
-            {
-              "name": "heirarchy_path",
-              "description": null,
-              "type": {
-                "kind": "INPUT_OBJECT",
-                "name": "ModelSubscriptionStringInput",
-                "ofType": null
-              },
-              "defaultValue": null
-            },
-            {
-              "name": "id",
-              "description": null,
-              "type": {
-                "kind": "INPUT_OBJECT",
-                "name": "ModelSubscriptionIDInput",
-                "ofType": null
-              },
-              "defaultValue": null
-            },
-            {
-              "name": "identifier",
-              "description": null,
-              "type": {
-                "kind": "INPUT_OBJECT",
-                "name": "ModelSubscriptionStringInput",
-                "ofType": null
-              },
-              "defaultValue": null
-            },
-            {
-              "name": "language",
-              "description": null,
-              "type": {
-                "kind": "INPUT_OBJECT",
-                "name": "ModelSubscriptionStringInput",
-                "ofType": null
-              },
-              "defaultValue": null
-            },
-            {
-              "name": "location",
-              "description": null,
-              "type": {
-                "kind": "INPUT_OBJECT",
-                "name": "ModelSubscriptionStringInput",
-                "ofType": null
-              },
-              "defaultValue": null
-            },
-            {
-              "name": "modified_date",
-              "description": null,
-              "type": {
-                "kind": "INPUT_OBJECT",
-                "name": "ModelSubscriptionStringInput",
-                "ofType": null
-              },
-              "defaultValue": null
-            },
-            {
-              "name": "ownerinfo",
-              "description": null,
-              "type": {
-                "kind": "INPUT_OBJECT",
-                "name": "ModelSubscriptionStringInput",
-                "ofType": null
-              },
-              "defaultValue": null
-            },
-            {
-              "name": "parent_collection",
-              "description": null,
-              "type": {
-                "kind": "INPUT_OBJECT",
-                "name": "ModelSubscriptionStringInput",
-                "ofType": null
-              },
-              "defaultValue": null
-            },
-            {
-              "name": "provenance",
-              "description": null,
-              "type": {
-                "kind": "INPUT_OBJECT",
-                "name": "ModelSubscriptionStringInput",
-                "ofType": null
-              },
-              "defaultValue": null
-            },
-            {
-              "name": "related_url",
-              "description": null,
-              "type": {
-                "kind": "INPUT_OBJECT",
-                "name": "ModelSubscriptionStringInput",
-                "ofType": null
-              },
-              "defaultValue": null
-            },
-            {
-              "name": "rights_holder",
-              "description": null,
-              "type": {
-                "kind": "INPUT_OBJECT",
-                "name": "ModelSubscriptionStringInput",
-                "ofType": null
-              },
-              "defaultValue": null
-            },
-            {
-              "name": "rights_statement",
-              "description": null,
-              "type": {
-                "kind": "INPUT_OBJECT",
-                "name": "ModelSubscriptionStringInput",
-                "ofType": null
-              },
-              "defaultValue": null
-            },
-            {
-              "name": "source",
-              "description": null,
-              "type": {
-                "kind": "INPUT_OBJECT",
-                "name": "ModelSubscriptionStringInput",
-                "ofType": null
-              },
-              "defaultValue": null
-            },
-            {
-              "name": "start_date",
-              "description": null,
-              "type": {
-                "kind": "INPUT_OBJECT",
-                "name": "ModelSubscriptionStringInput",
-                "ofType": null
-              },
-              "defaultValue": null
-            },
-            {
-              "name": "subject",
-              "description": null,
-              "type": {
-                "kind": "INPUT_OBJECT",
-                "name": "ModelSubscriptionStringInput",
-                "ofType": null
-              },
-              "defaultValue": null
-            },
-            {
-              "name": "thumbnail_path",
-              "description": null,
-              "type": {
-                "kind": "INPUT_OBJECT",
-                "name": "ModelSubscriptionStringInput",
-                "ofType": null
-              },
-              "defaultValue": null
-            },
-            {
-              "name": "title",
-              "description": null,
-              "type": {
-                "kind": "INPUT_OBJECT",
-                "name": "ModelSubscriptionStringInput",
-                "ofType": null
-              },
-              "defaultValue": null
-            },
-            {
-              "name": "visibility",
-              "description": null,
-              "type": {
-                "kind": "INPUT_OBJECT",
-                "name": "ModelSubscriptionBooleanInput",
-                "ofType": null
-              },
-              "defaultValue": null
-            },
-            {
-              "name": "and",
+              "name": "range",
               "description": null,
               "type": {
                 "kind": "LIST",
                 "name": null,
                 "ofType": {
-                  "kind": "INPUT_OBJECT",
-                  "name": "ModelSubscriptionCollectionFilterInput",
+                  "kind": "SCALAR",
+                  "name": "Int",
+                  "ofType": null
+                }
+              },
+              "defaultValue": null
+            }
+          ],
+          "interfaces": null,
+          "enumValues": null,
+          "possibleTypes": null
+        },
+        {
+          "kind": "INPUT_OBJECT",
+          "name": "SearchableFloatFilterInput",
+          "description": null,
+          "fields": null,
+          "inputFields": [
+            {
+              "name": "ne",
+              "description": null,
+              "type": {
+                "kind": "SCALAR",
+                "name": "Float",
+                "ofType": null
+              },
+              "defaultValue": null
+            },
+            {
+              "name": "gt",
+              "description": null,
+              "type": {
+                "kind": "SCALAR",
+                "name": "Float",
+                "ofType": null
+              },
+              "defaultValue": null
+            },
+            {
+              "name": "lt",
+              "description": null,
+              "type": {
+                "kind": "SCALAR",
+                "name": "Float",
+                "ofType": null
+              },
+              "defaultValue": null
+            },
+            {
+              "name": "gte",
+              "description": null,
+              "type": {
+                "kind": "SCALAR",
+                "name": "Float",
+                "ofType": null
+              },
+              "defaultValue": null
+            },
+            {
+              "name": "lte",
+              "description": null,
+              "type": {
+                "kind": "SCALAR",
+                "name": "Float",
+                "ofType": null
+              },
+              "defaultValue": null
+            },
+            {
+              "name": "eq",
+              "description": null,
+              "type": {
+                "kind": "SCALAR",
+                "name": "Float",
+                "ofType": null
+              },
+              "defaultValue": null
+            },
+            {
+              "name": "range",
+              "description": null,
+              "type": {
+                "kind": "LIST",
+                "name": null,
+                "ofType": {
+                  "kind": "SCALAR",
+                  "name": "Float",
+                  "ofType": null
+                }
+              },
+              "defaultValue": null
+            }
+          ],
+          "interfaces": null,
+          "enumValues": null,
+          "possibleTypes": null
+        },
+        {
+          "kind": "INPUT_OBJECT",
+          "name": "ModelSubscriptionIntInput",
+          "description": null,
+          "fields": null,
+          "inputFields": [
+            {
+              "name": "ne",
+              "description": null,
+              "type": {
+                "kind": "SCALAR",
+                "name": "Int",
+                "ofType": null
+              },
+              "defaultValue": null
+            },
+            {
+              "name": "eq",
+              "description": null,
+              "type": {
+                "kind": "SCALAR",
+                "name": "Int",
+                "ofType": null
+              },
+              "defaultValue": null
+            },
+            {
+              "name": "le",
+              "description": null,
+              "type": {
+                "kind": "SCALAR",
+                "name": "Int",
+                "ofType": null
+              },
+              "defaultValue": null
+            },
+            {
+              "name": "lt",
+              "description": null,
+              "type": {
+                "kind": "SCALAR",
+                "name": "Int",
+                "ofType": null
+              },
+              "defaultValue": null
+            },
+            {
+              "name": "ge",
+              "description": null,
+              "type": {
+                "kind": "SCALAR",
+                "name": "Int",
+                "ofType": null
+              },
+              "defaultValue": null
+            },
+            {
+              "name": "gt",
+              "description": null,
+              "type": {
+                "kind": "SCALAR",
+                "name": "Int",
+                "ofType": null
+              },
+              "defaultValue": null
+            },
+            {
+              "name": "between",
+              "description": null,
+              "type": {
+                "kind": "LIST",
+                "name": null,
+                "ofType": {
+                  "kind": "SCALAR",
+                  "name": "Int",
                   "ofType": null
                 }
               },
               "defaultValue": null
             },
             {
-              "name": "or",
+              "name": "in",
               "description": null,
               "type": {
                 "kind": "LIST",
                 "name": null,
                 "ofType": {
-                  "kind": "INPUT_OBJECT",
-                  "name": "ModelSubscriptionCollectionFilterInput",
+                  "kind": "SCALAR",
+                  "name": "Int",
                   "ofType": null
                 }
+              },
+              "defaultValue": null
+            },
+            {
+              "name": "notIn",
+              "description": null,
+              "type": {
+                "kind": "LIST",
+                "name": null,
+                "ofType": {
+                  "kind": "SCALAR",
+                  "name": "Int",
+                  "ofType": null
+                }
+              },
+              "defaultValue": null
+            }
+          ],
+          "interfaces": null,
+          "enumValues": null,
+          "possibleTypes": null
+        },
+        {
+          "kind": "INPUT_OBJECT",
+          "name": "ModelSubscriptionBooleanInput",
+          "description": null,
+          "fields": null,
+          "inputFields": [
+            {
+              "name": "ne",
+              "description": null,
+              "type": {
+                "kind": "SCALAR",
+                "name": "Boolean",
+                "ofType": null
+              },
+              "defaultValue": null
+            },
+            {
+              "name": "eq",
+              "description": null,
+              "type": {
+                "kind": "SCALAR",
+                "name": "Boolean",
+                "ofType": null
               },
               "defaultValue": null
             }
@@ -15614,7 +16399,7 @@
         },
         {
           "kind": "INPUT_OBJECT",
-          "name": "ModelSubscriptionBooleanInput",
+          "name": "ModelIntInput",
           "description": null,
           "fields": null,
           "inputFields": [
@@ -15623,7 +16408,7 @@
               "description": null,
               "type": {
                 "kind": "SCALAR",
-                "name": "Boolean",
+                "name": "Int",
                 "ofType": null
               },
               "defaultValue": null
@@ -15633,7 +16418,81 @@
               "description": null,
               "type": {
                 "kind": "SCALAR",
+                "name": "Int",
+                "ofType": null
+              },
+              "defaultValue": null
+            },
+            {
+              "name": "le",
+              "description": null,
+              "type": {
+                "kind": "SCALAR",
+                "name": "Int",
+                "ofType": null
+              },
+              "defaultValue": null
+            },
+            {
+              "name": "lt",
+              "description": null,
+              "type": {
+                "kind": "SCALAR",
+                "name": "Int",
+                "ofType": null
+              },
+              "defaultValue": null
+            },
+            {
+              "name": "ge",
+              "description": null,
+              "type": {
+                "kind": "SCALAR",
+                "name": "Int",
+                "ofType": null
+              },
+              "defaultValue": null
+            },
+            {
+              "name": "gt",
+              "description": null,
+              "type": {
+                "kind": "SCALAR",
+                "name": "Int",
+                "ofType": null
+              },
+              "defaultValue": null
+            },
+            {
+              "name": "between",
+              "description": null,
+              "type": {
+                "kind": "LIST",
+                "name": null,
+                "ofType": {
+                  "kind": "SCALAR",
+                  "name": "Int",
+                  "ofType": null
+                }
+              },
+              "defaultValue": null
+            },
+            {
+              "name": "attributeExists",
+              "description": null,
+              "type": {
+                "kind": "SCALAR",
                 "name": "Boolean",
+                "ofType": null
+              },
+              "defaultValue": null
+            },
+            {
+              "name": "attributeType",
+              "description": null,
+              "type": {
+                "kind": "ENUM",
+                "name": "ModelAttributeTypes",
                 "ofType": null
               },
               "defaultValue": null
@@ -17406,7 +18265,7 @@
         },
         {
           "kind": "INPUT_OBJECT",
-          "name": "SearchableIntFilterInput",
+          "name": "ModelFloatInput",
           "description": null,
           "fields": null,
           "inputFields": [
@@ -17415,47 +18274,7 @@
               "description": null,
               "type": {
                 "kind": "SCALAR",
-                "name": "Int",
-                "ofType": null
-              },
-              "defaultValue": null
-            },
-            {
-              "name": "gt",
-              "description": null,
-              "type": {
-                "kind": "SCALAR",
-                "name": "Int",
-                "ofType": null
-              },
-              "defaultValue": null
-            },
-            {
-              "name": "lt",
-              "description": null,
-              "type": {
-                "kind": "SCALAR",
-                "name": "Int",
-                "ofType": null
-              },
-              "defaultValue": null
-            },
-            {
-              "name": "gte",
-              "description": null,
-              "type": {
-                "kind": "SCALAR",
-                "name": "Int",
-                "ofType": null
-              },
-              "defaultValue": null
-            },
-            {
-              "name": "lte",
-              "description": null,
-              "type": {
-                "kind": "SCALAR",
-                "name": "Int",
+                "name": "Float",
                 "ofType": null
               },
               "defaultValue": null
@@ -17465,52 +18284,7 @@
               "description": null,
               "type": {
                 "kind": "SCALAR",
-                "name": "Int",
-                "ofType": null
-              },
-              "defaultValue": null
-            },
-            {
-              "name": "range",
-              "description": null,
-              "type": {
-                "kind": "LIST",
-                "name": null,
-                "ofType": {
-                  "kind": "SCALAR",
-                  "name": "Int",
-                  "ofType": null
-                }
-              },
-              "defaultValue": null
-            }
-          ],
-          "interfaces": null,
-          "enumValues": null,
-          "possibleTypes": null
-        },
-        {
-          "kind": "INPUT_OBJECT",
-          "name": "ModelIntInput",
-          "description": null,
-          "fields": null,
-          "inputFields": [
-            {
-              "name": "ne",
-              "description": null,
-              "type": {
-                "kind": "SCALAR",
-                "name": "Int",
-                "ofType": null
-              },
-              "defaultValue": null
-            },
-            {
-              "name": "eq",
-              "description": null,
-              "type": {
-                "kind": "SCALAR",
-                "name": "Int",
+                "name": "Float",
                 "ofType": null
               },
               "defaultValue": null
@@ -17520,7 +18294,7 @@
               "description": null,
               "type": {
                 "kind": "SCALAR",
-                "name": "Int",
+                "name": "Float",
                 "ofType": null
               },
               "defaultValue": null
@@ -17530,7 +18304,7 @@
               "description": null,
               "type": {
                 "kind": "SCALAR",
-                "name": "Int",
+                "name": "Float",
                 "ofType": null
               },
               "defaultValue": null
@@ -17540,7 +18314,7 @@
               "description": null,
               "type": {
                 "kind": "SCALAR",
-                "name": "Int",
+                "name": "Float",
                 "ofType": null
               },
               "defaultValue": null
@@ -17550,7 +18324,7 @@
               "description": null,
               "type": {
                 "kind": "SCALAR",
-                "name": "Int",
+                "name": "Float",
                 "ofType": null
               },
               "defaultValue": null
@@ -17563,7 +18337,7 @@
                 "name": null,
                 "ofType": {
                   "kind": "SCALAR",
-                  "name": "Int",
+                  "name": "Float",
                   "ofType": null
                 }
               },
@@ -17591,6 +18365,45 @@
             }
           ],
           "interfaces": null,
+          "enumValues": null,
+          "possibleTypes": null
+        },
+        {
+          "kind": "OBJECT",
+          "name": "SearchableAggregateResult",
+          "description": null,
+          "fields": [
+            {
+              "name": "name",
+              "description": null,
+              "args": [],
+              "type": {
+                "kind": "NON_NULL",
+                "name": null,
+                "ofType": {
+                  "kind": "SCALAR",
+                  "name": "String",
+                  "ofType": null
+                }
+              },
+              "isDeprecated": false,
+              "deprecationReason": null
+            },
+            {
+              "name": "result",
+              "description": null,
+              "args": [],
+              "type": {
+                "kind": "UNION",
+                "name": "SearchableAggregateGenericResult",
+                "ofType": null
+              },
+              "isDeprecated": false,
+              "deprecationReason": null
+            }
+          ],
+          "inputFields": null,
+          "interfaces": [],
           "enumValues": null,
           "possibleTypes": null
         },
@@ -18466,25 +19279,19 @@
           "onField": true
         },
         {
-          "name": "aws_cognito_user_pools",
-          "description": "Tells the service this field/object has access authorized by a Cognito User Pools token.",
+          "name": "aws_lambda",
+          "description": "Tells the service this field/object has access authorized by a Lambda Authorizer.",
           "locations": ["OBJECT", "FIELD_DEFINITION"],
-          "args": [
-            {
-              "name": "cognito_groups",
-              "description": "List of cognito user pool groups which have access on this field",
-              "type": {
-                "kind": "LIST",
-                "name": null,
-                "ofType": {
-                  "kind": "SCALAR",
-                  "name": "String",
-                  "ofType": null
-                }
-              },
-              "defaultValue": null
-            }
-          ],
+          "args": [],
+          "onOperation": false,
+          "onFragment": false,
+          "onField": false
+        },
+        {
+          "name": "aws_oidc",
+          "description": "Tells the service this field/object has access authorized by an OIDC token.",
+          "locations": ["OBJECT", "FIELD_DEFINITION"],
+          "args": [],
           "onOperation": false,
           "onFragment": false,
           "onField": false
@@ -18499,32 +19306,17 @@
           "onField": false
         },
         {
-          "name": "aws_subscribe",
-          "description": "Tells the service which mutation triggers this subscription.",
-          "locations": ["FIELD_DEFINITION"],
-          "args": [
-            {
-              "name": "mutations",
-              "description": "List of mutations which will trigger this subscription when they are called.",
-              "type": {
-                "kind": "LIST",
-                "name": null,
-                "ofType": {
-                  "kind": "SCALAR",
-                  "name": "String",
-                  "ofType": null
-                }
-              },
-              "defaultValue": null
-            }
-          ],
+          "name": "aws_oidc",
+          "description": "Tells the service this field/object has access authorized by an OIDC token.",
+          "locations": ["OBJECT", "FIELD_DEFINITION"],
+          "args": [],
           "onOperation": false,
           "onFragment": false,
           "onField": false
         },
         {
-          "name": "aws_oidc",
-          "description": "Tells the service this field/object has access authorized by an OIDC token.",
+          "name": "aws_iam",
+          "description": "Tells the service this field/object has access authorized by sigv4 signing.",
           "locations": ["OBJECT", "FIELD_DEFINITION"],
           "args": [],
           "onOperation": false,
@@ -18600,19 +19392,25 @@
           "onField": false
         },
         {
-          "name": "aws_iam",
-          "description": "Tells the service this field/object has access authorized by sigv4 signing.",
-          "locations": ["OBJECT", "FIELD_DEFINITION"],
-          "args": [],
-          "onOperation": false,
-          "onFragment": false,
-          "onField": false
-        },
-        {
-          "name": "aws_lambda",
-          "description": "Tells the service this field/object has access authorized by a Lambda Authorizer.",
-          "locations": ["OBJECT", "FIELD_DEFINITION"],
-          "args": [],
+          "name": "aws_subscribe",
+          "description": "Tells the service which mutation triggers this subscription.",
+          "locations": ["FIELD_DEFINITION"],
+          "args": [
+            {
+              "name": "mutations",
+              "description": "List of mutations which will trigger this subscription when they are called.",
+              "type": {
+                "kind": "LIST",
+                "name": null,
+                "ofType": {
+                  "kind": "SCALAR",
+                  "name": "String",
+                  "ofType": null
+                }
+              },
+              "defaultValue": null
+            }
+          ],
           "onOperation": false,
           "onFragment": false,
           "onField": false

--- a/src/graphql/subscriptions.js
+++ b/src/graphql/subscriptions.js
@@ -658,6 +658,105 @@ export const onDeleteCollectionmap = /* GraphQL */ `
     }
   }
 `;
+export const onCreatePageContent = /* GraphQL */ `
+  subscription OnCreatePageContent {
+    onCreatePageContent {
+      page_content_category
+      id
+      content
+      pageContentSiteId {
+        analyticsID
+        assetBasePath
+        browseCollections
+        contact
+        displayedAttributes
+        groups
+        homePage
+        id
+        lang
+        miradorOptions
+        searchPage
+        siteColor
+        siteId
+        siteName
+        siteOptions
+        sitePages
+        siteTitle
+        createdAt
+        updatedAt
+      }
+      createdAt
+      updatedAt
+      pageContentPageContentSiteIdId
+    }
+  }
+`;
+export const onUpdatePageContent = /* GraphQL */ `
+  subscription OnUpdatePageContent {
+    onUpdatePageContent {
+      page_content_category
+      id
+      content
+      pageContentSiteId {
+        analyticsID
+        assetBasePath
+        browseCollections
+        contact
+        displayedAttributes
+        groups
+        homePage
+        id
+        lang
+        miradorOptions
+        searchPage
+        siteColor
+        siteId
+        siteName
+        siteOptions
+        sitePages
+        siteTitle
+        createdAt
+        updatedAt
+      }
+      createdAt
+      updatedAt
+      pageContentPageContentSiteIdId
+    }
+  }
+`;
+export const onDeletePageContent = /* GraphQL */ `
+  subscription OnDeletePageContent {
+    onDeletePageContent {
+      page_content_category
+      id
+      content
+      pageContentSiteId {
+        analyticsID
+        assetBasePath
+        browseCollections
+        contact
+        displayedAttributes
+        groups
+        homePage
+        id
+        lang
+        miradorOptions
+        searchPage
+        siteColor
+        siteId
+        siteName
+        siteOptions
+        sitePages
+        siteTitle
+        createdAt
+        updatedAt
+      }
+      createdAt
+      updatedAt
+      pageContentPageContentSiteIdId
+    }
+  }
+`;
 export const onCreateArchive = /* GraphQL */ `
   subscription OnCreateArchive($filter: ModelSubscriptionArchiveFilterInput) {
     onCreateArchive(filter: $filter) {

--- a/src/lib/MetadataRenderer.js
+++ b/src/lib/MetadataRenderer.js
@@ -109,7 +109,7 @@ export function cleanHTML(content, type) {
         "video"
       ],
       allowedAttributes: {
-        "*": ["id", "style"],
+        "*": ["id", "style", "class"],
         a: ["href", "name", "target", "rel", "title"],
         audio: ["autoplay", "controls", "loop", "muted", "preload", "src"],
         img: ["src", "srcset", "alt", "title", "width", "height", "loading"],
@@ -130,7 +130,7 @@ export function cleanHTML(content, type) {
     };
   } else if (type === "html") {
     options = {
-      allowedTags: ["b", "i", "em", "strong", "a"],
+      allowedTags: ["b", "em", "strong", "u", "a"],
       allowedAttributes: {
         a: ["href", "target", "rel"]
       }
@@ -181,10 +181,6 @@ export function getCategory(item) {
 
 export function arkLinkFormatted(customKey) {
   return customKey.split("/").pop();
-}
-
-export function htmlParsedValue(value) {
-  return value.includes("<a href=") ? ReactHtmlParser(value) : value;
 }
 
 export function titleFormatted(item, category) {
@@ -272,7 +268,7 @@ function listValue(category, attr, value, languages) {
     }
     return <a href={`/search/?${qs.stringify(parsedObject)}`}>{value}</a>;
   } else if (attr === "source" || attr === "related_url") {
-    return htmlParsedValue(value);
+    return cleanHTML(value);
   } else {
     return value;
   }
@@ -306,7 +302,7 @@ function textFormat(item, attr, languages, collectionCustomKey, site) {
       </a>
     );
   } else if (attr === "rights_statement") {
-    return htmlParsedValue(item[attr]);
+    return cleanHTML(item[attr], "html");
   } else if (attr === "custom_key") {
     let redirect = "";
     try {
@@ -317,7 +313,7 @@ function textFormat(item, attr, languages, collectionCustomKey, site) {
     } catch (error) {
       console.log("Redirect url not defined in site config.");
     }
-    return htmlParsedValue(
+    return ReactHtmlParser(
       `<a href="${redirect}/${item.custom_key}">${redirect}/${item.custom_key}</a>`
     );
   } else if (attr === "description") {

--- a/src/pages/AboutPage.js
+++ b/src/pages/AboutPage.js
@@ -2,10 +2,11 @@ import React, { Component } from "react";
 import { Helmet } from "react-helmet";
 import SiteTitle from "../components/SiteTitle";
 import ContactSection from "../components/ContactSection";
-import { getFileContent } from "../lib/fetchTools";
+import { getFileContent, getPageContentById } from "../lib/fetchTools";
 import { buildHeaderSchema } from "../lib/richSchemaTools";
 import { cleanHTML } from "../lib/MetadataRenderer";
 
+import "../css/Editor.scss";
 import "../css/AboutPage.scss";
 
 class AboutPage extends Component {
@@ -17,9 +18,17 @@ class AboutPage extends Component {
   }
 
   componentDidMount() {
-    const htmlUrl = JSON.parse(this.props.site.sitePages)[this.props.parentKey]
-      .data_url;
-    getFileContent(htmlUrl, "html", this);
+    const page = JSON.parse(this.props.site.sitePages)[this.props.parentKey];
+    const { data_url, useDataUrl, pageContentId } = page;
+    if (data_url && useDataUrl) {
+      getFileContent(data_url, "html", this);
+    } else if (pageContentId) {
+      getPageContentById(pageContentId).then(resp => {
+        this.setState({
+          copy: resp
+        });
+      });
+    }
   }
 
   render() {
@@ -46,7 +55,7 @@ class AboutPage extends Component {
           ></Helmet>
         </div>
         <div className="col-md-8" role="region" aria-labelledby="about-heading">
-          <div className="about-details">
+          <div className="about-details quill-styles">
             {cleanHTML(this.state.copy, "page")}
           </div>
         </div>

--- a/src/pages/AdditionalPages.js
+++ b/src/pages/AdditionalPages.js
@@ -1,7 +1,8 @@
 import React, { Component } from "react";
-import { getFileContent } from "../lib/fetchTools";
+import { getFileContent, getPageContentById } from "../lib/fetchTools";
 import { cleanHTML } from "../lib/MetadataRenderer";
 
+import "../css/Editor.scss";
 import "../css/AdditionalPages.scss";
 
 class AdditionalPages extends Component {
@@ -17,13 +18,21 @@ class AdditionalPages extends Component {
     if (copyObj.children && this.props.childKey) {
       copyObj = copyObj.children[this.props.childKey];
     }
-    const copyUrl = copyObj.data_url;
-    getFileContent(copyUrl, "html", this);
+    const { data_url, useDataUrl, pageContentId } = copyObj;
+    if (data_url && useDataUrl) {
+      getFileContent(data_url, "html", this);
+    } else if (pageContentId) {
+      getPageContentById(pageContentId).then(resp => {
+        this.setState({
+          copy: resp
+        });
+      });
+    }
   }
 
   render() {
     return (
-      <div className="additional-pages-wrapper">
+      <div className="additional-pages-wrapper quill-styles">
         {cleanHTML(this.state.copy, "page")}
       </div>
     );

--- a/src/pages/PermissionsPage.js
+++ b/src/pages/PermissionsPage.js
@@ -1,10 +1,11 @@
 import React, { Component } from "react";
 import SiteTitle from "../components/SiteTitle";
 import ContactSection from "../components/ContactSection";
-import { getFileContent } from "../lib/fetchTools";
+import { getFileContent, getPageContentById } from "../lib/fetchTools";
 import { cleanHTML } from "../lib/MetadataRenderer";
 
 import "../css/TermsPage.scss";
+import "../css/Editor.scss";
 class PermissionsPage extends Component {
   constructor(props) {
     super(props);
@@ -14,9 +15,17 @@ class PermissionsPage extends Component {
   }
 
   componentDidMount() {
-    const htmlUrl = JSON.parse(this.props.site.sitePages)[this.props.parentKey]
-      .data_url;
-    getFileContent(htmlUrl, "html", this);
+    const page = JSON.parse(this.props.site.sitePages)[this.props.parentKey];
+    const { data_url, useDataUrl, pageContentId } = page;
+    if (data_url && useDataUrl) {
+      getFileContent(data_url, "html", this);
+    } else if (pageContentId) {
+      getPageContentById(pageContentId).then(resp => {
+        this.setState({
+          copy: resp
+        });
+      });
+    }
   }
 
   render() {
@@ -42,7 +51,7 @@ class PermissionsPage extends Component {
             role="region"
             aria-labelledby="permissions-heading"
           >
-            <div className="terms-details">
+            <div className="terms-details quill-styles">
               {cleanHTML(this.state.copy, "page")}
             </div>
           </div>

--- a/src/pages/admin/ArchiveCollectionEdit/ArchiveForm.js
+++ b/src/pages/admin/ArchiveCollectionEdit/ArchiveForm.js
@@ -220,7 +220,18 @@ const ArchiveForm = React.memo(props => {
         }
       }
     }
-
+    const empty = new RegExp("<p>(<br>|\\s+)</p>");
+    for (const key in archive) {
+      if (Array.isArray(archive[key])) {
+        archive[key].forEach(el => {
+          archive[key] = [...archive[key].filter(el => !empty.test(el))];
+        });
+      } else {
+        if (empty.test(archive[key])) {
+          archive[key] = null;
+        }
+      }
+    }
     if (validEmbargo(archive)) {
       await createEmbargoRecord(archive, fullArchive, embargo, "archive");
     } else {
@@ -324,26 +335,38 @@ const ArchiveForm = React.memo(props => {
     });
   };
 
-  const changeValueHandler = (event, field, valueIdx) => {
-    let inputValue = event.target.value;
+  const changeValueHandler = (event, field) => {
+    let inputValue = null;
+    if (event.target) {
+      inputValue = event.target.value;
+    } else {
+      inputValue = event;
+    }
     if (inputValue.trim() === "") {
       inputValue = null;
     }
     if (booleanFields.indexOf(field) !== -1) {
       inputValue = event.target.checked;
     }
+    let fieldName = field;
+    let index = null;
+    if (field.includes("-")) {
+      const arr = field.split("-");
+      fieldName = arr[0];
+      index = arr[1];
+    }
     setArchive(prevArchive => {
-      if (valueIdx === undefined) {
+      if (!index) {
         return {
           ...prevArchive,
-          [field]: inputValue
+          [fieldName]: inputValue
         };
       } else {
-        const values = [...prevArchive[field]];
-        values[valueIdx] = inputValue;
+        const values = [...prevArchive[fieldName]];
+        values[index] = inputValue;
         return {
           ...prevArchive,
-          [field]: values
+          [fieldName]: values
         };
       }
     });

--- a/src/pages/admin/ArchiveCollectionEdit/CollectionForm.js
+++ b/src/pages/admin/ArchiveCollectionEdit/CollectionForm.js
@@ -223,6 +223,17 @@ const CollectionForm = React.memo(props => {
         }
       }
     }
+    const empty = new RegExp("<p>(<br>|\\s+)</p>");
+    for (const key in collection) {
+      if (Array.isArray(collection[key])) {
+        collection[key] = [...collection[key].filter(el => !empty.test(el))];
+      } else {
+        if (empty.test(collection[key])) {
+          collection[key] = null;
+        }
+      }
+    }
+
     if (
       collection.ownerinfo &&
       collection.ownerinfo.constructor === {}.constructor
@@ -367,34 +378,46 @@ const CollectionForm = React.memo(props => {
     setViewState("view");
   };
 
-  const changeValueHandler = (event, field, valueIdx) => {
-    let inputValue = event.target.value;
+  const changeValueHandler = (event, field) => {
+    let inputValue = null;
+    if (event.target) {
+      inputValue = event.target.value;
+    } else {
+      inputValue = event;
+    }
     if (inputValue.trim() === "") {
       inputValue = null;
     }
     if (field === "explicit_content" || field === "visibility") {
       inputValue = event.target.checked;
     }
-    if (field.indexOf("ownerinfo") !== -1) {
+    let fieldName = field;
+    let index = null;
+    if (field.includes("-")) {
+      const arr = field.split("-");
+      fieldName = arr[0];
+      index = arr[1];
+    }
+    if (fieldName.indexOf("ownerinfo") !== -1) {
       const ownerField = field.split("_")[1];
       let ownerinfo = collection.ownerinfo || {};
       ownerinfo[ownerField] = ownerinfo[ownerField] || "";
       ownerinfo[ownerField] = inputValue;
-      field = "ownerinfo";
+      fieldName = "ownerinfo";
       inputValue = ownerinfo;
     }
     setCollection(prevCollection => {
-      if (valueIdx === undefined) {
+      if (!index) {
         return {
           ...prevCollection,
-          [field]: inputValue
+          [fieldName]: inputValue
         };
       } else {
-        const values = [...prevCollection[field]];
-        values[valueIdx] = inputValue;
+        const values = [...prevCollection[fieldName]];
+        values[index] = inputValue;
         return {
           ...prevCollection,
-          [field]: values
+          [fieldName]: values
         };
       }
     });

--- a/src/pages/admin/ArchiveCollectionEdit/EditMetadata.js
+++ b/src/pages/admin/ArchiveCollectionEdit/EditMetadata.js
@@ -1,33 +1,69 @@
 import React, { Fragment } from "react";
 import { Form, Input, TextArea } from "semantic-ui-react";
+import Editor from "../../../components/Editor";
+
+const editorModules = {
+  toolbar: [["bold", "italic", "underline"], ["link"], ["clean"]],
+  clipboard: {
+    matchVisual: false
+  }
+};
+const editorFormats = ["bold", "italic", "underline", "link"];
 
 const EditMetadata = React.memo(props => {
   let editInput = null;
+  let htmlFields = ["source", "related_url", "description", "rights_statement"];
   if (props.isMulti) {
     editInput = (
       <Fragment>
         <ul>
           {props.values &&
-            props.values.map((value, idx) => (
-              <li key={`${props.label}_${idx}`}>
-                <TextArea
-                  name={`${props.field}_${idx}`}
-                  onChange={event =>
-                    props.onChangeValue(event, props.field, idx)
-                  }
-                  placeholder={`Enter ${props.field} for the record`}
-                  value={value || ""}
-                />
-                <button
-                  type="button"
-                  onClick={() => props.onRemoveValue(props.field, idx)}
-                  className="small deleteValue"
-                >
-                  Delete Value
-                </button>
-                <div className="clear"></div>
-              </li>
-            ))}
+            props.values.map((value, idx) => {
+              if (htmlFields.find(el => el === props.field)) {
+                return (
+                  <li key={`${props.label}_${idx}`}>
+                    <Editor
+                      value={value}
+                      placeholder={`Enter ${props.field} for the record`}
+                      onChange={props.onChangeValue}
+                      fieldName={`${props.field}-${idx}`}
+                      modules={editorModules}
+                      formats={editorFormats}
+                      id={`${props.field}_${idx}`}
+                    ></Editor>
+                    <button
+                      type="button"
+                      onClick={() => props.onRemoveValue(props.field, idx)}
+                      className="small deleteValue"
+                    >
+                      Delete Value
+                    </button>
+                    <div className="clear"></div>
+                  </li>
+                );
+              } else {
+                return (
+                  <li key={`${props.label}_${idx}`}>
+                    <TextArea
+                      name={`${props.field}_${idx}`}
+                      onChange={event =>
+                        props.onChangeValue(event, `${props.field}-${idx}`)
+                      }
+                      placeholder={`Enter ${props.field} for the record`}
+                      value={value || ""}
+                    />
+                    <button
+                      type="button"
+                      onClick={() => props.onRemoveValue(props.field, idx)}
+                      className="small deleteValue"
+                    >
+                      Delete Value
+                    </button>
+                    <div className="clear"></div>
+                  </li>
+                );
+              }
+            })}
         </ul>
         <button
           type="button"
@@ -49,14 +85,28 @@ const EditMetadata = React.memo(props => {
       />
     );
   } else {
-    editInput = (
-      <TextArea
-        name={`${props.field}`}
-        onChange={event => props.onChangeValue(event, props.field)}
-        placeholder={`Enter ${props.field} for the record`}
-        value={props.values || ""}
-      />
-    );
+    if (htmlFields.find(el => el === props.field)) {
+      editInput = (
+        <Editor
+          value={props.values}
+          placeholder={`Enter ${props.field} for the record`}
+          onChange={props.onChangeValue}
+          fieldName={props.field}
+          modules={editorModules}
+          formats={editorFormats}
+          id={props.field}
+        ></Editor>
+      );
+    } else {
+      editInput = (
+        <TextArea
+          name={`${props.field}`}
+          onChange={event => props.onChangeValue(event, props.field)}
+          placeholder={`Enter ${props.field} for the record`}
+          value={props.values || ""}
+        />
+      );
+    }
   }
 
   return (

--- a/src/pages/admin/HomepageForm.js
+++ b/src/pages/admin/HomepageForm.js
@@ -8,7 +8,7 @@ import {
   CollectionHighlightsForm,
   CollectionHighlights
 } from "./CollectionHighlightsFields";
-import { cleanHTML } from "../../lib/MetadataRenderer";
+import Editor from "../../components/Editor";
 
 const initialFormState = {
   homeStatementHeading: "",
@@ -24,6 +24,14 @@ const initialFormState = {
   featuredItems: [],
   collectionHighlights: []
 };
+
+const editorModules = {
+  toolbar: [["bold", "italic", "underline"], ["link"], ["clean"]],
+  clipboard: {
+    matchVisual: false
+  }
+};
+const editorFormats = ["bold", "italic", "underline", "link"];
 
 class HomepageForm extends Component {
   constructor(props) {
@@ -100,29 +108,38 @@ class HomepageForm extends Component {
     }
   }
 
-  updateInputValue = event => {
-    const target = event.target;
-    const value = target.type === "checkbox" ? target.checked : target.value;
-    const property_index = target.name.split("_");
-    let name = "";
-    let index = 0;
-    if (property_index.length === 2) {
-      [name, index] = property_index;
-      this.setState(prevState => {
-        let itemArray = [...prevState.formState[name]];
-        let item = { ...itemArray[index], src: value };
-        itemArray[index] = item;
-        return {
-          formState: { ...prevState.formState, [name]: itemArray }
-        };
-      });
-    } else if (property_index.length === 1) {
-      [name] = property_index;
+  updateInputValue = (event, fieldName) => {
+    if (!event.target) {
       this.setState(prevState => {
         return {
-          formState: { ...prevState.formState, [name]: value }
+          formState: { ...prevState.formState, [fieldName]: event }
         };
       });
+    }
+    if (event.target) {
+      const target = event.target;
+      const value = target.type === "checkbox" ? target.checked : target.value;
+      const property_index = target.name.split("_");
+      let name = "";
+      let index = 0;
+      if (property_index.length === 2) {
+        [name, index] = property_index;
+        this.setState(prevState => {
+          let itemArray = [...prevState.formState[name]];
+          let item = { ...itemArray[index], src: value };
+          itemArray[index] = item;
+          return {
+            formState: { ...prevState.formState, [name]: itemArray }
+          };
+        });
+      } else if (property_index.length === 1) {
+        [name] = property_index;
+        this.setState(prevState => {
+          return {
+            formState: { ...prevState.formState, [name]: value }
+          };
+        });
+      }
     }
   };
 
@@ -130,10 +147,7 @@ class HomepageForm extends Component {
     this.setState({ viewState: "view" });
     let homePage = JSON.parse(this.props.site.homePage);
     homePage.homeStatement.heading = this.state.formState.homeStatementHeading;
-    homePage.homeStatement.statement = cleanHTML(
-      this.state.formState.homeStatement,
-      "html"
-    );
+    homePage.homeStatement.statement = this.state.formState.homeStatement;
     homePage.staticImage.src = this.state.formState.staticImageSrc;
     homePage.staticImage.altText = this.state.formState.staticImageAltText;
     homePage.staticImage.titleFont = this.state.formState.staticImageTitleFont;
@@ -185,13 +199,21 @@ class HomepageForm extends Component {
               placeholder="Enter Heading"
               onChange={this.updateInputValue}
             />
-            <Form.TextArea
-              label="Statement"
+            <label
+              htmlFor="homeStatement-editor"
+              aria-labelledby="homeStatement-editor"
+            >
+              Statement
+            </label>
+            <Editor
               value={this.state.formState.homeStatement}
-              name="homeStatement"
               placeholder="Enter Statement"
               onChange={this.updateInputValue}
-            />
+              fieldName="homeStatement"
+              modules={editorModules}
+              formats={editorFormats}
+              id="homeStatement-editor"
+            ></Editor>
           </section>
           <section className="static-image">
             <h3>Homepage Image and Title</h3>
@@ -333,10 +355,10 @@ class HomepageForm extends Component {
               <span className="key">Heading:</span>{" "}
               {this.state.formState.homeStatementHeading}
             </p>
-            <p>
+            <div>
               <span className="key">Statement:</span>{" "}
-              {cleanHTML(this.state.formState.homeStatement, "html")}
-            </p>
+              {this.state.formState.homeStatement}
+            </div>
             <h3>Static Image</h3>
             <p>
               <span className="key">Src:</span>{" "}

--- a/src/pages/admin/SitePagesForm.js
+++ b/src/pages/admin/SitePagesForm.js
@@ -1,17 +1,41 @@
 import React, { Component } from "react";
 import { withAuthenticator } from "@aws-amplify/ui-react";
 import { NavLink } from "react-router-dom";
-import { Form } from "semantic-ui-react";
+import { Form, Button, Label } from "semantic-ui-react";
 import { updatedDiff } from "deep-object-diff";
 import { API, Auth } from "aws-amplify";
-import { getSite } from "../../lib/fetchTools";
+import {
+  getSite,
+  getFileContent,
+  getPageContentById,
+  downloadFile
+} from "../../lib/fetchTools";
 import { input } from "../../components/FormFields";
 import * as mutations from "../../graphql/mutations";
+import FocusLock from "react-focus-lock";
+import { v4 as uuidv4 } from "uuid";
+import { FontAwesomeIcon } from "@fortawesome/react-fontawesome";
+import Editor from "../../components/Editor";
 
 import "../../css/adminForms.scss";
 
 const initialFormState = [];
 
+const editorModules = {
+  toolbar: [
+    [{ header: [2, 3, 4, 5, 6, false] }],
+    ["bold", "italic", "underline"],
+    [{ script: "sub" }, { script: "super" }],
+    [{ list: "ordered" }, { list: "bullet" }],
+    [{ indent: "-1" }, { indent: "+1" }],
+    [{ align: [] }],
+    ["link", "code-block", "blockquote"],
+    ["clean"]
+  ],
+  clipboard: {
+    matchVisual: false
+  }
+};
 class SitePagesForm extends Component {
   constructor(props) {
     super(props);
@@ -21,7 +45,11 @@ class SitePagesForm extends Component {
       viewState: "view",
       site: null,
       added: 0,
-      fileFolder: ""
+      fileFolder: "",
+      copy: "",
+      pageId: null,
+      isEditorActive: false,
+      pageContentId: null
     };
   }
 
@@ -37,7 +65,6 @@ class SitePagesForm extends Component {
       this.setState({
         formState: pages,
         prevFormState: pages,
-        pages: pages,
         site: site
       });
     }
@@ -59,8 +86,12 @@ class SitePagesForm extends Component {
     return `${pathPrefix}${value}`;
   }
 
-  updateInputValue = event => {
+  updateInputValue = (event, data) => {
     let { name, value, type } = event.target;
+    if (event.target.role === "option" || data?.name?.includes("useDataUrl")) {
+      name = data.name;
+      value = data.value || data.checked;
+    }
     if (type === "upload") {
       const url = this.getFileUrl(value);
       if (name.indexOf("assets") !== -1) {
@@ -71,6 +102,7 @@ class SitePagesForm extends Component {
         value = url;
       }
     }
+
     const page = name.split("_")[0];
     let formField = name.split("_")[1];
     let tempState = JSON.parse(JSON.stringify(this.state.formState));
@@ -81,6 +113,7 @@ class SitePagesForm extends Component {
           formField = "local_url";
         } else if (formField === "dataURL") {
           formField = "data_url";
+          tempState[idx]["useDataUrl"] = true;
         }
         tempState[idx][formField] = value;
       }
@@ -173,8 +206,12 @@ class SitePagesForm extends Component {
     }
   };
 
-  handleChange = (e, { value }) => {
-    this.setState({ viewState: value });
+  handleChange = (e, data) => {
+    if (data) {
+      this.setState({ viewState: data.value });
+    } else {
+      this.setState({ copy: e });
+    }
   };
 
   addPage() {
@@ -183,10 +220,20 @@ class SitePagesForm extends Component {
     this.setState({ formState: pages, added: this.state.added + 1 });
   }
 
-  deletePage(page) {
+  async deletePage(page) {
     let pages = JSON.parse(JSON.stringify(this.state.formState));
     for (const idx in pages) {
       if (pages[idx].pageName === page) {
+        if (pages[idx].pageContentId) {
+          let pageContent = {
+            id: pages[idx].pageContentId
+          };
+          await API.graphql({
+            query: mutations.deletePageContent,
+            variables: { input: pageContent },
+            authMode: "AMAZON_COGNITO_USER_POOLS"
+          });
+        }
         pages.splice(idx, 1);
       }
     }
@@ -217,7 +264,9 @@ class SitePagesForm extends Component {
     const current = this.formatAssets(item.assets);
     if (current) {
       retVal = (
-        <span class="current-asset-file">Current asset file: {current}</span>
+        <span className="current-asset-file">
+          Current asset file: {current}
+        </span>
       );
     }
     return retVal;
@@ -231,65 +280,187 @@ class SitePagesForm extends Component {
     return assets;
   }
 
+  async openEditor(htmlUrl, pageId, pageContentId, useDataUrl) {
+    if (htmlUrl && useDataUrl) {
+      await getFileContent(htmlUrl, "html", this);
+    } else if (pageContentId) {
+      await getPageContentById(pageContentId).then(resp => {
+        this.setState({
+          copy: resp,
+          pageContentId: pageContentId
+        });
+      });
+    }
+    this.setState({
+      pageId: pageId,
+      isEditorActive: true
+    });
+  }
+
+  async handleEditorSave() {
+    let page = {
+      content: this.state.copy
+    };
+    let temp = this.state.formState;
+    if (!this.state.pageContentId) {
+      page.id = uuidv4();
+      page.page_content_category = process.env.REACT_APP_REP_TYPE.toLowerCase();
+      await API.graphql({
+        query: mutations.createPageContent,
+        variables: { input: page },
+        authMode: "AMAZON_COGNITO_USER_POOLS"
+      });
+      temp.forEach(item => {
+        if (item.pageName === this.state.pageId) {
+          item.pageContentId = page.id;
+          item.useDataUrl = false;
+        }
+      });
+    } else {
+      page.id = this.state.pageContentId;
+      await API.graphql({
+        query: mutations.updatePageContent,
+        variables: { input: page },
+        authMode: "AMAZON_COGNITO_USER_POOLS"
+      });
+      temp.forEach(item => {
+        if (item.pageName === this.state.pageId) {
+          item.useDataUrl = false;
+        }
+      });
+    }
+    this.setState({
+      formState: temp,
+      copy: "",
+      pageId: null,
+      isEditorActive: false,
+      pageContentId: null
+    });
+    this.handleSubmit();
+  }
+
   editSitePagesSection = (item, idx) => {
     return (
       <section key={idx}>
+        <div className="deleteWrapper">
+          <Button
+            className="delete float-right"
+            onClick={() => this.deletePage(item.pageName)}
+          >
+            Delete Page
+          </Button>
+        </div>
+        <h2 className="admin">{`Configuration for page: ${item.text}`}</h2>
         <fieldset>
-          <legend className="admin">{`Configuration for page: ${item.pageName}`}</legend>
+          <legend>Page Details</legend>
           <Form.Input
             key={`${idx}_pageName`}
+            id={`${idx}_pageName`}
             label="Page ID"
             value={item.pageName}
             name={`${item.pageName}_pageName`}
             placeholder="Enter Page ID"
             onChange={this.updateInputValue}
           />
-          <Form.Input
+          <Form.Select
             key={`${idx}_component`}
-            label="Component"
+            id={`${idx}_component`}
+            label="Page Type"
             value={item.component || ""}
             name={`${item.pageName}_component`}
-            placeholder="Enter Handling Component"
+            placeholder="Select the type of page to create"
             onChange={this.updateInputValue}
-          />
-          <div class="field">
-            {this.currentAssetFile(item)}
-            {input(
-              {
-                label: "Assets",
-                id: `${item.pageName}_assets`,
-                name: `${item.pageName}_assets`,
-                placeholder: "Enter Page Assets",
-                setSrc: this.updateInputValue,
-                setFileFolder: this.setFileFolder,
-                context: this,
-                fileType: "any"
-              },
-              "file"
-            )}
-          </div>
-          <Form.Input
-            key={`${idx}_localURL`}
-            label="Local URL"
-            value={item.local_url || ""}
-            name={`${item.pageName}_localURL`}
-            placeholder="Enter Local URL"
-            onChange={this.updateInputValue}
+            options={[
+              { key: "a", text: "About Page", value: "AboutPage" },
+              { key: "p", text: "Permissions Page", value: "PermissionsPage" },
+              { key: "ad", text: "Additional Page", value: "AdditionalPages" }
+            ]}
           />
           <Form.Input
             key={`${idx}_text`}
-            label="Link Text"
+            id={`${idx}_text`}
+            label="Page Title"
             value={item.text || ""}
             name={`${item.pageName}_text`}
-            placeholder="Enter Link Text"
+            placeholder="Enter Page Name"
             onChange={this.updateInputValue}
           />
-
-          <div class="field">
-            <span>Current Data URL: {item.data_url}</span>
+          <Form.Input
+            key={`${idx}_localURL`}
+            id={`${idx}_localURL`}
+            label="Page URL"
+            value={item.local_url || ""}
+            name={`${item.pageName}_localURL`}
+            placeholder="/example-page-url"
+            onChange={this.updateInputValue}
+          >
+            <Label>{`${window.location.href.substring(
+              0,
+              window.location.href.lastIndexOf("/")
+            )}`}</Label>
+            <input />
+          </Form.Input>
+          {item.component === "PermissionsPage" ? (
+            <div className="field">
+              {this.currentAssetFile(item)}
+              {input(
+                {
+                  label: "Upload Assets",
+                  id: `${item.pageName}_assets`,
+                  name: `${item.pageName}_assets`,
+                  placeholder: "Enter Page Assets",
+                  setSrc: this.updateInputValue,
+                  setFileFolder: this.setFileFolder,
+                  context: this,
+                  fileType: "any"
+                },
+                "file"
+              )}
+            </div>
+          ) : (
+            <></>
+          )}
+        </fieldset>
+        <fieldset>
+          <legend>Page Content</legend>
+          <div className="field">
+            <p>
+              Page content can be added by either uploading an HTML file, or
+              using the editor below.
+            </p>
+            <div className="file-status">
+              {item.data_url ? (
+                <div>
+                  <span>Current HTML file:</span>{" "}
+                  {item.data_url.split("/").pop()}
+                  <button
+                    className="download-link"
+                    title="Download HTML file"
+                    aria-label="Download HTML file"
+                    onClick={() => downloadFile(item.data_url)}
+                  >
+                    <FontAwesomeIcon icon="download" />
+                  </button>
+                </div>
+              ) : (
+                <strong>No HTML file uploaded</strong>
+              )}
+              {"useDataUrl" in item && item.data_url ? (
+                <Form.Checkbox
+                  key={`${item.pageName}_useDataUrl`}
+                  id={`${item.pageName}_useDataUrl`}
+                  label="Use HTML file"
+                  name={`${item.pageName}_useDataUrl`}
+                  onChange={(e, data) => this.updateInputValue(e, data)}
+                  checked={item.useDataUrl}
+                />
+              ) : (
+                <></>
+              )}
+            </div>
             {input(
               {
-                label: "Data URL",
+                label: "File Upload:",
                 id: `${item.pageName}_dataURL`,
                 name: `${item.pageName}_dataURL`,
                 placeholder: "Enter Data URL",
@@ -301,17 +472,23 @@ class SitePagesForm extends Component {
               "file"
             )}
           </div>
-        </fieldset>
-        <div className="deleteWrapper">
-          <NavLink
-            className="delete"
-            to="#"
-            onClick={() => this.deletePage(item.pageName)}
+          <br />
+          <Button
+            key={`${item.pageName}_openEditor`}
+            id={`${item.pageName}_openEditor`}
+            onClick={() =>
+              this.openEditor(
+                item.data_url,
+                item.pageName,
+                item.pageContentId,
+                item.useDataUrl
+              )
+            }
           >
-            Delete Page
-          </NavLink>
-          <div className="clear"></div>
-        </div>
+            Open text editor
+          </Button>
+        </fieldset>
+        <div className="clear"></div>
       </section>
     );
   };
@@ -324,11 +501,13 @@ class SitePagesForm extends Component {
             <li key={page.pageName}>
               <div>
                 <p>Page ID: {page.pageName} </p>
-                <p>Component: {page.component}</p>
+                <p>Page Type: {page.component}</p>
                 <p>Assets: {JSON.stringify(page.assets) || ""}</p>
-                <p>Local URL: {page.local_url}</p>
-                <p>Text: {page.text}</p>
-                <p>Data URL: {page.data_url}</p>
+                <p>Page URL: {page.local_url}</p>
+                <p>Page Title: {page.text}</p>
+                <p>
+                  Current HTML File: {page.data_url?.split("/").pop() || "None"}{" "}
+                </p>
               </div>
               <hr />
             </li>
@@ -365,6 +544,42 @@ class SitePagesForm extends Component {
         {this.state.viewState === "view"
           ? this.viewSitePages()
           : this.editSitePagesForm()}
+        {this.state.isEditorActive ? (
+          <div className="editor-modal-wrapper" role="dialog" aria-modal="true">
+            <FocusLock>
+              <div className="editor-wrapper">
+                <Editor
+                  value={this.state.copy}
+                  placeholder={"Enter page content"}
+                  onChange={this.handleChange}
+                  modules={editorModules}
+                ></Editor>
+                <Button
+                  className="mr-2"
+                  onClick={() =>
+                    this.setState({
+                      copy: "",
+                      pageId: null,
+                      isEditorActive: false,
+                      pageContentId: null
+                    })
+                  }
+                >
+                  Cancel
+                </Button>
+                <Button
+                  onClick={() => {
+                    this.handleEditorSave();
+                  }}
+                >
+                  Save
+                </Button>
+              </div>
+            </FocusLock>
+          </div>
+        ) : (
+          <></>
+        )}
       </div>
     );
   }


### PR DESCRIPTION
**JIRA Ticket**: (link) (:star:)
https://webapps.es.vt.edu/jira/browse/LIBTD-2661

# What does this Pull Request do? (:star:)
This adds WYSIWYG editor to the parts of the admin site that accept html content (HomepageForm, SitePagesForm, and the forms for editing archives and collections (EditMetadata). It also adds a new PageContent table to store the html for site pages. It also updates the places throughout the site so that HTML is rendered correctly.

# What's the changes? (:star:)
- src/components/Citation.js - just a small change to parse the html using the same tool consistently.
- src/components/Editor.js - the component for the WYSIWYG editor, which is called Quill. The modules prop defines which options to display in the toolbar. The formats prop defines what html elements can be copied and pasted in the text editing area. 
-src/components/MediaElement.js and src/components/PodcastMediaElement.js - just a small change to update the downloadFile function.
-src/lib/MetadataRenderer.js - a couple small updates to adjust the tags allowed by the sanitizer and removes the htmlParsedValue function because more than <a> links are allowed now, so this wasn't needed anymore.
- src/lib/fetchTools.js - changes the dowloadFile function to use the getFileContent function below it instead of the FileGetter class. This change allows files to be downloaded whether or not the content disposition for the file is attachment. Also adds separate query for PageContent table.
- src/pages/AboutPage.js, src/pages/AdditionalPages.js, src/pages/PermissionsPage.js - These got a small update to retrieve either the html content from the html file for that page or the PageContent table. Also adds some necessary styles for classes that Quill uses.
-src/pages/admin/ArchiveCollectionEdit/ArchiveForm.js and src/pages/admin/ArchiveCollectionEdit/CollectionForm.js - both of these got updates to the changeHandler so that the value in the text editor will be controlled by state values. Also the submit handler was updated to null out the value that is equivalent to an empty entry in the text editor.
- src/pages/admin/ArchiveCollectionEdit/EditMetadata.js - Updated to display the editor for the 4 metadata fields that accept html ("source", "related_url", "description", "rights_statement"). The rest just use the textarea input as usual.
- src/pages/admin/HomepageForm.js - adds the editor for the home statement.
- src/pages/admin/SitePagesForm.js - This component saw the most revisions and probably should have been a separate ticket. Sorry! :( Basically it adds everything needed to use the editor to create page content and then save and retrieve that content from the new PageContent table. Users can still choose to upload an html file for their content, and now they can also download whatever the current file is to make changes on their own and upload again. when they upload an html file, the component assumes they want to use it and checks the "use html file" box. If a user makes edits and saves them in the editor, then the component assumes they would like to use the editor content and unchecks the "use html file" box. The user can change their mind at any time and check/uncheck that box themselves.

# How should this be tested?
Use the editor to make changes to the home statement, site pages, and the "source", "related_url", "description", or "rights_statement" fields of an archive/collection record.

# Additional Notes:
This PR uses the trytable backend.
branch is LIBTD-2661

# Interested parties
@whunter 

(:star:) Required fields
