### PR TITLE
Minerva viewer styles

### DIFF
--- a/cypress/integration/archive_media_views.spec.js
+++ b/cypress/integration/archive_media_views.spec.js
@@ -67,11 +67,11 @@ describe("archive_media_views: Archive Mirador viewer", () => {
 describe('archive_media_views: Archive Minerva viewer', () => {
   it('renders viewer if exhibit.json', () => {
     cy.visit('/archive/s253n52s').wait(2000);
-    cy.get('span#minerva-open-dialog')
+    cy.get('div#minerva-open-dialog')
       .eq(0)
       .should('be.visible')
-      .should('contain', "This record type requires a full screen image viewer. Please click")
-    cy.get('span#minerva-open-dialog > a')
+      .should('contain', "This record type requires a full screen image viewer.")
+    cy.get('div#minerva-open-dialog > button')
       .click({force: true})
     cy.get("div.minerva-root")
       .eq(0)

--- a/src/components/GalleryView.js
+++ b/src/components/GalleryView.js
@@ -16,7 +16,6 @@ const GalleryView = (props) => {
             item={props.item}
             category={props.category}
             className="card-img-top"
-            label={props.label}
             site={props.site}
           />
         </NavLink>

--- a/src/components/ItemListView.js
+++ b/src/components/ItemListView.js
@@ -35,7 +35,6 @@ class ItemListView extends Component {
               <Thumbnail
                 item={this.props.item}
                 category={this.props.category}
-                label={this.props.label}
                 site={this.props.site}
               />
             </div>

--- a/src/components/MinervaPlayer/MinervaPlayer.tsx
+++ b/src/components/MinervaPlayer/MinervaPlayer.tsx
@@ -4,9 +4,14 @@ import MinervaStory from "minerva-browser";
 import { Thumbnail } from "../Thumbnail";
 import { Link, useLocation } from "react-router-dom";
 import Modal from "react-modal";
-
+import { FontAwesomeIcon } from "@fortawesome/react-fontawesome";
+import {
+  faArrowUpRightFromSquare,
+  faXmark
+} from "@fortawesome/free-solid-svg-icons";
 interface MinervaPlayerProps {
-  item: any;
+  item: Archive;
+  site: Site;
 }
 
 declare global {
@@ -15,9 +20,7 @@ declare global {
   }
 }
 
-export const MinervaPlayer: FC<MinervaPlayerProps> = ({
-  item
-}: MinervaPlayerProps): ReactElement => {
+export const MinervaPlayer: FC<MinervaPlayerProps> = ({ item, site }) => {
   let display: ReactElement;
   const location = useLocation();
   const [fullScreenViewer, setFullScreenViewer] = useState(false);
@@ -42,23 +45,18 @@ export const MinervaPlayer: FC<MinervaPlayerProps> = ({
 
   const defaultView = (): ReactElement => {
     return (
-      <div>
-        <Thumbnail
-          item={item}
-          imgURL={item.thumbnail_path}
-          className={"minerva-thumbnail"}
-          label={item.title}
-          altText={item.title}
-          category="archive"
-          site={{ siteId: "" } as Site}
-        />
-        <span id="minerva-open-dialog">
-          This record type requires a full screen image viewer. Please click{" "}
-          <Link to={location.pathname} onClick={setFullScreenView}>
-            here
-          </Link>{" "}
-          to open the viewer.
-        </span>
+      <div className="minerva-image-wrapper">
+        <Link to={location.pathname} onClick={setFullScreenView}>
+          <Thumbnail item={item} altText={true} site={site} />
+          <span className="visually-hidden">Opens fullscreen viewer</span>
+        </Link>
+        <div id="minerva-open-dialog">
+          <p>This record type requires a full screen image viewer.</p>
+          <button onClick={setFullScreenView}>
+            Open Viewer
+            <FontAwesomeIcon icon={faArrowUpRightFromSquare} />
+          </button>
+        </div>
       </div>
     );
   };
@@ -86,9 +84,10 @@ export const MinervaPlayer: FC<MinervaPlayerProps> = ({
         <>
           <div id="minerva-browser"></div>
           <span id="minerva-browser-closer">
-            <Link to={location.pathname} onClick={setDefaultView}>
-              Return to metadata view
-            </Link>
+            <button onClick={setDefaultView}>
+              Close Viewer
+              <FontAwesomeIcon icon={faXmark} />
+            </button>
           </span>
         </>
       </Modal>

--- a/src/components/Thumbnail/Thumbnail.tsx
+++ b/src/components/Thumbnail/Thumbnail.tsx
@@ -3,23 +3,21 @@ import "../../css/Thumbnail.scss";
 import { useSignedLink } from "../../hooks/useSignedLink";
 
 type Props = {
-  imgURL?: string;
   item: Collection | Archive;
   site: Site;
-  label?: boolean;
-  category: string;
+  category?: string;
   className?: string;
   altText?: boolean;
+  imgURL?: string;
 };
 
 export const Thumbnail: FC<Props> = ({
-  imgURL,
   item,
   site,
-  label,
   category,
   className,
-  altText
+  altText,
+  imgURL
 }) => {
   const image = useSignedLink(
     imgURL || item.thumbnail_path,
@@ -31,7 +29,7 @@ export const Thumbnail: FC<Props> = ({
   }
   return (
     <div className="image-container">
-      {label && (
+      {category && (
         <div className={`${category}-label`}>
           <p>{category === "collection" ? "Collection" : "Item"}</p>
         </div>

--- a/src/components/Thumbnail/thumbnail.test.js
+++ b/src/components/Thumbnail/thumbnail.test.js
@@ -7,7 +7,6 @@ describe("Thumbnail component", () => {
   const setup = (
     category = "archive",
     imgUrl = "https://img.cloud.lib.vt.edu/iawa/Ms1990_025_Rudoff/Ms1990_025_Box1/Ms1990_025_Box1_Folder1/tiles/Ms1990_025_Per_Ms_B001_F001_002-1/full/193,/0/default.jpg",
-    label = true,
     altText = false
   ) => {
     jest.spyOn(FunctionalFileGetter, "getFile").mockResolvedValue(imgUrl);
@@ -19,7 +18,6 @@ describe("Thumbnail component", () => {
           thumbnail_path: imgUrl,
           title: "Title"
         }}
-        label={label}
         site={{
           siteId: "default"
         }}
@@ -40,13 +38,13 @@ describe("Thumbnail component", () => {
   });
 
   it("displays no label", async () => {
-    setup(undefined, undefined, false);
+    setup(null);
     const label = await waitFor(() => screen.queryByRole("paragraph"));
     expect(label).toBeNull();
   });
 
   it("populates alternative text", async () => {
-    setup(undefined, undefined, undefined, true);
+    setup(undefined, undefined, true);
     expect(await screen.findByAltText("Title")).toBeInTheDocument();
   });
 

--- a/src/css/ArchivePage.scss
+++ b/src/css/ArchivePage.scss
@@ -146,3 +146,69 @@ div.obj-wrapper {
   font-weight: 600;
   padding: 5px 10px;
 }
+
+div.minerva-image-wrapper {
+  display: flex;
+  flex-wrap: wrap;
+  justify-content: center;
+}
+
+div.minerva-image-wrapper a {
+  width: 100%;
+}
+
+div.minerva-image-wrapper div.image-container {
+  width: 100%;
+  position: static;
+  border: none;
+}
+
+div.minerva-image-wrapper div.image-container img {
+  display: block;
+  max-width: 90%;
+  margin: 0 auto;
+}
+
+@media (min-width: 768px) {
+  div.minerva-image-wrapper div.image-container img {
+    max-width: 50%;
+  }
+}
+
+div.minerva-image-wrapper #minerva-open-dialog {
+  width: 100%;
+  flex-wrap: wrap;
+  justify-content: center;
+  font-size: 1.2rem;
+  margin-top: 15px;
+  text-align: center;
+}
+
+#minerva-browser-closer button {
+  position: fixed;
+  right: 10px;
+  bottom: 10px;
+}
+
+div.minerva-image-wrapper #minerva-open-dialog button,
+#minerva-browser-closer button {
+  color: white;
+  background-color: var(--hokieMaroon);
+  font-family: "Acherus", sans-serif;
+  font-weight: 600;
+  padding: 7px 15px;
+  font-size: 1.2rem;
+  border: none;
+}
+
+div.minerva-image-wrapper #minerva-open-dialog svg,
+#minerva-browser-closer svg {
+  padding-left: 10px;
+  display: inline-block;
+  vertical-align: middle;
+}
+
+div.minerva-image-wrapper #minerva-open-dialog button:hover,
+#minerva-browser-closer button:hover {
+  background-color: var(--hokieMaroonHover);
+}

--- a/src/css/Viewer.scss
+++ b/src/css/Viewer.scss
@@ -10,26 +10,6 @@
   width: 100%;
   height: 1000px;
 }
-#minerva-browser-closer {
-  position: fixed;
-  right: 10px;
-  bottom: 10px;
-  background-color: white;
-  border: 2px solid var(--hokieMaroon);
-  padding: 2px 5px;
-  a {
-    color: var(--hokieOrange);
-  }
-}
-#minerva-open-dialog {
-  position: relative;
-  display: block;
-  font-size: 1.2rem;
-  margin-top: 15px;
-}
-img.minerva-thumbnail {
-  width: 350px;
-}
 
 nav#vt_nav.hidden {
   display: none;

--- a/src/pages/archives/ArchivePage.js
+++ b/src/pages/archives/ArchivePage.js
@@ -170,7 +170,7 @@ class ArchivePage extends Component {
     if (this.isMiradorURL(item.manifest_url)) {
       display = <MiradorViewer item={item} site={this.props.site} />;
     } else if (this.isMinervaURL(item.manifest_url)) {
-      display = <MinervaPlayer item={item} />;
+      display = <MinervaPlayer item={item} site={this.props.site} />;
     } else if (this.isImgURL(item.manifest_url)) {
       display = (
         <Thumbnail

--- a/src/pages/collections/CollectionsShowPage/CollectionItems.tsx
+++ b/src/pages/collections/CollectionsShowPage/CollectionItems.tsx
@@ -70,7 +70,7 @@ export const CollectionItems: FC<Props> = ({
                 <div key={item.identifier} className="collection-entry">
                   <Link to={`/archive/${arkLinkFormatted(item.custom_key)}`}>
                     <div className="collection-img">
-                      <Thumbnail item={item} site={site} category="archive" />
+                      <Thumbnail item={item} site={site} />
                     </div>
                     <div className="collection-details">
                       <h3>{item.title}</h3>
@@ -92,7 +92,7 @@ export const CollectionItems: FC<Props> = ({
                   <div className="collection-item-wrapper">
                     <Link to={`/archive/${arkLinkFormatted(item.custom_key)}`}>
                       <div className="item-image">
-                        <Thumbnail item={item} site={site} category="archive" />
+                        <Thumbnail item={item} site={site} />
                       </div>
                       <div className="item-info">
                         <h3>{item.title}</h3>

--- a/src/pages/collections/CollectionsShowPage/tests/collection-top-content.test.js
+++ b/src/pages/collections/CollectionsShowPage/tests/collection-top-content.test.js
@@ -42,9 +42,7 @@ describe("CollectionsTopContent component", () => {
     ).toBeInTheDocument();
     expect(screen.getByText(/Created by: Test Creator/i)).toBeInTheDocument();
     expect(
-      screen.getByText(
-        /Eastern Standard Time)/i
-      )
+      screen.getByText(/Last updated:/i)
     ).toBeInTheDocument();
     expect(
       screen.getByRole("heading", { name: "Description" })

--- a/src/pages/search/ItemsList.js
+++ b/src/pages/search/ItemsList.js
@@ -29,7 +29,6 @@ class ItemsList extends Component {
                   key={item.id}
                   item={item}
                   category={getCategory(item)}
-                  label={true}
                   site={this.props.site}
                 />
               );
@@ -39,7 +38,6 @@ class ItemsList extends Component {
                   key={item.id}
                   item={item}
                   category={getCategory(item)}
-                  label={true}
                   site={this.props.site}
                 />
               );
@@ -49,7 +47,6 @@ class ItemsList extends Component {
                   key={item.id}
                   item={item}
                   category={getCategory(item)}
-                  label={true}
                   site={this.props.site}
                 />
               );

--- a/src/pages/search/MasonryView.js
+++ b/src/pages/search/MasonryView.js
@@ -3,7 +3,7 @@ import { arkLinkFormatted } from "../../lib/MetadataRenderer";
 import { Thumbnail } from "../../components/Thumbnail";
 import "../../css/SearchResult.scss";
 
-const MasonryView = props => {
+const MasonryView = (props) => {
   return (
     <div className="masonry">
       <div className="card border-0">
@@ -13,7 +13,6 @@ const MasonryView = props => {
           <Thumbnail
             item={props.item}
             category={props.category}
-            label={props.label}
             className="card-img"
             altText="true"
           />


### PR DESCRIPTION
**JIRA Ticket**: (link) (:star:)
https://webapps.es.vt.edu/jira/browse/LIBTD-2673

# What does this Pull Request do? (:star:)
Styles the minerva viewer component

# What's the changes? (:star:)
-MinervaPlayer.tsx - makes some semantic changes (links to buttons), adds a link around the image, makes some adjustments to typescript stuff.
-thumbnail, galleryview, itemlistview, masonryview, itemslist, collectionitems - removes unnecessary label props for thumbnail component.

# How should this be tested?
Styles should be visible in minerva item in the Demo collection. Check that the buttons work same as the links did.

# Additional Notes:
branch is LIBTD-2673

# Interested parties
@whunter 

(:star:) Required fields
