### PR TITLE
render multivalued stuff on separate lines

### DIFF
--- a/src/css/ListPages.scss
+++ b/src/css/ListPages.scss
@@ -84,6 +84,12 @@ td.collection-detail-value div span.list-unstyled {
   flex-wrap: wrap;
   gap: 0.3em;
 }
+.archive-item-tags.multi {
+  display: block;
+  .list-unstyled {
+    display: block;
+  }
+}
 
 a.more-link {
   margin-left: 10px;

--- a/src/lib/MetadataRenderer.js
+++ b/src/lib/MetadataRenderer.js
@@ -252,10 +252,11 @@ function textFormat(item, attr, languages, collectionCustomKey, site) {
   let category = "archive";
   if (item.collection_category) category = "collection";
   if (Array.isArray(item[attr]) && attr !== "description") {
+    console.log("textFormat", attr, item[attr]);
     return (
-      <div className="archive-item-tags">
+      <div className="archive-item-tags multi">
         {item[attr].map((value, i) => (
-          <span className="list-unstyled" key={i} data-cy="multi-field-span">
+          <div className="list-unstyled" key={i} data-cy="multi-field-span">
             {attr === "is_part_of" && i === 0 ? (
               <a href={`/collection/${arkLinkFormatted(collectionCustomKey)}`}>
                 {value}
@@ -263,8 +264,7 @@ function textFormat(item, attr, languages, collectionCustomKey, site) {
             ) : (
               listValue(category, attr, value, languages)
             )}
-            {i < item[attr].length - 1 && ","}
-          </span>
+          </div>
         ))}
       </div>
     );


### PR DESCRIPTION
**Render multivalued stuff on separate lines.**
* * *

**JIRA Ticket**: (link) (:star:)

* Other Relevant Links (Meeting note, project page, related pull requests, etc.)

# What does this Pull Request do? (:star:)
Changes metadata sections to render multivalued stuff on separate lines

# What's the changes? (:star:)
* Changes metadata sections to render multivalued stuff on separate lines

# How should this be tested?
* Visit generated preview here: https://pr-469.d234tdmg9icdwk.amplifyapp.com/archive/425cb429
  (or any other record with multiple values)
* Check that metadata items that have multiple values use "newline" as the delimiter (each value on it's own line)

# Additional Notes:
* branch: `multi-val_newline`
* THIS PR DOES NOT CONTAIN THE UPDATES FOR THE 3D VIEW. This pr ONLY addresses the multi-value -> multi-line thing so don't worry that it looks like the old 3D view.

# Interested parties
@goynejennifer 

(:star:) Required fields
