### PR TITLE
Collection page sorting

### DIFF
--- a/amplify/backend/api/collectionarchives/resolvers/Query.searchArchives.req.vtl
+++ b/amplify/backend/api/collectionarchives/resolvers/Query.searchArchives.req.vtl
@@ -1,35 +1,43 @@
 #set( $indexPath = "/archive/_search" )
 #set( $nonKeywordFields = ["visibility", "start_date"] )
 #if( $util.isNullOrEmpty($context.args.sort) )
-  #set( $sortDirection = "desc" )
-  #set( $sortField = "id" )
+  #set( $sortDirection = "asc" )
+  #set( $sortField = "title" )
 #else
-  #set( $sortDirection = $util.defaultIfNull($context.args.sort.direction, "desc") )
-  #set( $sortField = $util.defaultIfNull($context.args.sort.field, "id") )
+  #set( $sortDirection = $util.defaultIfNull($context.args.sort[0].direction, "asc") )
+  #set( $sortField = $util.defaultIfNull($context.args.sort[0].field, "title") )
 #end
 #if( $nonKeywordFields.contains($sortField) )
   #set( $sortField0 = $util.toJson($sortField) )
 #else
   #set( $sortField0 = $util.toJson("${sortField}.keyword") )
 #end
+#set( $sortFieldCustomKey = $util.toJson("custom_key.keyword") )
+#set( $indexPath = "/archive/_search" )
 {
   "version": "2018-05-29",
   "operation": "GET",
   "path": "$indexPath",
   "params": {
     "body": {
-      #if( $context.args.nextToken )"search_after": [$util.toJson($context.args.nextToken)], #end
-      #if( $context.args.from )"from": $context.args.from, #end
+      #if( $context.args.nextToken )
+      	#set( $nextToken = $context.args.nextToken )
+        #set( $tokens = $nextToken.split("::key::") )
+        "search_after": [
+          #if ( $tokens[0] == "NULL_FIELD" ) null #else $util.toJson($tokens[0]) #end,
+          $util.toJson($tokens[1])
+        ],
+      #end
       "size": #if( $context.args.limit ) $context.args.limit #else 100 #end,
-      "sort": [{$sortField0: { "order" : $util.toJson($sortDirection) }}],
-      "version": false,
-      "query":
-        #if( $context.args.filter )
-          $util.transform.toElasticsearchQueryDSL($ctx.args.filter)
-        #else {
-          "match_all": {}
-        }
-        #end
+      "sort": [
+        { $sortField0: { "order": $util.toJson($sortDirection) } },
+        { $sortFieldCustomKey: { "order": "asc" } }
+      ],
+      "query": #if( $context.args.filter )
+        $util.transform.toElasticsearchQueryDSL($ctx.args.filter)
+      #else
+        { "match_all": {} }
+      #end
     }
   }
 }

--- a/amplify/backend/api/collectionarchives/resolvers/Query.searchArchives.res.vtl
+++ b/amplify/backend/api/collectionarchives/resolvers/Query.searchArchives.res.vtl
@@ -1,7 +1,10 @@
 #set( $es_items = [] )
 #foreach( $entry in $context.result.hits.hits )
   #if( !$foreach.hasNext )
-    #set( $nextToken = $entry.sort.get(0) )
+    #set( $sortFieldValue = $util.defaultIfNull($entry.sort.get(0), "NULL_FIELD") )
+    #set( $customKey = $entry.get("_source").get("custom_key") )
+    #set( $tokenString = "${sortFieldValue}::key::$customKey" )
+    #set( $nextToken = $tokenString )
   #end
   $util.qr($es_items.add($entry.get("_source")))
 #end

--- a/cypress.config.ts
+++ b/cypress.config.ts
@@ -1,10 +1,9 @@
-import { defineConfig } from 'cypress'
+import { defineConfig } from "cypress";
 
+const apiTestOnly = process.env.CYPRESS_API_TEST_ONLY == "true";
 export default defineConfig({
   chromeWebSecurity: false,
   e2e: {
-    // We've imported your old cypress plugins here.
-    // You may want to clean this up later by importing these.
-    baseUrl: 'http://localhost:3000/',
-  },
-})
+    baseUrl: apiTestOnly ? null : "http://localhost:3000"
+  }
+});

--- a/cypress/e2e/api/search_archives_graphql.cy.js
+++ b/cypress/e2e/api/search_archives_graphql.cy.js
@@ -1,0 +1,244 @@
+const searchArchivesQuery = `
+  query SearchCollectionItems(
+      $parent_id: String!
+      $limit: Int
+      $sort: [SearchableArchiveSortInput]
+      $nextToken: String
+  ) {
+      searchArchives(
+          filter: { heirarchy_path: { eq: $parent_id }, visibility: { eq: true } }
+          sort: $sort
+          limit: $limit
+          nextToken: $nextToken
+      ) {
+          items {
+              id
+              title
+              description
+              start_date
+              custom_key
+              identifier
+              description
+              tags
+              creator
+              create_date
+          }
+          total
+          nextToken
+      }
+  }
+
+`;
+
+describe("searchArchives query default sorting", () => {
+  it("Archives sorted by title in asc order by default", () => {
+    const variables = {
+      limit: 5,
+      parent_id: "4172836b-4760-423c-bb4e-c5215e069d76"
+    };
+    cy.graphqlRequest(searchArchivesQuery, variables).then((res) => {
+      expect(res.status).to.eq(200);
+      const items = res.body.data.searchArchives.items;
+      expect(items).to.exist;
+      expect(items).to.have.lengthOf(5);
+      expect(items[0].title).to.eq("Abaeis nicippe ((Cramer, 1779))");
+      expect(items[1].title).to.eq("Abaeis nicippe ((Cramer, 1779))");
+      expect(items[2].title).to.eq("Achalarus lyciades ((Geyer, [1832]))");
+      expect(items[3].title).to.eq("Achalarus lyciades ((Geyer, [1832]))");
+      expect(items[4].title).to.eq("Achalarus lyciades ((Geyer, [1832]))");
+    });
+  });
+});
+
+describe("searchArchives query sort by title by desc order", () => {
+  it("Archives sorted by title in desc order", () => {
+    const variables = {
+      limit: 5,
+      parent_id: "4172836b-4760-423c-bb4e-c5215e069d76",
+      sort: [
+        {
+          field: "title",
+          direction: "desc"
+        }
+      ]
+    };
+    cy.graphqlRequest(searchArchivesQuery, variables).then((res) => {
+      expect(res.status).to.eq(200);
+      const items = res.body.data.searchArchives.items;
+      expect(items).to.exist;
+      expect(items).to.have.lengthOf(5);
+      expect(items[0].title).to.eq("speyeria idalia ((Drury, 1773))");
+      expect(items[1].title).to.eq("moduza (Moore, 1881)");
+      expect(items[2].title).to.eq("hes");
+      expect(items[3].title).to.eq("Zerene cesonia ((Stoll, 1790))");
+      expect(items[4].title).to.eq("Xylocopa virginica ((Linnaeus, 1771))");
+    });
+  });
+});
+
+describe("searchArchives query sort by start_date by asc order", () => {
+  it("Archives sorted by title in desc order", () => {
+    const variables = {
+      limit: 5,
+      parent_id: "4172836b-4760-423c-bb4e-c5215e069d76",
+      sort: [
+        {
+          field: "start_date",
+          direction: "asc"
+        }
+      ]
+    };
+    cy.graphqlRequest(searchArchivesQuery, variables).then((res) => {
+      expect(res.status).to.eq(200);
+      const items = res.body.data.searchArchives.items;
+      expect(items).to.exist;
+      expect(items).to.have.lengthOf(5);
+      expect(items[0].id).to.eq("5965bd54-6958-4a87-8c3d-024b716bc482");
+      expect(items[0].start_date).to.eq("1874/08/13");
+
+      expect(items[1].id).to.eq("81675218-2bd6-45cb-972a-318b6f076d43");
+      expect(items[1].start_date).to.eq("1876/07/20");
+
+      expect(items[2].id).to.eq("80323649-2160-458a-ab92-4a9596c9e760");
+      expect(items[2].start_date).to.eq("1889/07/03");
+
+      expect(items[3].id).to.eq("950254d0-8b29-4d4a-806b-3ec5a837f4ce");
+      expect(items[3].start_date).to.eq("1894/08/02");
+
+      expect(items[4].id).to.eq("559bcb88-14c9-4cc9-a587-a2b5c7b6fd7d");
+      expect(items[4].start_date).to.eq("1895/08/02");
+    });
+  });
+});
+
+describe("searchArchives query sort by start_date by desc order", () => {
+  let nextToken = null;
+  const variables = {
+    limit: 5,
+    parent_id: "4172836b-4760-423c-bb4e-c5215e069d76",
+    sort: [
+      {
+        field: "start_date",
+        direction: "desc"
+      }
+    ]
+  };
+  it("Archives sorted by title in desc order", () => {
+    cy.graphqlRequest(searchArchivesQuery, variables).then((res) => {
+      expect(res.status).to.eq(200);
+      let items = res.body.data.searchArchives.items;
+      expect(items).to.exist;
+      expect(items).to.have.lengthOf(5);
+
+      expect(items[0].id).to.eq("0e894be0-9a70-456e-bd58-682c9a9943a0");
+      expect(items[0].start_date).to.eq("2019/09/05");
+
+      expect(items[1].id).to.eq("257c59d2-c2c0-4144-82e1-91e846fe10cf");
+      expect(items[1].start_date).to.eq("2018/08/14");
+
+      expect(items[2].id).to.eq("7af4c0f2-5279-4ba8-8062-31f95c50674b");
+      expect(items[2].start_date).to.eq("2018/08/14");
+
+      expect(items[3].id).to.eq("d858803d-73df-4724-a7ac-c205f266cff4");
+      expect(items[3].start_date).to.eq("2018/08/14");
+
+      expect(items[4].id).to.eq("916b1668-ae83-4f81-9ddd-56cc01f9b473");
+      expect(items[4].start_date).to.eq("2018/08/14");
+
+      nextToken = res.body.data.searchArchives.nextToken;
+      expect(nextToken).to.exist.to.eq(
+        "1534204800000::key::ark:/53696/ss07hm3g"
+      );
+    });
+  });
+  it("Paginate results with nextToken", () => {
+    variables["nextToken"] = nextToken;
+    cy.graphqlRequest(searchArchivesQuery, variables).then((res) => {
+      expect(res.status).to.eq(200);
+      const items = res.body.data.searchArchives.items;
+      expect(items).to.exist;
+      expect(items).to.have.lengthOf(5);
+
+      expect(items[0].id).to.eq("d6c01b8c-ab24-4018-bf38-5061203f15c4");
+      expect(items[0].start_date).to.eq("2018/08/13");
+
+      expect(items[1].id).to.eq("e315eefa-6425-447f-99ca-3df0fdecfd1e");
+      expect(items[1].start_date).to.eq("2018/08/13");
+
+      expect(items[2].id).to.eq("58b724e3-f9bc-418a-bf86-526be1251f33");
+      expect(items[2].start_date).to.eq("2018/08/13");
+
+      expect(items[3].id).to.eq("b00a2cf8-f569-4b5c-b1b8-8acec70af9ad");
+      expect(items[3].start_date).to.eq("2018/08/13");
+
+      expect(items[4].id).to.eq("0edc34fa-9899-457b-9cad-2152065038e0");
+      expect(items[4].start_date).to.eq("2018/08/13");
+    });
+  });
+});
+
+describe("searchArchives query sort by a null field (creator)", () => {
+  let nextToken = null;
+  const variables = {
+    limit: 5,
+    parent_id: "4172836b-4760-423c-bb4e-c5215e069d76",
+    sort: [
+      {
+        field: "creator",
+        direction: "asc"
+      }
+    ],
+    nextToken: null
+  };
+  it("Archives sorted by custom key in asc order", () => {
+    cy.graphqlRequest(searchArchivesQuery, variables).then((res) => {
+      expect(res.status).to.eq(200);
+      const items = res.body.data.searchArchives.items;
+      expect(items).to.exist;
+      expect(items).to.have.lengthOf(5);
+
+      expect(items[0].id).to.eq("7b52b83a-4509-46cd-84b5-c296f554f3a8");
+      expect(items[0].custom_key).to.eq("ark:/53696/0046p295");
+
+      expect(items[1].id).to.eq("539885c3-bdaf-4b23-8a86-39c2e1615861");
+      expect(items[1].custom_key).to.eq("ark:/53696/0057rw0d");
+
+      expect(items[2].id).to.eq("b251e06e-9015-42f5-97a5-642c1dca2a18");
+      expect(items[2].custom_key).to.eq("ark:/53696/0194fs3t");
+
+      expect(items[3].id).to.eq("f2c08f0b-0171-49b7-9f57-84e002b78bdc");
+      expect(items[3].custom_key).to.eq("ark:/53696/0267d54x");
+
+      expect(items[4].id).to.eq("05878b4f-6cff-4433-b2fb-f050ba0a08fa");
+      expect(items[4].custom_key).to.eq("ark:/53696/0270450w");
+
+      nextToken = res.body.data.searchArchives.nextToken;
+      expect(nextToken).to.exist.to.eq("NULL_FIELD::key::ark:/53696/0270450w");
+    });
+
+    it("Paginate results with nextToken", () => {
+      variables["nextToken"] = nextToken;
+      cy.graphqlRequest(searchArchivesQuery, variables).then((res) => {
+        expect(res.status).to.eq(200);
+        const items = res.body.data.searchArchives.items;
+        expect(items).to.exist;
+        expect(items).to.have.lengthOf(5);
+
+        expect(items[0].id).to.eq("96dcdec6-1309-4c49-a58e-019b4479fbbd");
+        expect(items[0].custom_key).to.eq("ark:/53696/0318mv04");
+
+        expect(items[1].id).to.eq("32725f42-dc95-4214-8bbc-ab7a134e379a");
+        expect(items[1].custom_key).to.eq("ark:/53696/0326tc5f");
+
+        expect(items[2].id).to.eq("21dbb27a-e1d6-4428-bf26-62a87560a846");
+        expect(items[2].custom_key).to.eq("ark:/53696/0366j31q");
+
+        expect(items[3].id).to.eq("c7746e9b-3fb8-477f-be54-6b4bdc84a923");
+        expect(items[3].custom_key).to.eq("ark:/53696/0413w83z");
+
+        expect(items[4].id).to.eq("493f1e39-2099-4c74-b889-1cefd5f84f7d");
+        expect(items[4].custom_key).to.eq("ark:/53696/0448df2p");
+      });
+    });
+  });
+});

--- a/cypress/support/commands.js
+++ b/cypress/support/commands.js
@@ -1,31 +1,46 @@
-const Auth = require ("aws-amplify").Auth;
-import "cypress-file-upload"
-import "cypress-localstorage-commands"; 
+const Auth = require("aws-amplify").Auth;
+import "cypress-file-upload";
+import "cypress-localstorage-commands";
 import { Amplify } from "aws-amplify";
 import config from "../../src/aws-exports";
-const username = "devtest"; 
-const password = Cypress.env("password"); 
+const username = "devtest";
+const password = Cypress.env("password");
 
-Amplify.configure(config)
-const awsconfig = { 
-  aws_user_pools_id: Amplify.Auth._config.aws_user_pools_id, 
-  aws_user_pools_web_client_id: Amplify.Auth._config.aws_user_pools_web_client_id, 
-}; 
+Amplify.configure(config);
+const awsconfig = {
+  aws_user_pools_id: Amplify.Auth._config.aws_user_pools_id,
+  aws_user_pools_web_client_id:
+    Amplify.Auth._config.aws_user_pools_web_client_id
+};
 Auth.configure(awsconfig);
 
 Cypress.Commands.add("signIn", () => {
-    cy.then(() => Auth.signIn(username, password)).then((cognitoUser) => {
-      const idToken = cognitoUser.signInUserSession.idToken.jwtToken;
-      const accessToken = cognitoUser.signInUserSession.accessToken.jwtToken;
-  
-      const makeKey = (name) => `CognitoIdentityServiceProvider.${cognitoUser.pool.clientId}.${cognitoUser.username}.${name}`;
-  
-      cy.setLocalStorage(makeKey("accessToken"), accessToken);
-      cy.setLocalStorage(makeKey("idToken"), idToken);
-      cy.setLocalStorage(
-        `CognitoIdentityServiceProvider.${cognitoUser.pool.clientId}.LastAuthUser`,
-        cognitoUser.username
-      );
-    });
-    cy.saveLocalStorage();
+  cy.then(() => Auth.signIn(username, password)).then((cognitoUser) => {
+    const idToken = cognitoUser.signInUserSession.idToken.jwtToken;
+    const accessToken = cognitoUser.signInUserSession.accessToken.jwtToken;
+    const makeKey = (name) =>
+      `CognitoIdentityServiceProvider.${cognitoUser.pool.clientId}.${cognitoUser.username}.${name}`;
+    cy.setLocalStorage(makeKey("accessToken"), accessToken);
+    cy.setLocalStorage(makeKey("idToken"), idToken);
+    cy.setLocalStorage(
+      `CognitoIdentityServiceProvider.${cognitoUser.pool.clientId}.LastAuthUser`,
+      cognitoUser.username
+    );
   });
+  cy.saveLocalStorage();
+});
+
+Cypress.Commands.add("graphqlRequest", (query, variables) => {
+  cy.request({
+    method: "POST",
+    url: Cypress.env("apiUrl"),
+    headers: {
+      "x-api-key": Cypress.env("apiKey"),
+      "Content-Type": "application/json"
+    },
+    body: {
+      query: query,
+      variables: variables
+    }
+  });
+});

--- a/src/components/Pagination.js
+++ b/src/components/Pagination.js
@@ -45,7 +45,12 @@ class Pagination extends Component {
     const Previous = () => {
       if (this.props.page > 0) {
         return (
-          <Button onClick={this.props.previousPage} aria-live="off">
+          <Button
+            onClick={this.props.previousPage}
+            aria-live="off"
+            aria-label="Previous page button"
+            title="Previous page"
+          >
             <i className="fas fa-angle-double-left"></i> Previous
           </Button>
         );
@@ -56,7 +61,12 @@ class Pagination extends Component {
     const Next = () => {
       if (this.props.page < this.props.totalPages - 1) {
         return (
-          <Button onClick={this.props.nextPage} aria-live="off">
+          <Button
+            onClick={this.props.nextPage}
+            aria-live="off"
+            aria-label="Next page button"
+            title="Next page"
+          >
             Next <i className="fas fa-angle-double-right"></i>
           </Button>
         );

--- a/src/components/ResultsNumberDropdown.js
+++ b/src/components/ResultsNumberDropdown.js
@@ -1,24 +1,24 @@
-import React, { Component } from "react";
+import { Component } from "react";
 import { Dropdown } from "semantic-ui-react";
 
 class ResultsNumberDropdown extends Component {
   constructor(props) {
     super(props);
     this.state = {
-      selectedLimit: 10
+      selectedLimit: "10"
     };
   }
 
-  handleChange(event, result) {
-    this.setState(
-      {
-        selectedLimit: parseInt(result.value)
-      },
-      function () {
-        this.props.setLimit(event, result);
-      }
-    );
-  }
+  handleChange = (event, result) => {
+    this.setState({
+      selectedLimit: result.value
+    });
+    this.props.setLimit(event, result);
+  };
+
+  formatActiveDisplayText = () => {
+    return `${this.state.selectedLimit} per page`;
+  };
 
   render() {
     const numberOptions = [
@@ -38,17 +38,21 @@ class ResultsNumberDropdown extends Component {
         value: "100"
       }
     ];
-    const placeholder = this.state.selectedLimit + " per page";
     return (
-      <Dropdown
-        placeholder={placeholder}
-        compact
-        selection
-        options={numberOptions}
-        onChange={this.props.setLimit}
-        aria-label="Results per page"
-        aria-haspopup="listbox"
-      />
+      <>
+        <Dropdown
+          title="Items per page"
+          selection
+          compact
+          text={this.formatActiveDisplayText()}
+          value={this.state.selectedLimit}
+          options={numberOptions}
+          onChange={this.handleChange}
+          aria-label="Results per page"
+          aria-haspopup="listbox"
+          className={this.props.className || ""}
+        />
+      </>
     );
   }
 }

--- a/src/components/SortOrderDropdown.js
+++ b/src/components/SortOrderDropdown.js
@@ -1,37 +1,140 @@
-import React, { Component } from "react";
-import { Dropdown } from "semantic-ui-react";
+import { Component } from "react";
+import { Button, Dropdown, Icon } from "semantic-ui-react";
 
 class SortOrderDropdown extends Component {
-  setSortOrder = (event, result) => {
+  constructor(props) {
+    super(props);
+    this.state = {
+      sortField: "title",
+      sortDirection: "asc"
+    };
+    this.sortFieldOptions = [
+      {
+        key: "title",
+        text: "Title",
+        value: "title"
+      },
+      {
+        key: "creator",
+        text: "Creator",
+        value: "creator"
+      },
+      {
+        key: "contributor",
+        text: "Contributor",
+        value: "contributor"
+      },
+      {
+        key: "description",
+        text: "Description",
+        value: "description"
+      },
+      {
+        key: "format",
+        text: "Format",
+        value: "format"
+      },
+      {
+        key: "language",
+        text: "Language",
+        value: "language"
+      },
+      {
+        key: "source",
+        text: "Source",
+        value: "source"
+      },
+      {
+        key: "subject",
+        text: "Subject",
+        value: "subject"
+      },
+      {
+        key: "spatial",
+        text: "Spatial",
+        value: "spatial"
+      },
+      {
+        key: "start_date",
+        text: "Start Date",
+        value: "start_date"
+      },
+      {
+        key: "type",
+        text: "Type",
+        value: "type"
+      },
+      {
+        key: "tags",
+        text: "Tags",
+        value: "tags"
+      }
+    ];
+  }
+
+  handleFieldChange = (_, result) => {
+    this.setState((prevState) => ({
+      ...prevState,
+      sortField: result.value
+    }));
     if (typeof this.props.setSortOrder === "function") {
-      this.props.setSortOrder(event, result);
+      this.props.setSortOrder(result.value, this.state.sortDirection);
+    }
+  };
+
+  handleSortOrderChange = () => {
+    const newSortOrder = this.state.sortDirection === "asc" ? "desc" : "asc";
+    this.setState((prevState) => ({
+      ...prevState,
+      sortDirection: newSortOrder
+    }));
+    if (typeof this.props.setSortOrder === "function") {
+      this.props.setSortOrder(this.state.sortField, newSortOrder);
+    }
+  };
+
+  formatActiveDisplayText = () => {
+    try {
+      const currentSortOpt = this.sortFieldOptions.find(
+        (option) => option.value === this.state.sortField
+      );
+      return `Sort by ${currentSortOpt.text}`;
+    } catch (err) {
+      console.error(err);
     }
   };
 
   render() {
-    const options = [
-      {
-        key: "asc",
-        text: "Oldest to Newest",
-        value: "asc"
-      },
-      {
-        key: "desc",
-        text: "Newest to Oldest",
-        value: "desc"
-      }
-    ];
-    const placeholder = "Sort order";
     return (
-      <Dropdown
-        placeholder={placeholder}
-        compact
-        selection
-        options={options}
-        onChange={this.setSortOrder}
-        aria-label="Sort order dropdown"
-        aria-haspopup="listbox"
-      />
+      <>
+        <Dropdown
+          selection
+          compact
+          scrolling
+          text={this.formatActiveDisplayText()}
+          value={this.state.sortField}
+          options={this.sortFieldOptions}
+          onChange={this.handleFieldChange}
+          aria-label="Sort field option dropdown"
+          aria-haspopup="listbox"
+          className="mr-2"
+          title="Sort fields"
+        />
+        <Button
+          basic
+          icon
+          className="sort-btn"
+          title="Sort order"
+          aria-label="Sort order button"
+          onClick={this.handleSortOrderChange}
+        >
+          {this.state.sortDirection === "asc" ? (
+            <Icon name="sort content ascending" className="sort-btn-icon" />
+          ) : (
+            <Icon name="sort content descending" className="sort-btn-icon" />
+          )}
+        </Button>
+      </>
     );
   }
 }

--- a/src/css/CollectionsShowPage.scss
+++ b/src/css/CollectionsShowPage.scss
@@ -402,3 +402,25 @@ div.collection-item .item-image img {
     width: calc(100% - 182px);
   }
 }
+
+.collection-items-list-wrapper .display-option-container {
+  display: flex;
+  justify-content: flex-end;
+  font-family: "gineso-condensed", sans-serif;
+  font-size: 1.14em;
+}
+
+.collection-items-list-wrapper .sort-label {
+  font-size: 14px;
+  font-weight: 500;
+  color: black;
+}
+
+.collection-items-list-wrapper .sort-btn {
+  padding: 11px !important;
+  margin: 0 !important;
+}
+
+.collection-items-list-wrapper .sort-btn .sort-btn-icon {
+  font-size: 0.98rem;
+}

--- a/src/lib/fetchTools.js
+++ b/src/lib/fetchTools.js
@@ -520,46 +520,46 @@ export const getCollectionByIdentifier = async (identifier) => {
 
 export const getCollectionItems = async (
   collectionID,
-  sort_order,
+  sortOpt,
   limit,
   nextToken
 ) => {
   const queryGetCollectionItems = `query SearchCollectionItems(
-    $parent_id: String!
-    $limit: Int
-    $sort_order: SearchableSortDirection
-    $nextToken: String
-  ) {
-  searchArchives(
-    filter: {
-      heirarchy_path: { eq: $parent_id },
-      visibility: { eq: true }
-    },
-    sort: {
-      field: identifier
-      direction: $sort_order
-    },
-    limit: $limit
-    nextToken: $nextToken
-  ) {
-    items {
-      title
-      thumbnail_path
-      custom_key
-      identifier
-      description
-      tags
-      creator
+      $parent_id: String!
+      $limit: Int
+      $sort: [SearchableArchiveSortInput]
+      $nextToken: String
+    ) {
+    searchArchives(
+      filter: {
+        heirarchy_path: { eq: $parent_id },
+        visibility: { eq: true }
+      },
+      sort: $sort
+      limit: $limit
+      nextToken: $nextToken
+    ) {
+      items {
+        title
+        archiveOptions
+        description
+        start_date
+        thumbnail_path
+        custom_key
+        identifier
+        description
+        tags
+        creator
+      }
+      total
+      nextToken
     }
-    total
-    nextToken
-  }
-}`;
+  }`;
   const items = await API.graphql(
     graphqlOperation(queryGetCollectionItems, {
       parent_id: collectionID,
       limit: limit,
-      sort_order: sort_order,
+      sort: [{ field: sortOpt.field, direction: sortOpt.direction }],
       nextToken: nextToken
     })
   );

--- a/src/pages/collections/CollectionsShowPage/CollectionItems.tsx
+++ b/src/pages/collections/CollectionsShowPage/CollectionItems.tsx
@@ -1,12 +1,12 @@
 import { FC } from "react";
+import { Link } from "react-router-dom";
+import Pagination from "../../../components/Pagination";
 import ResultsNumberDropdown from "../../../components/ResultsNumberDropdown";
 import SortOrderDropdown from "../../../components/SortOrderDropdown";
 import { Thumbnail } from "../../../components/Thumbnail";
-import { Link } from "react-router-dom";
-import { RenderItems, arkLinkFormatted } from "../../../lib/MetadataRenderer";
-import Pagination from "../../../components/Pagination";
-import { useGetCollectionItems } from "./useGetCollectionItems";
 import { language_codes } from "../../../lib/language_codes";
+import { RenderItems, arkLinkFormatted } from "../../../lib/MetadataRenderer";
+import { useGetCollectionItems } from "./useGetCollectionItems";
 
 const languages = language_codes["abbr"];
 
@@ -23,6 +23,7 @@ export const CollectionItems: FC<Props> = ({
   const {
     items,
     total,
+    sortOpt,
     totalPages,
     page,
     limit,
@@ -48,12 +49,31 @@ export const CollectionItems: FC<Props> = ({
           >
             {`Items in Collection (${total})`}
           </h2>
-          <div className="col-auto">
-            <ResultsNumberDropdown setLimit={handleResultsNumberDropdown} />
-            {site.siteId === "podcasts" && (
-              <SortOrderDropdown setSortOrder={handleSortOrderDropdown} />
-            )}
+          <div className="col-auto mr-1">
+            <div className="display-option-container">
+              <ResultsNumberDropdown
+                setLimit={handleResultsNumberDropdown}
+                className="page-cnt-dropdown mr-2"
+              />
+              <SortOrderDropdown
+                sortOpt={sortOpt}
+                setSortOrder={handleSortOrderDropdown}
+              />
+            </div>
           </div>
+        </div>
+        <div aria-live="polite" className="mb-3">
+          <Pagination
+            numResults={items.length}
+            total={total}
+            page={page}
+            limit={limit}
+            previousPage={handlePrevPage}
+            nextPage={handleNextPage}
+            totalPages={totalPages}
+            isSearch={false}
+            atBottom={true}
+          />
         </div>
         <div
           className={


### PR DESCRIPTION
Collection page sorting improvements

Asana Ticket: https://app.asana.com/0/1205959349035436/1207433495102602/f

# What does this Pull Request do? (:star:)
Improves collection page archive sorting.

# What's the changes? (:star:)
- Default sorting archives by title in asc order
- Add more sorting option (creator, type, spatial, language etc.)
- Add pagination component on top of the collection items
- Fix pagination error in searchArchives VTL resolver
- Add support for additional sort fields to searchArchives query

# How should this be tested?
- Go to generated [preview](https://collection-items-sort.d2ysrrdhih4bgc.amplifyapp.com/collection/vb765t25)
- For each collection page, choose any sort option and the archives should be sorted by the selected sort field
- Toggle sort order button should change the order of how archives are sorted

# Additional Notes:
- Amplify backend needs to be updated to reflect changes in VTL resolvers
- Amplify CI/CD yml needs to be updated to support API testing in Cypress

# Interested parties
Tag (@ mention) interested parties
@goynejennifer 
@sushmadeegojuVT 

(:star:) Required fields
