### PR TITLE
render git commit info if env var is set

### DIFF
--- a/cypress/e2e/integration/browse_collections.cy.js
+++ b/cypress/e2e/integration/browse_collections.cy.js
@@ -3,10 +3,6 @@ describe("browse_collections: Browse collections page", () => {
     cy.visit("/collections");
   });
 
-  it("displays the correct page title", () => {
-    cy.get("h1").invoke("text").should("equal", "About Our Collections");
-  });
-
   it("finds the first collection sorted by title as default", () => {
     cy.get(".gallery-item")
       .first()

--- a/package-lock.json
+++ b/package-lock.json
@@ -83,7 +83,7 @@
         "husky": "^3.1.0",
         "lint-staged": "^13.2.0",
         "prettier": "^2.8.7",
-        "semantic-ui-css": "^2.5.0"
+        "semantic-ui-css": "git+https://github.com/Semantic-Org/Semantic-UI-CSS.git"
       }
     },
     "node_modules/@aashutoshrathi/word-wrap": {

--- a/src/App.js
+++ b/src/App.js
@@ -12,6 +12,7 @@ import AnalyticsConfig from "./components/AnalyticsConfig";
 import Header from "./components/Header";
 import NavBar from "./components/NavBar";
 import Footer from "./components/Footer";
+import { GitDetails } from "./components/GitDetails";
 import LoadingScreen from "./components/LoadingScreen";
 import { buildRoutes } from "./lib/CustomPageRoutes";
 import HomePage from "./pages/HomePage";
@@ -192,6 +193,7 @@ class App extends Component {
                 </Routes>
               </div>
             </main>
+            <GitDetails />
             <Footer />
           </ThemeProvider>
         </StyledEngineProvider>

--- a/src/components/GitDetails.js
+++ b/src/components/GitDetails.js
@@ -1,0 +1,25 @@
+import { Link } from "react-router-dom";
+import "../css/GitDetails.scss";
+
+const GitDetails = () => {
+  const gitCommit = process.env.REACT_APP_GIT_COMMIT;
+  console.log("GitDetails gitCommit", gitCommit);
+  if (!gitCommit) {
+    return null;
+  }
+  return (
+    <div className="git-detail-section">
+      <p>
+        This site is running commit{" "}
+        <Link to={`https://github.com/VTUL/dlp-access/commit/${gitCommit}`}>
+          {gitCommit.length > 8 ? gitCommit.substring(0, 7) : gitCommit}
+        </Link>{" "}
+        of the{" "}
+        <Link to={"https://github.com/VTUL/dlp-access/"}>vtdlp-access</Link>{" "}
+        project
+      </p>
+    </div>
+  );
+};
+
+export { GitDetails };

--- a/src/css/GitDetails.scss
+++ b/src/css/GitDetails.scss
@@ -1,0 +1,20 @@
+.git-detail-section {
+  position: relative;
+  display: block;
+  background-color: var(--light-gray);
+  width: 100%;
+  margin-bottom: 15px;
+  padding: 10px;
+  p {
+    position: relative;
+    display: block;
+    text-align: center;
+    font-family: "gineso-condensed", sans-serif;
+    a,
+    a:visited {
+      position: relative;
+      color: var(--themeHighlightColor);
+      cursor: pointer;
+    }
+  }
+}


### PR DESCRIPTION
**render git commit info above footer if env var is set**
* * *

**JIRA Ticket**: (link) (:star:)

* Other Relevant Links (Meeting note, project page, related pull requests, etc.)

# What does this Pull Request do? (:star:)
renders git commit info above footer if env var is set

# How should this be tested?
* visit generated preview site
* check that commit number is rendered above footer in a usable link to that commit. It should be the first 7 characters of this commit: 13942cd128ec52cbff75655c9a58da63b848c112

# Additional Notes:
* branch: `git_commit_section`

# Interested parties
@goynejennifer 

(:star:) Required fields
