### PR TITLE
Change default search field to 'all'

### DIFF
--- a/src/components/SearchBar.js
+++ b/src/components/SearchBar.js
@@ -11,7 +11,7 @@ class SearchBar extends Component {
     q: this.props.q
   };
 
-  fields = ["title", "description", "all"];
+  fields = ["all", "description", "title"];
 
   fieldOptions = () => {
     return this.fields.map((field) => (

--- a/src/pages/HomePage.js
+++ b/src/pages/HomePage.js
@@ -40,7 +40,7 @@ class HomePage extends Component {
             site={this.props.site}
           />
           <div className="home-search-wrapper">
-            <SearchBar filters={{}} view="Gallery" field="title" q="" />
+            <SearchBar filters={{}} view="Gallery" field="all" q="" />
           </div>
           <HomeStatement homeStatement={homeStatement} />
           <div className="home-nav-links">

--- a/src/pages/archives/ArchivePage.js
+++ b/src/pages/archives/ArchivePage.js
@@ -42,7 +42,7 @@ class ArchivePage extends Component {
       collectionTitle: "",
       page: 0,
       category: "archive",
-      searchField: "title",
+      searchField: "all",
       view: "Gallery",
       info: {},
       languages: null,
@@ -304,7 +304,7 @@ class ArchivePage extends Component {
           <SearchBar
             category={this.state.category}
             view={this.state.view}
-            searchField={this.state.searchField}
+            field={this.state.searchField}
             setPage={this.setPage}
             updateFormState={this.updateFormState}
           />

--- a/src/pages/search/SearchLoader.js
+++ b/src/pages/search/SearchLoader.js
@@ -18,7 +18,7 @@ class SearchLoader extends Component {
       page: 0,
       totalPages: 1,
       filters: {},
-      field: "title",
+      field: "all",
       view: "Gallery",
       q: "",
       languages: null,
@@ -138,7 +138,7 @@ class SearchLoader extends Component {
     }
     return {
       q: searchParams.get("q") || "",
-      field: searchParams.get("field") || "title",
+      field: searchParams.get("field") || "all",
       view: searchParams.get("view") || "Gallery",
       ...restQuery
     };


### PR DESCRIPTION
**Change default search field to 'all'**

**Asana Ticket**: (link) (:star:)
https://app.asana.com/0/1205959349035436/1206858934896517/f

# What does this Pull Request do? (:star:)
Change the default search field from 'title' to 'all'

# What's the changes? (:star:)
- Search bar search field in the home page is set to 'all' by default.
- Re-ordered all search fields to be in alphabetical order

# How should this be tested?
- In home page or in search result page, the default search field for search bar is set to 'all'.

# Interested parties
Tag (@ mention) interested parties
@whunter 
@goynejennifer 

(:star:) Required fields
