### PR TITLE
Hide channel groups section in Minerva player

### DIFF
--- a/src/components/MinervaPlayer/MinervaPlayer.tsx
+++ b/src/components/MinervaPlayer/MinervaPlayer.tsx
@@ -1,14 +1,14 @@
-import React, { FC, ReactElement, useState } from "react";
-import "../../css/Viewer.scss";
-import MinervaStory from "minerva-browser";
-import { Thumbnail } from "../Thumbnail";
-import { Link, useLocation } from "react-router-dom";
-import Modal from "react-modal";
-import { FontAwesomeIcon } from "@fortawesome/react-fontawesome";
 import {
   faArrowUpRightFromSquare,
   faXmark
 } from "@fortawesome/free-solid-svg-icons";
+import { FontAwesomeIcon } from "@fortawesome/react-fontawesome";
+import MinervaStory from "minerva-browser";
+import React, { FC, ReactElement, useState } from "react";
+import Modal from "react-modal";
+import { Link, useLocation } from "react-router-dom";
+import { Thumbnail } from "../Thumbnail";
+import "../../css/Viewer.scss";
 interface MinervaPlayerProps {
   item: Archive;
   site: Site;

--- a/src/css/Viewer.scss
+++ b/src/css/Viewer.scss
@@ -9,6 +9,9 @@
   display: block;
   width: 100%;
   height: 1000px;
+  .minerva-root .minerva-legend {
+    display: none;
+  }
 }
 
 nav#vt_nav.hidden {


### PR DESCRIPTION
**Hide channel groups section in Minerva player.**
* * *

**JIRA Ticket**: (link) (:star:)

* Other Relevant Links (Meeting note, project page, related pull requests, etc.)

# What does this Pull Request do? (:star:)
Hide channel groups section in Minerva player

# What's the changes? (:star:)
* adds "display:none" to `.minerva-root .minerva-legend` class to hide the Channel Groups section

# How should this be tested?
* Visit preview site (I'll put the link here when it finishes deploying): https://remove-pws-channels.d234tdmg9icdwk.amplifyapp.com/archive/8919df16
* The Minerva player should look like this (no Channel Groups interface on right side):

![pvn](https://github.com/VTUL/dlp-access/assets/1202435/f9d9b8d1-e83a-48f2-bfcd-f44649cb8612)


# Additional Notes:
Any additional information that you think would be helpful when reviewing this PR.
* branch: `remove_pws_channels`

# Interested parties
@goynejennifer 

(:star:) Required fields
